### PR TITLE
feat(core): window functions on GPU — ROW_NUMBER scaffold (interface + CPU + Metal stub)

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -2,6 +2,61 @@
 
 Append-only. Reproducible runs only — include hardware, CUDA toolkit, build flags.
 
+## 2026-05-09 (night, macOS) — Window functions: ROW_NUMBER scaffold, CPU vs Metal stub
+
+Hardware: Apple M4 Max, ~64 GB unified memory. macOS 15.x, AppleClang 21.0.0.
+Code state: `feat/core-window-functions`. New `WindowAggregator` interface,
+CPU reference, Metal scaffold, and `gpudb-window-bench`.
+
+This is **GOAL.md item 8** — the operator Sirius (CIDR 2026 GPU OLAP paper)
+explicitly lacks. The v1 ships the interface and the CPU reference; the Metal
+scaffold reports `backend()==METAL` but delegates to the CPU implementation.
+Honest reporting: `device_name()` says "Metal scaffold — ROW_NUMBER delegates
+to CPU; real radix-sort + scatter kernel gated on PR #5".
+
+### Numbers (1 M random int64 keys over [0, 1e6], 3 runs, median)
+
+| Backend | wall (ms) | kernel (ms) | input throughput | Correctness |
+|---|---:|---:|---:|---|
+| CPU (`std::stable_sort` reference) | 42.19 | — | 0.18 GiB/s | OK vs oracle |
+| **Metal stub** (delegates to CPU)  | 42.22 | 0.00 | 0.18 GiB/s | OK vs oracle |
+
+Metal == CPU is expected and correct: the stub *is* the CPU code path, plus
+a constructor that opens the MTL device so the wiring is real. The bench
+verifies each output value against an independent stable-sort oracle living
+inside the bench binary, so a buggy aggregator can't validate itself.
+
+### What unblocks the real Metal kernel
+
+PR #5 (`feat/metal-radix-sort`) lands an LSD radix sort over int64 keys with
+a sibling int64 payload buffer. Once it merges to main:
+
+1. ROW_NUMBER reuses that radix sort with `payload[i] = i` (the original
+   row index as int64). The sort is stable by construction (per-bucket
+   relative-order preservation), which matches the CPU `std::stable_sort`
+   tie-break exactly.
+2. A trivial `row_number_scatter_i64` kernel writes `output[orig_index[p]]
+   = p + 1`. One dispatch, ceil(N/256) threadgroups, all UMA so the host
+   reads `output` with no D2H copy.
+3. Total expected GPU time: ~radix-sort time + a sub-millisecond scatter.
+   At the 1 M-rows × 1 M-groups sweet spot where `groupby_sum` already
+   wins 2.1× over CPU on this M4 Max, ROW_NUMBER should land in the same
+   neighborhood — both are bounded by the sort, not by what comes after.
+
+The full algorithm is documented in the long header comment of
+`src/backends/metal/metal_window.mm`. PR #5 is the only blocker.
+
+### Reproduce
+
+```bash
+export PATH="/Users/aiexplore369/Library/Python/3.9/bin:$PATH"
+cmake -S . -B build-macos
+cmake --build build-macos -j
+./build-macos/bin/gpudb-window-bench --rows 1000000 --runs 3
+```
+
+---
+
 ## 2026-05-09 (night, macOS) — TPC-H SF1 + scale sweep to 1 billion rows
 
 Hardware: Apple M4 Max, ~64 GB unified memory. macOS 15.x, MSL 3.2.

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -22,6 +22,12 @@ set_target_properties(gpudb-groupby-bench PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
+add_executable(gpudb-window-bench window_bench_main.cpp)
+target_link_libraries(gpudb-window-bench PRIVATE gpudb)
+set_target_properties(gpudb-window-bench PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
 if(GPUDB_BUILD_EXT)
     add_executable(gpudb-sql sql_demo_main.cpp)
     target_link_libraries(gpudb-sql PRIVATE gpudb_ext)

--- a/benchmark/window_bench_main.cpp
+++ b/benchmark/window_bench_main.cpp
@@ -1,0 +1,175 @@
+// gpudb-window-bench — ROW_NUMBER() OVER (ORDER BY key ASC).
+//
+// v1 scaffold: times the CPU reference and the Metal stub (which currently
+// delegates to CPU). Verifies correctness against an independent oracle:
+// each output[i] should equal i's rank in the stable-sorted key order.
+//
+// Usage:
+//   gpudb-window-bench [--rows N] [--runs K] [--no-verify]
+//
+// The bench is intentionally simple — no resident-column path, no
+// partitioning. The point is to lock the surface for window functions.
+// Real Metal speedups land when PR #5 (`feat/metal-radix-sort`) merges
+// and metal_window.mm switches from delegate-to-CPU to radix sort + scatter.
+
+#include "gpu_backend.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+struct Args {
+    std::size_t rows   = 1'000'000;
+    int         runs   = 3;
+    bool        verify = true;
+};
+
+void usage(const char* a0) {
+    std::fprintf(stderr,
+        "usage: %s [--rows N] [--runs K] [--no-verify]\n", a0);
+}
+
+bool parse(int argc, char** argv, Args& a) {
+    for (int i = 1; i < argc; ++i) {
+        std::string s = argv[i];
+        auto next = [&](const char* w) -> std::string {
+            if (i + 1 >= argc) { std::fprintf(stderr, "missing arg for %s\n", w); std::exit(1); }
+            return argv[++i];
+        };
+        if      (s == "--rows")        a.rows = std::strtoull(next("--rows").c_str(), nullptr, 10);
+        else if (s == "--runs")        a.runs = std::atoi(next("--runs").c_str());
+        else if (s == "--no-verify")   a.verify = false;
+        else if (s == "-h" || s == "--help") { usage(argv[0]); return false; }
+        else { std::fprintf(stderr, "unknown arg: %s\n", s.c_str()); usage(argv[0]); return false; }
+    }
+    return true;
+}
+
+double median(std::vector<double> v) {
+    std::sort(v.begin(), v.end());
+    return v[v.size() / 2];
+}
+double gibps(std::size_t bytes, double ms) {
+    if (ms <= 0.0) return 0.0;
+    return (static_cast<double>(bytes) / (1024.0 * 1024.0 * 1024.0)) / (ms / 1000.0);
+}
+
+// Independent oracle for ROW_NUMBER over ORDER BY key ASC: stable-sort the
+// (key, original_index) pairs and walk them in sorted order assigning 1..N.
+// Lives outside the aggregator so a buggy CPU impl can't validate itself.
+std::vector<std::int64_t> oracle_row_number(const std::vector<std::int64_t>& keys) {
+    const std::size_t n = keys.size();
+    std::vector<std::pair<std::int64_t, std::size_t>> pairs;
+    pairs.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) pairs.emplace_back(keys[i], i);
+    std::stable_sort(pairs.begin(), pairs.end(),
+                     [](const auto& a, const auto& b) { return a.first < b.first; });
+    std::vector<std::int64_t> out(n, 0);
+    for (std::size_t p = 0; p < n; ++p) {
+        out[pairs[p].second] = static_cast<std::int64_t>(p + 1);
+    }
+    return out;
+}
+
+bool output_equals(const std::vector<std::int64_t>& a, const std::vector<std::int64_t>& b) {
+    if (a.size() != b.size()) return false;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (a[i] != b[i]) return false;
+    }
+    return true;
+}
+
+void run_backend(gpudb::Backend b,
+                 const std::vector<std::int64_t>& keys,
+                 const std::vector<std::int64_t>& expected,
+                 int runs, bool verify) {
+    const std::size_t bytes_in  = keys.size() * sizeof(std::int64_t);
+    std::printf("\n[%s]\n", gpudb::to_string(b));
+    std::unique_ptr<gpudb::WindowAggregator> agg;
+    try { agg = gpudb::make_window_aggregator(b); }
+    catch (const std::exception& e) { std::printf("  unavailable: %s\n", e.what()); return; }
+    std::printf("  device: %s\n", agg->device_name().c_str());
+
+    // First call: verify against the oracle.
+    auto first = agg->row_number_i64(keys.data(), keys.size());
+    if (verify) {
+        if (!output_equals(first.output, expected)) {
+            std::fprintf(stderr, "  CORRECTNESS FAIL: ROW_NUMBER mismatch vs oracle\n");
+            // Show first divergence to ease debugging.
+            for (std::size_t i = 0; i < first.output.size(); ++i) {
+                if (first.output[i] != expected[i]) {
+                    std::fprintf(stderr,
+                        "    first diff at i=%zu: key=%lld got=%lld want=%lld\n",
+                        i, static_cast<long long>(keys[i]),
+                        static_cast<long long>(first.output[i]),
+                        static_cast<long long>(expected[i]));
+                    break;
+                }
+            }
+            std::exit(2);
+        }
+        std::printf("  correctness: OK (%zu rows)\n", first.output.size());
+    }
+
+    std::vector<double> wall, kernel;
+    for (int i = 0; i < runs; ++i) {
+        auto r = agg->row_number_i64(keys.data(), keys.size());
+        wall.push_back(r.wall_ms);
+        kernel.push_back(r.kernel_ms);
+    }
+    const double w = median(wall), k = median(kernel);
+    std::printf("  median wall=%8.3f ms  kernel=%8.3f ms  "
+                "input throughput=%6.2f GiB/s",
+                w, k, gibps(bytes_in, w));
+    if (k > 0.0) std::printf("  (kernel %6.2f GiB/s)", gibps(bytes_in, k));
+    std::printf("\n");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    Args a;
+    if (!parse(argc, argv, a)) return 1;
+
+    std::printf("gpudb-window-bench  rows=%zu runs=%d\n", a.rows, a.runs);
+    auto backends = gpudb::available_backends();
+    std::printf("backends:");
+    for (auto b : backends) std::printf(" %s", gpudb::to_string(b));
+    std::printf("\n");
+
+    // Keys: int64 in a moderate range so we get plenty of ties (exercises
+    // the stable tie-break path). Seed is fixed for reproducibility.
+    std::vector<std::int64_t> keys(a.rows);
+    {
+        std::mt19937_64 rng(0xCAFED00DULL);
+        std::uniform_int_distribution<std::int64_t> kd(0, 1'000'000);
+        for (auto& x : keys) x = kd(rng);
+    }
+
+    // Oracle: stable-sort once on the host. Used for verification only.
+    auto expected = oracle_row_number(keys);
+    std::printf("oracle: %zu rows ranked\n", expected.size());
+
+    for (auto b : backends) {
+        // Skip backends that don't yet implement WindowAggregator (e.g. CUDA).
+        try {
+            auto agg = gpudb::make_window_aggregator(b);
+            (void)agg;
+        } catch (const std::exception& e) {
+            std::printf("\n[%s]\n  unavailable: %s\n", gpudb::to_string(b), e.what());
+            continue;
+        }
+        run_backend(b, keys, expected, a.runs, a.verify);
+    }
+
+    std::printf("\ndone.\n");
+    return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ if(GPUDB_HAS_METAL)
     list(APPEND GPUDB_SOURCES
         backends/metal/metal_aggregator.mm
         backends/metal/metal_groupby.mm
+        backends/metal/metal_window.mm
     )
 
     # Embed .metal source as C strings so the Objective-C++ TUs can compile

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(GPUDB_SOURCES
     backends/cpu/cpu_aggregator.cpp
     backends/cpu/cpu_groupby.cpp
+    backends/cpu/cpu_window.cpp
     backends/backend_factory.cpp
 )
 

--- a/src/backends/backend_factory.cpp
+++ b/src/backends/backend_factory.cpp
@@ -16,6 +16,7 @@ const char* to_string(Backend b) noexcept {
 // Forward declarations (impls live in their respective TUs)
 std::unique_ptr<Aggregator> make_cpu_aggregator();
 std::unique_ptr<GroupByAggregator> make_cpu_groupby_aggregator();
+std::unique_ptr<WindowAggregator> make_cpu_window_aggregator();
 #if GPUDB_HAVE_CUDA
 std::unique_ptr<Aggregator> make_cuda_aggregator();
 std::unique_ptr<GroupByAggregator> make_cuda_groupby_aggregator();
@@ -70,6 +71,33 @@ std::unique_ptr<GroupByAggregator> make_groupby_aggregator(Backend b) {
         case Backend::METAL:
 #if GPUDB_HAVE_METAL
             return make_metal_groupby_aggregator();
+#else
+            throw std::runtime_error("Metal backend not compiled in");
+#endif
+    }
+    throw std::runtime_error("Unknown backend");
+}
+
+std::unique_ptr<WindowAggregator> make_window_aggregator(Backend b) {
+    switch (b) {
+        case Backend::CPU:
+            return make_cpu_window_aggregator();
+        case Backend::CUDA:
+#if GPUDB_HAVE_CUDA
+            // CUDA window aggregator is the Linux instance's lane; not yet
+            // implemented. Throw an honest error instead of silently
+            // delegating to CPU — callers should pick CPU explicitly.
+            throw std::runtime_error(
+                "CUDA window aggregator not implemented yet (Linux lane)");
+#else
+            throw std::runtime_error("CUDA backend not compiled in");
+#endif
+        case Backend::METAL:
+#if GPUDB_HAVE_METAL
+            // Metal window aggregator lives in a follow-up commit on this
+            // same branch. Throwing keeps this commit's surface honest.
+            throw std::runtime_error(
+                "Metal window aggregator not wired yet (follow-up commit)");
 #else
             throw std::runtime_error("Metal backend not compiled in");
 #endif

--- a/src/backends/backend_factory.cpp
+++ b/src/backends/backend_factory.cpp
@@ -87,20 +87,27 @@ std::unique_ptr<WindowAggregator> make_window_aggregator(Backend b) {
             return make_cpu_window_aggregator();
         case Backend::CUDA:
 #if GPUDB_HAVE_CUDA
-            // CUDA window aggregator is the Linux instance's lane; not yet
-            // implemented. Throw an honest error instead of silently
-            // delegating to CPU — callers should pick CPU explicitly.
             throw std::runtime_error(
                 "CUDA window aggregator not implemented yet (Linux lane)");
+#else
+            throw std::runtime_error("CUDA backend not compiled in");
+#endif
+        case Backend::METAL:
+#if GPUDB_HAVE_METAL
+            return make_metal_window_aggregator();
+#else
+            throw std::runtime_error("Metal backend not compiled in");
+#endif
+    }
+    throw std::runtime_error("Unknown backend");
+}
+
 std::unique_ptr<HashJoinProbe> make_hashjoin_probe(Backend b) {
     switch (b) {
         case Backend::CPU:
             return make_cpu_hashjoin_probe();
         case Backend::CUDA:
 #if GPUDB_HAVE_CUDA
-            // Will be filled in by the Linux Claude when feat/cuda-hashjoin
-            // lands on main. The interface and CPU/Metal implementations
-            // exist already so the swap is a single TU change.
             throw std::runtime_error(
                 "CUDA hash-join not implemented yet — coming on feat/cuda-hashjoin");
 #else
@@ -108,7 +115,6 @@ std::unique_ptr<HashJoinProbe> make_hashjoin_probe(Backend b) {
 #endif
         case Backend::METAL:
 #if GPUDB_HAVE_METAL
-            return make_metal_window_aggregator();
             return make_metal_hashjoin_probe();
 #else
             throw std::runtime_error("Metal backend not compiled in");

--- a/src/backends/backend_factory.cpp
+++ b/src/backends/backend_factory.cpp
@@ -25,6 +25,7 @@ bool cuda_runtime_available() noexcept;
 #if GPUDB_HAVE_METAL
 std::unique_ptr<Aggregator> make_metal_aggregator();
 std::unique_ptr<GroupByAggregator> make_metal_groupby_aggregator();
+std::unique_ptr<WindowAggregator> make_metal_window_aggregator();
 bool metal_runtime_available() noexcept;
 #endif
 
@@ -94,10 +95,7 @@ std::unique_ptr<WindowAggregator> make_window_aggregator(Backend b) {
 #endif
         case Backend::METAL:
 #if GPUDB_HAVE_METAL
-            // Metal window aggregator lives in a follow-up commit on this
-            // same branch. Throwing keeps this commit's surface honest.
-            throw std::runtime_error(
-                "Metal window aggregator not wired yet (follow-up commit)");
+            return make_metal_window_aggregator();
 #else
             throw std::runtime_error("Metal backend not compiled in");
 #endif

--- a/src/backends/cpu/cpu_window.cpp
+++ b/src/backends/cpu/cpu_window.cpp
@@ -1,0 +1,78 @@
+// cpu_window.cpp — CPU window-function reference implementation.
+//
+// v1 scope: ROW_NUMBER() OVER (ORDER BY key ASC).
+//
+// Algorithm:
+//   1. Build a vector of (key, original_index) pairs.
+//   2. std::stable_sort by key. Stability gives the tie-break we want
+//      (earlier input rows get the smaller rank when keys collide), and
+//      matches the GPU plan: a stable radix sort over (key, original_index)
+//      pairs leaves equal-keyed rows in their input order.
+//   3. Walk the sorted pairs; row at sort position p (0-indexed) gets
+//      rank p+1 written back to output[original_index].
+//
+// Complexity: O(N log N) for the sort; O(N) for the scatter. The whole
+// thing is the reference the Metal/CUDA backends must match bit-for-bit,
+// so it stays simple and single-threaded — correctness over speed.
+
+#include "gpu_backend.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace gpudb {
+
+namespace {
+
+class CpuWindowAggregator final : public WindowAggregator {
+public:
+    Backend backend() const noexcept override { return Backend::CPU; }
+
+    std::string device_name() const override {
+        return "CPU (std::stable_sort reference)";
+    }
+
+    WindowResult row_number_i64(const std::int64_t* keys, std::size_t n) override {
+        WindowResult r;
+        r.rows = n;
+        r.output.assign(n, 0);
+        if (n == 0) return r;
+
+        const auto t0 = std::chrono::steady_clock::now();
+
+        // (key, original_index) pairs.
+        std::vector<std::pair<std::int64_t, std::int64_t>> pairs;
+        pairs.reserve(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            pairs.emplace_back(keys[i], static_cast<std::int64_t>(i));
+        }
+
+        // Stable sort by key. Ties preserve original index order.
+        std::stable_sort(pairs.begin(), pairs.end(),
+                         [](const auto& a, const auto& b) { return a.first < b.first; });
+
+        // Scatter rank back to original positions. rank is 1-indexed.
+        for (std::size_t p = 0; p < n; ++p) {
+            const std::int64_t original_index = pairs[p].second;
+            r.output[static_cast<std::size_t>(original_index)] =
+                static_cast<std::int64_t>(p + 1);
+        }
+
+        r.wall_ms = std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - t0).count();
+        r.kernel_ms   = 0.0;
+        r.transfer_ms = 0.0;
+        return r;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<WindowAggregator> make_cpu_window_aggregator() {
+    return std::make_unique<CpuWindowAggregator>();
+}
+
+} // namespace gpudb

--- a/src/backends/metal/metal_window.mm
+++ b/src/backends/metal/metal_window.mm
@@ -1,0 +1,151 @@
+// metal_window.mm — Metal scaffold for window functions.
+//
+// CURRENT STATE: This file delegates ROW_NUMBER to the CPU reference
+// implementation. The MetalWindowAggregator reports backend()==METAL but
+// is functionally a thin pass-through. That is a deliberate v1 shape: it
+// pins the interface, the factory wiring, and the bench harness so the
+// real Metal kernel can land as a focused, reviewable follow-up patch
+// without having to also stand up plumbing.
+//
+// =========================================================================
+//  Planned real Metal algorithm (gated on PR #5 — `feat/metal-radix-sort`)
+// =========================================================================
+//
+// ROW_NUMBER over an int64 ASC ordering reduces to "stable sort the input
+// rows by key, then write 1..N as ranks back to original positions". On a
+// GPU that's two well-known kernels:
+//
+//   Step 1. Stable radix sort over (key, original_index) pairs.
+//
+//     PR #5 (`feat/metal-radix-sort`) introduces an LSD radix sort over
+//     int64 keys with a sibling payload buffer for groupby_sum. The same
+//     kernel (in groupby.metal) accepts a `payload[]` parameter that
+//     follows the key permutation. For ROW_NUMBER we reuse it with
+//     `payload[i] = i` (the original index, written as int64 so it fits
+//     the existing int64-payload kernel without a templated copy).
+//
+//     The radix sort is stable by construction (each pass scatters in
+//     bucket order, preserving relative order within a bucket), which
+//     matches the CPU std::stable_sort tie-break exactly.
+//
+//   Step 2. Scatter rank back to the original positions.
+//
+//     One trivial kernel:
+//
+//         kernel void row_number_scatter_i64(
+//             device const int64_t* original_index [[buffer(0)]],
+//             device int64_t*       output         [[buffer(1)]],
+//             uint                  gid            [[thread_position_in_grid]],
+//             constant uint&        n              [[buffer(2)]])
+//         {
+//             if (gid >= n) return;
+//             // After radix sort, original_index[p] holds the pre-sort
+//             // index of the row that ended up at sorted position p.
+//             // ROW_NUMBER is 1-indexed.
+//             output[ original_index[gid] ] = (int64_t)(gid + 1);
+//         }
+//
+//     Dispatch: ceil(n/256) threadgroups of 256 threads. Both buffers are
+//     MTLResourceStorageModeShared (UMA), so output is host-visible with
+//     no D2H copy.
+//
+// Memory traffic:
+//   - Radix sort dominates: 8 passes × (load 2N int64 + store 2N int64) =
+//     32N int64 read+write across the 8-bit-bucket passes.
+//   - Scatter: N reads + N random writes. Random writes hit the L2 hash
+//     not the HBM page line, but for N up to a few hundred million on
+//     LPDDR5X-class memory the kernel cost is sub-millisecond.
+//
+// Expected perf:
+//   The same kernel body that gives groupby_sum its win at the
+//   1M-rows × 1M-groups sweet spot also wins ROW_NUMBER there, because
+//   both are bounded by the sort, not by what comes after. For very low
+//   cardinality the sort is overkill (the rank assignment is trivial)
+//   and CPU std::stable_sort wins; the planner should keep that in mind.
+//
+// =========================================================================
+//  What unblocks the real implementation
+// =========================================================================
+//
+// PR #5 (`feat/metal-radix-sort`) must merge to main first. That PR adds
+// `groupby.metal` kernels for radix histogram + scan + scatter that this
+// file will reuse. Once it's in:
+//   1. Add a `row_number_scatter_i64` kernel to a new
+//      `src/backends/metal/kernels/window.metal` (or extend groupby.metal).
+//   2. Replace the `cpu_->row_number_i64(...)` call below with the radix
+//      sort + scatter pipeline. Time the GPU command buffer for kernel_ms.
+//   3. Update BENCHMARK.md with the Metal vs CPU numbers.
+//
+// Until then this delegate keeps the public surface honest: backend()
+// returns METAL, device_name() says exactly what's happening, and the
+// bench will report identical wall times for CPU and Metal — which is
+// the truthful state of the world right now.
+
+#include "gpu_backend.hpp"
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+
+namespace gpudb {
+
+// Forward decl from cpu_window.cpp; the Metal stub delegates to it.
+std::unique_ptr<WindowAggregator> make_cpu_window_aggregator();
+
+namespace {
+
+class MetalWindowAggregator final : public WindowAggregator {
+public:
+    MetalWindowAggregator() {
+        @autoreleasepool {
+            device_ = MTLCreateSystemDefaultDevice();
+            if (!device_) {
+                throw std::runtime_error("MTLCreateSystemDefaultDevice returned nil");
+            }
+        }
+        cpu_ = make_cpu_window_aggregator();
+    }
+
+    Backend backend() const noexcept override { return Backend::METAL; }
+
+    std::string device_name() const override {
+        @autoreleasepool {
+            std::ostringstream os;
+            os << [[device_ name] UTF8String]
+               << " (Metal scaffold — ROW_NUMBER delegates to CPU; "
+                  "real radix-sort + scatter kernel gated on PR #5)";
+            return os.str();
+        }
+    }
+
+    WindowResult row_number_i64(const std::int64_t* keys, std::size_t n) override {
+        // Time the call ourselves so wall_ms is consistent with what a
+        // future real kernel would report (otherwise we'd inherit the
+        // CPU's wall_ms, which is fine but slightly understates wrapper
+        // overhead).
+        const auto t_wall0 = std::chrono::steady_clock::now();
+        WindowResult r = cpu_->row_number_i64(keys, n);
+        r.kernel_ms   = 0.0;     // No GPU kernel ran. Honest reporting.
+        r.transfer_ms = 0.0;     // UMA on Apple Silicon — would be 0 anyway.
+        r.wall_ms     = std::chrono::duration<double, std::milli>(
+                            std::chrono::steady_clock::now() - t_wall0).count();
+        return r;
+    }
+
+private:
+    id<MTLDevice> device_ = nil;
+    std::unique_ptr<WindowAggregator> cpu_;
+};
+
+} // namespace
+
+std::unique_ptr<WindowAggregator> make_metal_window_aggregator() {
+    return std::make_unique<MetalWindowAggregator>();
+}
+
+} // namespace gpudb

--- a/src/include/gpu_backend.hpp
+++ b/src/include/gpu_backend.hpp
@@ -111,6 +111,51 @@ public:
 
 std::unique_ptr<GroupByAggregator> make_groupby_aggregator(Backend);
 
+// =========================================================================
+//  Window functions (v1: ROW_NUMBER() OVER (ORDER BY key ASC))
+// =========================================================================
+//
+// First window-function operator on the project. Sirius (CIDR 2026 GPU OLAP
+// paper) explicitly lacks window functions; shipping it differentiates us.
+// v1 covers the simplest meaningful case — ROW_NUMBER over a single ascending
+// key — to lock the interface shape. Later additions (RANK, DENSE_RANK,
+// LAG/LEAD, partitioning, frame clauses) extend this surface without churn.
+//
+// Output semantics:
+//   For input row i, output[i] is the 1-indexed rank that row i would have
+//   if the input were sorted by key ASC. Ties are broken by stable order
+//   (input position): earlier rows in the input get the smaller rank.
+//
+// Example:
+//   keys   = [40, 10, 30, 10, 20]
+//   sorted = [(10,1), (10,3), (20,4), (30,2), (40,0)]   // (key, orig_idx)
+//   ranks  =   1       2        3        4        5
+//   output[0] = 5  (key=40 → rank 5)
+//   output[1] = 1  (key=10, earliest → rank 1)
+//   output[2] = 4  (key=30 → rank 4)
+//   output[3] = 2  (key=10, later → rank 2)
+//   output[4] = 3  (key=20 → rank 3)
+
+struct WindowResult {
+    std::vector<std::int64_t> output;     // window function value per input row
+    std::size_t  rows = 0;
+    double       wall_ms     = 0.0;
+    double       kernel_ms   = 0.0;
+    double       transfer_ms = 0.0;
+};
+
+class WindowAggregator {
+public:
+    virtual ~WindowAggregator() = default;
+    [[nodiscard]] virtual Backend backend() const noexcept = 0;
+    [[nodiscard]] virtual std::string device_name() const = 0;
+    // ROW_NUMBER() OVER (ORDER BY key ASC).
+    // Output row i contains the rank of input row i (1-indexed).
+    virtual WindowResult row_number_i64(const std::int64_t* keys, std::size_t n) = 0;
+};
+
+std::unique_ptr<WindowAggregator> make_window_aggregator(Backend);
+
 // Returns the best backend available at runtime: CUDA if compiled+device,
 // else METAL if compiled+device, else CPU.
 [[nodiscard]] Backend default_backend() noexcept;

--- a/src/include/gpu_backend.hpp
+++ b/src/include/gpu_backend.hpp
@@ -162,6 +162,12 @@ std::unique_ptr<GroupByAggregator> make_groupby_aggregator(Backend);
 struct WindowResult {
     std::vector<std::int64_t> output;     // window function value per input row
     std::size_t  rows = 0;
+    double       wall_ms     = 0.0;
+    double       kernel_ms   = 0.0;
+    double       transfer_ms = 0.0;
+};
+
+// =========================================================================
 //  HASH JOIN probe (i64 keys, inner equi-join)
 // =========================================================================
 //


### PR DESCRIPTION
## Summary
- **GOAL.md item 8** — window functions on GPU. The operator Sirius (CIDR 2026 GPU OLAP paper) explicitly lacks; shipping it differentiates us.
- v1 scope: clean abstract `WindowAggregator` interface + CPU reference (`std::stable_sort` based) + Metal scaffold + benchmark harness with independent oracle.
- Metal currently delegates to CPU; the long header comment in `metal_window.mm` documents the planned real algorithm (radix sort over (key, original_index) pairs from PR #5 + scatter kernel). Real Metal speedup is gated on PR #5 (`feat/metal-radix-sort`) merging to main.

## What changed

### `feat(core)`: interface + CPU + bench (commit 1)
- `src/include/gpu_backend.hpp`: `WindowResult`, `WindowAggregator`, `make_window_aggregator(Backend)`. `row_number_i64(keys, n)` returns 1-indexed rank of each input row in ORDER BY key ASC ordering, with stable tie-break.
- `src/backends/cpu/cpu_window.cpp`: `(key, orig_index)` pairs → `std::stable_sort` by key → scatter rank back to original positions.
- `benchmark/window_bench_main.cpp`: synthetic int64 keys with deliberate ties; an independent stable-sort oracle (lives in the bench, not the aggregator) verifies element-wise correctness; times runs over every available backend.
- Factory: CPU returns the real impl; CUDA throws "not implemented yet (Linux lane)"; Metal throws "not wired yet (follow-up commit)" in this commit.

### `feat(metal)`: scaffold (commit 2)
- `src/backends/metal/metal_window.mm`: opens the MTL device (so `device_name()` reports the real GPU), then delegates `row_number_i64` to the CPU. Long header comment documents the planned real algorithm.
- Factory swaps the Metal branch from "throw" to `make_metal_window_aggregator()`.
- BENCHMARK.md: new "Window functions: ROW_NUMBER scaffold, CPU vs Metal stub" section with M4 Max numbers and the planned algorithm.

## Test plan
- [x] `cmake -S . -B build-macos && cmake --build build-macos -j` clean (one pre-existing unused-const warning, not from this PR).
- [x] `./build-macos/test/test_gpudb` — **24/24 checks pass**.
- [x] `./build-macos/bin/gpudb-window-bench --rows 1000000 --runs 3` — both CPU and Metal report **correctness OK**; wall times are identical (Metal delegates) which is the truthful state of the world right now.
- [x] Both commits build independently in order (verified by checking out and building each).

## What unblocks the real Metal kernel
PR #5 (`feat/metal-radix-sort`) must merge to main first. Once it does, the swap is mechanical: replace the CPU delegate in `metal_window.mm` with radix-sort + scatter, both reusing the kernels PR #5 introduces. The full algorithm is documented in the file's header comment.