### PR TITLE
test(sql): comprehensive SQL test suite + window bug documented

### DIFF
--- a/.sync/test-sql-suite-expand.md
+++ b/.sync/test-sql-suite-expand.md
@@ -1,0 +1,6 @@
+# test-sql-suite-expand
+- branch: test/sql-suite-expand
+- working on: expanding SQL test suite + documenting window bug
+- status: in_progress
+- blocked on: nothing
+- last update: 2026-05-09T21:55:58Z

--- a/.sync/test-sql-suite-expand.md
+++ b/.sync/test-sql-suite-expand.md
@@ -1,6 +1,6 @@
 # test-sql-suite-expand
 - branch: test/sql-suite-expand
-- working on: expanding SQL test suite + documenting window bug
-- status: in_progress
+- working on: (work complete)
+- status: done
 - blocked on: nothing
-- last update: 2026-05-09T21:55:58Z
+- last update: 2026-05-09T22:30:17Z

--- a/README.md
+++ b/README.md
@@ -110,7 +110,16 @@ Backend selection is automatic: CUDA if a device is found at runtime, else Metal
 ## Testing
 ```bash
 ./build-linux/test/test_gpudb        # 24 unit tests across CPU + CUDA backends
+./scripts/run_sql_tests.sh           # SQL-level suite: gpu_sum / min / max / GROUP BY / window
+./scripts/local_check.sh             # everything CI would run, end to end
 ```
+
+The SQL test suite lives in `test/sql/*.test`. Each file is plain SQL with
+`-- expect:` lines after each query; the runner reports per-query
+PASS / FAIL / XFAIL (expected fail) / SKIP. A few cases are currently
+documented as expected fails and are tracked on `fix/window-partition-bug`:
+the partitioned running-sum window, the unbounded `OVER ()` window, the
+running-sum across chunk boundaries, and mid-cardinality GROUP BY totals.
 
 CI runs on every push: Linux (Ubuntu 24.04, CPU-only) + macOS-14 (CPU + Metal scaffold).
 

--- a/scripts/local_check.sh
+++ b/scripts/local_check.sh
@@ -96,6 +96,13 @@ if [ "$NO_EXT" = "0" ]; then
             "SELECT gpu_sum(v) AS gpu, sum(v) AS native FROM read_parquet('data/tpch_sf1/lineitem_orderkey.parquet');"
     fi
     green "extension OK"
+
+    hr "SQL test suite (test/sql/*.test) — gpu_sum, gpu_min/max, GROUP BY, window"
+    if ! ./scripts/run_sql_tests.sh; then
+        red "SQL test suite reported FAIL (beyond the documented expected_fails)"
+        exit 1
+    fi
+    green "SQL test suite OK"
 fi
 
 hr "summary"

--- a/scripts/run_sql_tests.sh
+++ b/scripts/run_sql_tests.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# run_sql_tests.sh — runs all (or a named) gpudb-sql .test file in test/sql/
+# and compares each query's output against embedded `-- expect:` lines.
+#
+# Usage:
+#   ./scripts/run_sql_tests.sh                  # all .test files
+#   ./scripts/run_sql_tests.sh gpu_sum          # match basename
+#   ./scripts/run_sql_tests.sh gpu_sum.test     # match filename
+#
+# Test file format (see test/sql/gpu_sum.test for a full example):
+#   - SQL queries are separated by `;`
+#   - Lines starting with `--` or `#` are NOT sent as SQL
+#   - Per-query directives appear EITHER right before the query (env,
+#     requires_file, expected_fail) OR right after it (expect):
+#       -- expect: <line>           expected output line, one per result row
+#       -- requires_file: <path>    skip query if file missing (relative root)
+#       -- env: KEY=VAL             set env var for this query only
+#       -- expected_fail: <reason>  query is allowed to error/segfault/mismatch;
+#                                   the suite reports it but treats overall as PASS
+#
+# Comparison is whitespace-tolerant: header row is dropped, runs of
+# whitespace are collapsed, leading/trailing space is stripped.
+#
+# Exits 0 iff every query is either (a) PASS or (b) expected_fail. The
+# script also rebuilds the project if `gpudb-sql` is missing.
+
+set -uo pipefail
+
+# Resolve repo root (parent of scripts/).
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OS="$(uname -s)"
+case "$OS" in
+    Linux*)  BUILD_DIR="${BUILD_DIR:-build-linux}" ;;
+    Darwin*) BUILD_DIR="${BUILD_DIR:-build-macos}" ;;
+    *)       BUILD_DIR="${BUILD_DIR:-build}" ;;
+esac
+
+GPUDB_SQL="$BUILD_DIR/bin/gpudb-sql"
+
+# Build if the binary is missing. Don't rebuild on every run.
+if [ ! -x "$GPUDB_SQL" ]; then
+    echo "==> $GPUDB_SQL missing — building"
+    if [ -f scripts/env.sh ]; then
+        # shellcheck disable=SC1091
+        . scripts/env.sh >/dev/null 2>&1 || true
+    fi
+    ./scripts/build.sh >/tmp/gpudb-sql-build.log 2>&1 || {
+        echo "build failed — see /tmp/gpudb-sql-build.log" >&2
+        tail -30 /tmp/gpudb-sql-build.log >&2
+        exit 1
+    }
+    if [ ! -x "$GPUDB_SQL" ]; then
+        echo "build did not produce $GPUDB_SQL — make sure -DGPUDB_BUILD_EXT=ON" >&2
+        echo "(this requires third_party/duckdb-libs/; run ./scripts/get_duckdb_libs.sh)" >&2
+        exit 1
+    fi
+fi
+
+# Resolve which .test files to run.
+declare -a TEST_FILES
+if [ "$#" -eq 0 ]; then
+    while IFS= read -r f; do TEST_FILES+=("$f"); done < <(find test/sql -maxdepth 1 -name '*.test' | sort)
+else
+    for arg in "$@"; do
+        candidates=(
+            "test/sql/$arg"
+            "test/sql/${arg}.test"
+            "$arg"
+        )
+        found=""
+        for c in "${candidates[@]}"; do
+            if [ -f "$c" ]; then found="$c"; break; fi
+        done
+        if [ -z "$found" ]; then
+            echo "no .test file matches: $arg" >&2
+            exit 2
+        fi
+        TEST_FILES+=("$found")
+    done
+fi
+
+if [ "${#TEST_FILES[@]}" -eq 0 ]; then
+    echo "no .test files found in test/sql/" >&2
+    exit 2
+fi
+
+# Pretty colours when the terminal supports them.
+if [ -t 1 ]; then
+    C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YEL=$'\033[33m'
+    C_DIM=$'\033[2m';   C_BOLD=$'\033[1m'; C_OFF=$'\033[0m'
+else
+    C_GREEN=""; C_RED=""; C_YEL=""; C_DIM=""; C_BOLD=""; C_OFF=""
+fi
+
+# ----- helpers -----------------------------------------------------------
+
+normalise_line() {
+    # Collapse runs of whitespace to a single space; trim ends.
+    sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' <<<"$1"
+}
+
+# ----- per-file driver ---------------------------------------------------
+
+# Stats accumulators
+TOTAL_FILES=0
+TOTAL_PASS=0
+TOTAL_FAIL=0
+TOTAL_SKIP=0
+TOTAL_EXPECTED_FAIL=0
+TOTAL_UNEXPECTED_PASS=0
+declare -a FAIL_DETAILS=()
+
+# Parse a .test file into N queries. We build parallel arrays in memory and
+# then execute. This way `-- expect:` lines AFTER the query attach back.
+#
+# Conventions:
+#   - Pre-statement directives (env, requires_file, expected_fail) apply to
+#     the NEXT statement.
+#   - `-- expect:` lines apply to the PREVIOUSLY emitted statement (the one
+#     just terminated by a `;`).
+#   - If both pre and post directives are present, post-statement expects
+#     attach to the most recent query; pre-statement directives reset on
+#     each new query.
+
+execute_query() {
+    # Args: file_label query_no sql expects env requires_file expected_fail
+    local label="$1" sql="$2" expects="$3" envspec="$4" reqfile="$5" xfail="$6"
+
+    if [ -n "$reqfile" ] && [ ! -e "$reqfile" ]; then
+        printf "  %-32s  %sSKIP%s  (missing %s)\n" "$label" "$C_YEL" "$C_OFF" "$reqfile"
+        skip=$((skip + 1))
+        return
+    fi
+
+    local out_f="/tmp/gpudb-sql-out.$$"
+    local err_f="/tmp/gpudb-sql-err.$$"
+    local rc=0
+    # Per-query timeout. The partition-window bug is non-deterministic and
+    # can hang the process indefinitely; without a timeout the whole suite
+    # would stall. 30s is generous for everything currently in tree.
+    local TLIMIT="${GPUDB_SQL_TIMEOUT_SECS:-30}"
+    # Suppress bash's "Segmentation fault" diagnostic when the child dies
+    # by SIGSEGV — we want our own XFAIL/FAIL line, not noise. Putting the
+    # call inside { ... } 2>/dev/null with the redirection on the GROUP
+    # silences the diagnostic without dropping our captured stderr (which
+    # is going to $err_f via the inner redirection).
+    if [ -n "$envspec" ]; then
+        # shellcheck disable=SC2086
+        { env $envspec timeout --signal=TERM --kill-after=2s "$TLIMIT" \
+            "$GPUDB_SQL" --sql "$sql" >"$out_f" 2>"$err_f" ; } 2>/dev/null
+        rc=$?
+    else
+        { timeout --signal=TERM --kill-after=2s "$TLIMIT" \
+            "$GPUDB_SQL" --sql "$sql" >"$out_f" 2>"$err_f" ; } 2>/dev/null
+        rc=$?
+    fi
+    # `timeout` returns 124 (timed out, child exited cleanly after TERM)
+    # or 137 (had to send KILL). Flag both as a timeout for reporting.
+    local timed_out=0
+    if [ "$rc" = "124" ] || [ "$rc" = "137" ]; then
+        timed_out=1
+    fi
+
+    # Strip the header line (first line of stdout).
+    local actual=""
+    if [ -s "$out_f" ]; then
+        actual=$(tail -n +2 "$out_f")
+    fi
+
+    # Normalise expected & actual line by line.
+    local actual_norm="" expected_norm=""
+    local IFS=$'\n'
+    for ln in $actual; do
+        actual_norm+="$(normalise_line "$ln")"$'\n'
+    done
+    for ln in $expects; do
+        expected_norm+="$(normalise_line "$ln")"$'\n'
+    done
+    unset IFS
+
+    local matched=1
+    if [ "$rc" -ne 0 ]; then
+        matched=0
+    elif [ "$actual_norm" != "$expected_norm" ]; then
+        matched=0
+    fi
+
+    if [ "$matched" = "1" ]; then
+        if [ -n "$xfail" ]; then
+            printf "  %-32s  %sUNEXPECTED-PASS%s  (was tagged expected_fail: %s)\n" \
+                "$label" "$C_YEL" "$C_OFF" "$xfail"
+            unexpected_pass=$((unexpected_pass + 1))
+        else
+            printf "  %-32s  %sPASS%s\n" "$label" "$C_GREEN" "$C_OFF"
+            pass=$((pass + 1))
+        fi
+    else
+        if [ -n "$xfail" ]; then
+            printf "  %-32s  %sXFAIL%s  (%s)\n" \
+                "$label" "$C_YEL" "$C_OFF" "$xfail"
+            efail=$((efail + 1))
+        else
+            printf "  %-32s  %sFAIL%s\n" "$label" "$C_RED" "$C_OFF"
+            fail=$((fail + 1))
+            FAIL_DETAILS+=("$label")
+            if [ "$timed_out" = "1" ]; then
+                echo "    ${C_DIM}TIMEOUT after ${TLIMIT}s${C_OFF}"
+            elif [ "$rc" -ne 0 ]; then
+                echo "    ${C_DIM}exit=$rc; stderr tail:${C_OFF}"
+                tail -3 "$err_f" 2>/dev/null | sed 's/^/      /'
+            fi
+            echo "    ${C_DIM}expected:${C_OFF}"
+            printf '%s' "$expected_norm" | sed 's/^/      /'
+            echo "    ${C_DIM}actual:${C_OFF}"
+            printf '%s' "$actual_norm" | sed 's/^/      /'
+        fi
+    fi
+
+    rm -f "$out_f" "$err_f"
+}
+
+run_file() {
+    local file="$1"
+    pass=0; fail=0; skip=0; efail=0; unexpected_pass=0
+
+    # Parsed query arrays
+    local -a Q_SQL=() Q_EXP=() Q_ENV=() Q_REQ=() Q_XF=()
+
+    # Per-query in-flight scratch
+    local cur_sql=""
+    local cur_pre_env="" cur_pre_req="" cur_pre_xf=""
+
+    # State: have we emitted any query yet that subsequent `-- expect:`
+    # lines should attach to?
+    local last_idx=-1
+
+    flush() {
+        # Trim sql whitespace.
+        local stmt="${cur_sql%;}"
+        local stmt_strip
+        stmt_strip="$(printf '%s' "$stmt" | tr -d '[:space:]')"
+        if [ -n "$stmt_strip" ]; then
+            Q_SQL+=("$stmt")
+            Q_EXP+=("")
+            Q_ENV+=("$cur_pre_env")
+            Q_REQ+=("$cur_pre_req")
+            Q_XF+=("$cur_pre_xf")
+            last_idx=$((${#Q_SQL[@]} - 1))
+        fi
+        cur_sql=""
+        cur_pre_env=""
+        cur_pre_req=""
+        cur_pre_xf=""
+    }
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Pure blank line — preserve in SQL (no-op).
+        if [ -z "${line//[[:space:]]/}" ]; then
+            cur_sql+="$line"$'\n'
+            continue
+        fi
+
+        local trimmed="${line#"${line%%[![:space:]]*}"}"
+
+        case "$trimmed" in
+            "#"*)
+                continue
+                ;;
+            "-- expect:"*|"--expect:"*)
+                local val="${trimmed#*expect:}"
+                val="${val# }"
+                if [ "$last_idx" -ge 0 ]; then
+                    Q_EXP[last_idx]+="$val"$'\n'
+                else
+                    # Expect before any query — orphaned, ignore with warning
+                    echo "  ${C_YEL}warn:${C_OFF} '-- expect:' before any query in $file" >&2
+                fi
+                continue
+                ;;
+            "-- requires_file:"*|"--requires_file:"*)
+                local val="${trimmed#*requires_file:}"
+                val="${val# }"
+                cur_pre_req="$val"
+                continue
+                ;;
+            "-- env:"*|"--env:"*)
+                local val="${trimmed#*env:}"
+                val="${val# }"
+                if [ -n "$cur_pre_env" ]; then
+                    cur_pre_env+=" $val"
+                else
+                    cur_pre_env="$val"
+                fi
+                continue
+                ;;
+            "-- expected_fail:"*|"--expected_fail:"*)
+                local val="${trimmed#*expected_fail:}"
+                val="${val# }"
+                cur_pre_xf="$val"
+                continue
+                ;;
+            "--"*)
+                # Plain SQL comment — drop.
+                continue
+                ;;
+        esac
+
+        cur_sql+="$line"$'\n'
+        # Trailing `;` ends a statement.
+        local stripped="${line%"${line##*[![:space:]]}"}"
+        if [[ "$stripped" == *";" ]]; then
+            flush
+        fi
+    done <"$file"
+
+    # Final unterminated statement?
+    if [ -n "${cur_sql//[[:space:]]/}" ]; then
+        flush
+    fi
+
+    echo
+    echo "${C_BOLD}== $file (${#Q_SQL[@]} queries) ==${C_OFF}"
+
+    local i=0
+    while [ "$i" -lt "${#Q_SQL[@]}" ]; do
+        local label
+        label="$(basename "$file"):q$((i+1))"
+        execute_query "$label" "${Q_SQL[$i]}" "${Q_EXP[$i]}" \
+                      "${Q_ENV[$i]}" "${Q_REQ[$i]}" "${Q_XF[$i]}"
+        i=$((i + 1))
+    done
+
+    echo "  ${C_DIM}-> ${pass} pass / ${fail} fail / ${efail} xfail / ${skip} skip${C_OFF}"
+    if [ "$unexpected_pass" -gt 0 ]; then
+        echo "  ${C_DIM}-> ${unexpected_pass} unexpected-pass (consider clearing expected_fail tag)${C_OFF}"
+    fi
+
+    TOTAL_FILES=$((TOTAL_FILES + 1))
+    TOTAL_PASS=$((TOTAL_PASS + pass))
+    TOTAL_FAIL=$((TOTAL_FAIL + fail))
+    TOTAL_SKIP=$((TOTAL_SKIP + skip))
+    TOTAL_EXPECTED_FAIL=$((TOTAL_EXPECTED_FAIL + efail))
+    TOTAL_UNEXPECTED_PASS=$((TOTAL_UNEXPECTED_PASS + unexpected_pass))
+}
+
+# ----- main loop ---------------------------------------------------------
+
+for f in "${TEST_FILES[@]}"; do
+    run_file "$f"
+done
+
+echo
+echo "${C_BOLD}== summary ==${C_OFF}"
+echo "  files:           $TOTAL_FILES"
+echo "  pass:            ${C_GREEN}$TOTAL_PASS${C_OFF}"
+echo "  fail:            ${C_RED}$TOTAL_FAIL${C_OFF}"
+echo "  xfail (expected):${C_YEL}$TOTAL_EXPECTED_FAIL${C_OFF}"
+echo "  skip:            ${C_YEL}$TOTAL_SKIP${C_OFF}"
+echo "  unexpected pass: ${C_YEL}$TOTAL_UNEXPECTED_PASS${C_OFF}"
+
+if [ "$TOTAL_FAIL" -eq 0 ]; then
+    if [ "$TOTAL_EXPECTED_FAIL" -gt 0 ]; then
+        plural=""
+        [ "$TOTAL_EXPECTED_FAIL" -gt 1 ] && plural="s"
+        echo "${C_GREEN}all passed (${TOTAL_EXPECTED_FAIL} expected fail${plural} logged)${C_OFF}"
+    else
+        echo "${C_GREEN}all passed${C_OFF}"
+    fi
+    exit 0
+else
+    echo "${C_RED}FAILURES:${C_OFF}"
+    for d in "${FAIL_DETAILS[@]}"; do echo "  - $d"; done
+    exit 1
+fi

--- a/test/sql/gpu_force_backend.test
+++ b/test/sql/gpu_force_backend.test
@@ -1,0 +1,97 @@
+# gpu_force_backend SQL test — verifies the suite works under the
+# GPUDB_FORCE_BACKEND env var (cpu / gpu / auto).
+#
+# CURRENT STATE:
+#   The env var GPUDB_FORCE_BACKEND is NOT yet honoured by the extension.
+#   src/backends/backend_factory.cpp::default_backend() picks CUDA if the
+#   runtime is available; otherwise CPU. There is no `getenv("GPUDB_FORCE_
+#   BACKEND")` call anywhere in src/.
+#
+#   Consequently, all three sections of this file currently exercise the
+#   SAME backend (whatever default_backend() returns on the host). The
+#   tests still serve a purpose:
+#     1. They pin the contract: running gpudb-sql with the env var set
+#        must not error or crash (forward-compat regression guard).
+#     2. They re-exercise the core gpu_sum/gpu_min/gpu_max correctness
+#        invariants. If a future change wires up the env var and breaks
+#        any backend in isolation, this file will catch it.
+#
+# When the env var is wired up, update each section's expectations to
+# match the per-backend behaviour and split the file if the backends
+# diverge meaningfully (e.g. CPU returns NULL on empty, GPU returns 0).
+#
+# Run via:
+#   ./scripts/run_sql_tests.sh gpu_force_backend
+#
+# The runner honours `-- env: KEY=VAL` directives applied to the next query.
+
+# ===========================================================================
+# Section A — GPUDB_FORCE_BACKEND=cpu (forward-compat: env var no-op today)
+# ===========================================================================
+
+-- env: GPUDB_FORCE_BACKEND=cpu
+SELECT gpu_sum(range::BIGINT) AS gpu, sum(range::BIGINT) AS native FROM range(10);
+-- expect: 45  45
+
+-- env: GPUDB_FORCE_BACKEND=cpu
+SELECT gpu_min(range::BIGINT) AS gmin, min(range::BIGINT) AS nmin,
+       gpu_max(range::BIGINT) AS gmax, max(range::BIGINT) AS nmax
+FROM range(1, 11);
+-- expect: 1  1  10  10
+
+-- env: GPUDB_FORCE_BACKEND=cpu
+SELECT gpu_sum(range::BIGINT) AS gpu, sum(range::BIGINT) AS native FROM range(100000);
+-- expect: 4999950000  4999950000
+
+# ===========================================================================
+# Section B — GPUDB_FORCE_BACKEND=gpu
+# ===========================================================================
+
+-- env: GPUDB_FORCE_BACKEND=gpu
+SELECT gpu_sum(range::BIGINT) AS gpu, sum(range::BIGINT) AS native FROM range(10);
+-- expect: 45  45
+
+-- env: GPUDB_FORCE_BACKEND=gpu
+SELECT gpu_min(range::BIGINT) AS gmin, min(range::BIGINT) AS nmin,
+       gpu_max(range::BIGINT) AS gmax, max(range::BIGINT) AS nmax
+FROM range(1, 11);
+-- expect: 1  1  10  10
+
+-- env: GPUDB_FORCE_BACKEND=gpu
+SELECT gpu_sum(range::BIGINT) AS gpu, sum(range::BIGINT) AS native FROM range(1000000);
+-- expect: 499999500000  499999500000
+
+# ===========================================================================
+# Section C — GPUDB_FORCE_BACKEND=auto (default)
+# Skips window+PARTITION (covered as expected_fail in gpu_window.test)
+# ===========================================================================
+
+-- env: GPUDB_FORCE_BACKEND=auto
+SELECT gpu_sum(range::BIGINT) AS gpu, sum(range::BIGINT) AS native FROM range(10);
+-- expect: 45  45
+
+-- env: GPUDB_FORCE_BACKEND=auto
+SELECT gpu_sum(x) AS gpu, sum(x) AS native
+FROM (VALUES (-100::BIGINT), (50::BIGINT), (-25::BIGINT), (75::BIGINT), (0::BIGINT)) t(x);
+-- expect: 0  0
+
+-- env: GPUDB_FORCE_BACKEND=auto
+SELECT gpu_min(x) gmin, min(x) nmin, gpu_max(x) gmax, max(x) nmax
+FROM (VALUES (10::BIGINT), (3::BIGINT), (-7::BIGINT), (42::BIGINT), (0::BIGINT)) t(x);
+-- expect: -7  -7  42  42
+
+-- env: GPUDB_FORCE_BACKEND=auto
+SELECT gpu_sum(range::BIGINT) AS gpu, sum(range::BIGINT) AS native FROM range(1000000);
+-- expect: 499999500000  499999500000
+
+-- env: GPUDB_FORCE_BACKEND=auto
+-- Running-sum window — works under all backends today.
+SELECT range AS r,
+       gpu_sum(range::BIGINT) OVER (ORDER BY range) AS gs,
+       sum(range::BIGINT)     OVER (ORDER BY range) AS ns
+FROM range(5);
+-- expect: 0  0   0
+-- expect: 1  1   1
+-- expect: 2  3   3
+-- expect: 3  6   6
+-- expect: 4  10  10

--- a/test/sql/gpu_groupby.test
+++ b/test/sql/gpu_groupby.test
@@ -1,0 +1,86 @@
+# gpu_groupby SQL test — exercises gpu_sum under GROUP BY.
+#
+# IMPORTANT: gpu_sum has a documented mid-cardinality GROUP BY accuracy bug.
+# Tests in this file fall into three buckets:
+#   (a) low-cardinality cases where the per-state path happens to be correct
+#   (b) high-cardinality cases that hit the BATCHED finalize path (>= 64
+#       groups + total > 0 → src/extension/gpu_sum_extension.cpp:158-194):
+#       this path is correct because it routes through the GPU GROUP BY
+#       kernel directly.
+#   (c) one mid-cardinality case marked `expected_fail:` that demonstrates
+#       the bug. Other agent (fix/window-partition-bug branch) is investigating.
+#
+# Run via:
+#   ./scripts/run_sql_tests.sh gpu_groupby
+
+-- 1. Single-key GROUP BY (effectively ungrouped) — must match native
+SELECT k, gpu_sum(v) gs, sum(v) ns
+FROM (SELECT 0::BIGINT AS k, range::BIGINT AS v FROM range(100))
+GROUP BY k ORDER BY k;
+-- expect: 0  4950  4950
+
+-- 2. Tiny GROUP BY with 2 keys, 3 rows — first chunk small enough that the
+--    per-state pushback in update() walks each row distinctly. Correct here.
+SELECT k, gpu_sum(v) gs, sum(v) ns
+FROM (
+    SELECT 'a'::TEXT AS k, 10::BIGINT AS v
+    UNION ALL SELECT 'a', 20
+    UNION ALL SELECT 'b', 5
+) GROUP BY k ORDER BY k;
+-- expect: a  30  30
+-- expect: b  5   5
+
+-- 3. GROUP BY with HAVING — filter after aggregation
+SELECT k, gpu_sum(v) gs, sum(v) ns FROM (
+    SELECT 'a'::TEXT AS k, 1::BIGINT AS v
+    UNION ALL SELECT 'b', 2
+    UNION ALL SELECT 'a', 3
+) GROUP BY k HAVING sum(v) > 2 ORDER BY k;
+-- expect: a  4  4
+
+-- 4. count(*) check on a 100-group GROUP BY — count is independent of
+--    gpu_sum so this asserts that grouping itself is unbroken.
+SELECT (SUM(c) = 1000000)::INT eq, COUNT(*) ngrp
+FROM (
+    WITH g AS (SELECT (range % 100)::BIGINT AS k FROM range(1000000))
+    SELECT k, COUNT(*) c FROM g GROUP BY k
+);
+-- expect: 1  100
+
+-- 5. High-cardinality stress: 100k groups × 10 rows each = 1M rows.
+--    Triggers the batched finalize path (count >= 64); per BENCHMARK.md
+--    this routes through the GPU GROUP BY kernel and is the correct path.
+--    Asserts the total invariant SUM(gpu_sum(v)) == SUM(sum(v)).
+SELECT (SUM(gs) = SUM(ns))::INT eq, COUNT(*) ngrp
+FROM (
+    WITH g AS (SELECT (range % 100000)::BIGINT AS k, range::BIGINT AS v FROM range(1000000))
+    SELECT k, gpu_sum(v) gs, sum(v) ns FROM g GROUP BY k
+);
+-- expect: 1  100000
+
+-- 6. Cardinality=1 stress (high row count)
+SELECT (SUM(gs) = SUM(ns))::INT eq, COUNT(*) ngrp
+FROM (
+    SELECT 0::BIGINT AS k, gpu_sum(range::BIGINT) gs, sum(range::BIGINT) ns FROM range(1000000) GROUP BY k
+);
+-- expect: 1  1
+
+-- 7. Cardinality=100, 10M rows — KNOWN BUGGY (per-state path).
+--    Mid-cardinality (100 groups, above the 64-state batched threshold but
+--    the bug is wider than just the small-groups path) hits a correctness
+--    bug in src/extension/gpu_sum_extension.cpp where the per-state buf
+--    accumulated by update() does not match what DuckDB routed to the state.
+--    Other agent fixes this on branch fix/window-partition-bug.
+--
+--    The bug is intermittent at small scales (10 groups / 1M rows passes
+--    on a warm GPU); this 100×10M configuration triggers it reliably.
+--
+--    TODO: when the fix lands, change to `-- expect: 1  100` and remove the
+--    expected_fail tag.
+-- expected_fail: mid-cardinality GROUP BY total invariant currently broken
+SELECT (SUM(gs) = SUM(ns))::INT eq, COUNT(*) ngrp
+FROM (
+    WITH g AS (SELECT (range % 100)::BIGINT AS k, range::BIGINT AS v FROM range(10000000))
+    SELECT k, gpu_sum(v) gs, sum(v) ns FROM g GROUP BY k
+);
+-- expect: 1  100

--- a/test/sql/gpu_min_max.test
+++ b/test/sql/gpu_min_max.test
@@ -1,0 +1,68 @@
+# gpu_min_max SQL test — verifies gpu_min / gpu_max produce identical results
+# to DuckDB's native MIN / MAX on integer ranges, NULL-bearing data, and
+# pseudo-random samples; pins the documented "empty / all-NULL → 0" sentinel.
+#
+# Run via:
+#   ./scripts/run_sql_tests.sh gpu_min_max
+
+-- 1. Tiny mixed-sign sample
+SELECT gpu_min(x) gmin, min(x) nmin, gpu_max(x) gmax, max(x) nmax
+FROM (VALUES (10::BIGINT), (3::BIGINT), (-7::BIGINT), (42::BIGINT), (0::BIGINT)) t(x);
+-- expect: -7  -7  42  42
+
+-- 2. Strictly positive small range
+SELECT gpu_min(range::BIGINT) gmin, min(range::BIGINT) nmin,
+       gpu_max(range::BIGINT) gmax, max(range::BIGINT) nmax
+FROM range(1, 11);
+-- expect: 1  1  10  10
+
+-- 3. Negative range
+SELECT gpu_min((range - 100)::BIGINT) gmin, min((range - 100)::BIGINT) nmin,
+       gpu_max((range - 100)::BIGINT) gmax, max((range - 100)::BIGINT) nmax
+FROM range(50);
+-- expect: -100  -100  -51  -51
+
+-- 4. Signed range straddling 0
+SELECT gpu_min((range - 50000)::BIGINT) gmin, min((range - 50000)::BIGINT) nmin,
+       gpu_max((range - 50000)::BIGINT) gmax, max((range - 50000)::BIGINT) nmax
+FROM range(100000);
+-- expect: -50000  -50000  49999  49999
+
+-- 5. Large pseudo-random sample (deterministic linear congruential)
+WITH r AS (SELECT (range * 7919 + 13) % 1000003 - 500000 AS x FROM range(100000))
+SELECT gpu_min(x::BIGINT) gmin, min(x::BIGINT) nmin,
+       gpu_max(x::BIGINT) gmax, max(x::BIGINT) nmax FROM r;
+-- expect: -499999  -499999  499972  499972
+
+-- 6. INT64 boundary values must round-trip
+SELECT gpu_min(x) gmin, min(x) nmin, gpu_max(x) gmax, max(x) nmax
+FROM (VALUES
+        (-9223372036854775807::BIGINT),
+        (9223372036854775807::BIGINT),
+        (0::BIGINT)) t(x);
+-- expect: -9223372036854775807  -9223372036854775807  9223372036854775807  9223372036854775807
+
+-- 7. NULLs are skipped (matches SQL semantics)
+SELECT gpu_min(x) gmin, min(x) nmin, gpu_max(x) gmax, max(x) nmax
+FROM (SELECT CASE WHEN range % 3 = 0 THEN NULL ELSE range::BIGINT END AS x FROM range(100));
+-- expect: 1  1  98  98
+
+-- 8. MIN(empty) — gpu_min returns 0; native returns NULL.
+--    Documented divergence, same as gpu_sum on empty (see gpu_sum.test).
+SELECT gpu_min(x) gmin, min(x) nmin FROM (SELECT NULL::BIGINT WHERE FALSE) t(x);
+-- expect: 0  NULL
+
+-- 9. MAX(empty) — same divergence as MIN.
+SELECT gpu_max(x) gmax, max(x) nmax FROM (SELECT NULL::BIGINT WHERE FALSE) t(x);
+-- expect: 0  NULL
+
+-- 10. MIN/MAX over an all-NULL column — same divergence (gpu returns 0).
+SELECT gpu_min(x) gmin, min(x) nmin, gpu_max(x) gmax, max(x) nmax
+FROM (VALUES (NULL::BIGINT), (NULL::BIGINT), (NULL::BIGINT)) t(x);
+-- expect: 0  NULL  0  NULL
+
+-- 11. 1M-row range — wide span correctness
+SELECT gpu_min(range::BIGINT) gmin, min(range::BIGINT) nmin,
+       gpu_max(range::BIGINT) gmax, max(range::BIGINT) nmax
+FROM range(1000000);
+-- expect: 0  0  999999  999999

--- a/test/sql/gpu_sum.test
+++ b/test/sql/gpu_sum.test
@@ -2,8 +2,20 @@
 # results to DuckDB's native SUM on real and synthetic data.
 #
 # Run via:
-#   ./build-linux/bin/gpudb-sql --sql "$(cat test/sql/gpu_sum.test)"
-# Or wrap in a CTest target later.
+#   ./scripts/run_sql_tests.sh gpu_sum
+# Or all suites:
+#   ./scripts/run_sql_tests.sh
+#
+# Test format:
+#   - SQL queries are separated by `;`. Only the LAST result of a multi-
+#     statement script is captured by gpudb-sql, so each test query is
+#     a single SELECT.
+#   - Each query's expected output follows as `-- expect: <line>` comments
+#   - Columns are whitespace-separated; the runner normalises runs of
+#     whitespace and ignores the header row
+#   - Lines starting with `--` and `#` are ignored as SQL
+#   - `-- requires_file: <path>` skips the next query if the file is missing
+#   - `-- expected_fail:` marks a known-failing query (see gpu_window.test)
 
 -- 1. Trivial range
 SELECT
@@ -12,16 +24,71 @@ SELECT
 FROM range(10);
 -- expect: 45  45
 
--- 2. TPC-H lineitem orderkey (6M rows from SF1)
+-- 2. TPC-H lineitem orderkey (6M rows from SF1) — only runs if file exists.
+--    The suite skips this query if the parquet is absent; otherwise it must match.
+-- requires_file: data/tpch_sf1/lineitem_orderkey.parquet
 SELECT
     gpu_sum(v)             AS gpu,
     sum(v)                 AS native
 FROM read_parquet('data/tpch_sf1/lineitem_orderkey.parquet');
 -- expect: 18005322964949  18005322964949
 
--- 3. Negative + positive mix
+-- 3. Negative + positive mix (sums to 0)
 SELECT
     gpu_sum(x)             AS gpu,
     sum(x)                 AS native
 FROM (VALUES (-100::BIGINT), (50::BIGINT), (-25::BIGINT), (75::BIGINT), (0::BIGINT)) t(x);
 -- expect: 0  0
+
+-- 4. Empty table — gpu_sum returns 0; native returns NULL.
+--    This is a documented divergence: extension returns a 0 sentinel for
+--    the empty-state finalize, while DuckDB's native SUM follows the SQL
+--    spec and returns NULL. See src/extension/gpu_sum_extension.cpp.
+SELECT gpu_sum(x) AS gpu, sum(x) AS native FROM (SELECT NULL::BIGINT WHERE FALSE) t(x);
+-- expect: 0  NULL
+
+-- 5. All-NULL column — gpu_sum returns 0; native returns NULL (same rationale as #4).
+SELECT gpu_sum(x) AS gpu, sum(x) AS native FROM (VALUES (NULL::BIGINT), (NULL::BIGINT), (NULL::BIGINT)) t(x);
+-- expect: 0  NULL
+
+-- 6. Large NULL mix — every even row is NULL, odds carry the value.
+--    1 + 3 + 5 + ... + 99 = 50^2 = 2500
+SELECT
+    gpu_sum(CASE WHEN range % 2 = 0 THEN NULL ELSE range::BIGINT END) AS gpu,
+    sum(CASE WHEN range % 2 = 0 THEN NULL ELSE range::BIGINT END)     AS native
+FROM range(100);
+-- expect: 2500  2500
+
+-- 7. Larger NULL mix — 100k rows, half NULL.
+--    Sum of odd integers in [0,100000): 1+3+...+99999 = 50000^2 = 2_500_000_000
+SELECT
+    gpu_sum(CASE WHEN range % 2 = 0 THEN NULL ELSE range::BIGINT END) AS gpu,
+    sum(CASE WHEN range % 2 = 0 THEN NULL ELSE range::BIGINT END)     AS native
+FROM range(100000);
+-- expect: 2500000000  2500000000
+
+-- 8. All positive
+SELECT gpu_sum(x) AS gpu, sum(x) AS native
+FROM (VALUES (1::BIGINT), (2::BIGINT), (3::BIGINT), (4::BIGINT), (5::BIGINT)) t(x);
+-- expect: 15  15
+
+-- 9. All negative
+SELECT gpu_sum(x) AS gpu, sum(x) AS native
+FROM (VALUES (-1::BIGINT), (-2::BIGINT), (-3::BIGINT), (-4::BIGINT), (-5::BIGINT)) t(x);
+-- expect: -15  -15
+
+-- 10. Mixed sign — non-trivial cancellation
+SELECT gpu_sum(x) AS gpu, sum(x) AS native
+FROM (VALUES (-1000::BIGINT), (500::BIGINT), (-250::BIGINT), (1000::BIGINT), (-250::BIGINT)) t(x);
+-- expect: 0  0
+
+-- 11. Large positive set — 1M rows, range
+SELECT gpu_sum(range::BIGINT) AS gpu, sum(range::BIGINT) AS native FROM range(1000000);
+-- expect: 499999500000  499999500000
+
+-- 12. Large signed set — shift range to span negatives & positives.
+SELECT
+    gpu_sum((range - 50000)::BIGINT) AS gpu,
+    sum((range - 50000)::BIGINT)     AS native
+FROM range(100000);
+-- expect: -50000  -50000

--- a/test/sql/gpu_window.test
+++ b/test/sql/gpu_window.test
@@ -1,0 +1,118 @@
+# gpu_window SQL test — exercises gpu_sum used as a window function.
+#
+# State of the art (as of branch test/sql-suite-expand):
+#   * `gpu_sum(x) OVER (ORDER BY k)` running-sum: works
+#   * `gpu_sum(x) OVER ()` ungrouped scalar: SEGFAULTS (full-frame path
+#     not implemented in the aggregate state machine)
+#   * `gpu_sum(x) OVER (PARTITION BY g)` no order: produces the right total
+#     when invoked solo, but goes non-deterministic when another window
+#     function shares the same partition spec
+#   * `gpu_sum(x) OVER (PARTITION BY g ORDER BY k)` partitioned running
+#     sum: NON-DETERMINISTIC — sometimes wrong values, sometimes segfault.
+#     Memory corruption suspect. Tracked on branch fix/window-partition-bug.
+#
+# Run via:
+#   ./scripts/run_sql_tests.sh gpu_window
+
+-- 1. Native-only SUM OVER () (sanity: native windowing works in our env)
+SELECT range AS r, sum(range::BIGINT) OVER () AS ns FROM range(5);
+-- expect: 0  10
+-- expect: 1  10
+-- expect: 2  10
+-- expect: 3  10
+-- expect: 4  10
+
+-- 2. Running sum via ORDER BY — gpu_sum currently produces correct values
+SELECT range AS r,
+       gpu_sum(range::BIGINT) OVER (ORDER BY range) AS gs,
+       sum(range::BIGINT)     OVER (ORDER BY range) AS ns
+FROM range(5);
+-- expect: 0  0   0
+-- expect: 1  1   1
+-- expect: 2  3   3
+-- expect: 3  6   6
+-- expect: 4  10  10
+
+-- 3. Running sum, larger range — gpu_sum loses its running state across
+--    DuckDB chunk boundaries (default chunk size is 2048 but the window
+--    plan splits into smaller frames). After ~15 rows the running sum
+--    "resets" instead of accumulating. Documented as expected fail.
+--
+--    TODO when fixed: this should produce a clean ascending sequence
+--    matching `sum(...) OVER (ORDER BY range)` row-for-row.
+-- expected_fail: gpu_sum running sum loses state across chunk boundaries
+SELECT r, gs, ns FROM (
+    SELECT range AS r,
+           gpu_sum(range::BIGINT) OVER (ORDER BY range) AS gs,
+           sum(range::BIGINT)     OVER (ORDER BY range) AS ns
+    FROM range(20)
+) WHERE r = 19;
+-- expect: 19  190  190
+
+-- 4. SUM OVER () — gpu_sum SEGFAULTS on the unbounded-frame case.
+--    The aggregate function callback does not have a window/finalize path
+--    for "all rows, scalar broadcast", and DuckDB ends up dereferencing a
+--    state that was never combined.
+--
+--    TODO: when finalize-for-window lands, swap to:
+--      -- expect: 0  10  10
+--      -- expect: 1  10  10
+--      -- expect: 2  10  10
+--      -- expect: 3  10  10
+--      -- expect: 4  10  10
+--    and remove the expected_fail tag.
+-- expected_fail: gpu_sum OVER () segfaults — unbounded-frame window unimplemented
+SELECT range AS r,
+       gpu_sum(range::BIGINT) OVER () AS gs,
+       sum(range::BIGINT)     OVER () AS ns
+FROM range(5);
+-- expect: 0  10  10
+-- expect: 1  10  10
+-- expect: 2  10  10
+-- expect: 3  10  10
+-- expect: 4  10  10
+
+-- 5. KNOWN BUG: SUM OVER (PARTITION BY g ORDER BY k).
+--
+-- Reproducer (10 rows, 3 partitions = range % 3, partition-running sum):
+--   Native (correct) output, ordered by r:
+--     r  partition  ns
+--     0  0          0
+--     1  1          1
+--     2  2          2
+--     3  0          3   = 0+3
+--     4  1          5   = 1+4
+--     5  2          7   = 2+5
+--     6  0          9   = 0+3+6
+--     7  1         12   = 1+4+7
+--     8  2         15   = 2+5+8
+--     9  0         18   = 0+3+6+9
+--
+--   gpu_sum output:
+--     - Sometimes the first row of each partition shows 0 instead of the
+--       value (e.g. r=2 → gs=0 not 2)
+--     - Sometimes wildly wrong values across the whole result set
+--     - Sometimes the process SEGFAULTs
+--   The behaviour is NON-DETERMINISTIC — likely uninitialised state or
+--   an out-of-bounds write in the partition-walk path.
+--
+-- Other agent on branch `fix/window-partition-bug` is investigating.
+-- DO NOT delete this test when fixing — convert it to a strict positive
+-- assertion (every row matches native) once stable.
+--
+-- TODO when fixed: replace expected_fail with the 10 expect: lines below.
+-- expected_fail: PARTITION BY g ORDER BY k — non-deterministic wrong / segfault
+SELECT range AS r,
+       gpu_sum(range::BIGINT) OVER (PARTITION BY (range % 3) ORDER BY range) AS gs,
+       sum(range::BIGINT)     OVER (PARTITION BY (range % 3) ORDER BY range) AS ns
+FROM range(10);
+-- expect: 0  0   0
+-- expect: 1  1   1
+-- expect: 2  2   2
+-- expect: 3  3   3
+-- expect: 4  5   5
+-- expect: 5  7   7
+-- expect: 6  9   9
+-- expect: 7  12  12
+-- expect: 8  15  15
+-- expect: 9  18  18


### PR DESCRIPTION
## Summary

- Adds **5 SQL `.test` files** under `test/sql/` and a **runner script** (`scripts/run_sql_tests.sh`) that drives `gpudb-sql` one statement at a time and compares results against embedded `-- expect:` lines.
- Total suite: **46 queries → 42 PASS, 4 XFAIL (expected fail), 0 FAIL.** Exits 0 iff every query is either PASS or expected_fail.
- Documents four real bugs as `expected_fail:` tags with TODOs pointing at branch `fix/window-partition-bug`. Each XFAIL has the exact `-- expect:` lines that should pass once fixed (just remove the tag).

## Files added / changed

| File | Note |
|------|------|
| `test/sql/gpu_sum.test` | extended from 3 → 12 queries (NULL mix, empty, all-positive, all-negative, mixed sign, 1M-row, signed range) |
| `test/sql/gpu_min_max.test` | NEW — 11 queries; pins the `MIN/MAX(empty) → 0` sentinel divergence vs SQL `NULL` |
| `test/sql/gpu_groupby.test` | NEW — 7 queries; covers single-key, HAVING, count(*) sanity, high-cardinality batched-finalize total invariant; **1 XFAIL** for mid-cardinality per-state GROUP BY total bug |
| `test/sql/gpu_window.test` | NEW — 5 queries; running sum (works) + **3 XFAIL**: running-sum across chunk boundaries, `OVER ()` segfault, `PARTITION BY g ORDER BY k` non-determinism |
| `test/sql/gpu_force_backend.test` | NEW — 11 queries; `GPUDB_FORCE_BACKEND` env var (currently a no-op, left as forward-compat regression guard) across `cpu` / `gpu` / `auto` sections |
| `scripts/run_sql_tests.sh` | NEW — runner with `-- expect:` / `-- requires_file:` / `-- env:` / `-- expected_fail:` directives; per-query `timeout`; PASS / FAIL / XFAIL / SKIP / UNEXPECTED-PASS reporting |
| `scripts/local_check.sh` | wires the runner into the existing local-check sweep |
| `README.md` | mentions the runner and the four documented expected fails |

## Test format

```sql
-- env: GPUDB_FORCE_BACKEND=cpu                  # set env for the next query
-- requires_file: data/tpch_sf1/lineitem.parquet  # skip if missing
-- expected_fail: <reason>                        # next query may FAIL/segfault
SELECT gpu_sum(x) AS gpu, sum(x) AS native FROM ...;
-- expect: 45  45                                 # whitespace-tolerant
```

## Test plan

- [x] `./scripts/run_sql_tests.sh` → `all passed (4 expected fails logged)` (verified 5 consecutive runs)
- [x] `./scripts/run_sql_tests.sh gpu_sum` (single file by basename)
- [x] `./scripts/run_sql_tests.sh test/sql/gpu_window.test` (full path)
- [x] Verified failure mode: a deliberately-wrong `-- expect:` makes the runner exit `1` and list the failing query
- [x] Verified `requires_file:` SKIPs gracefully when the file is absent
- [x] Verified `expected_fail:` accepts segfault, timeout, AND wrong-output as XFAIL
- [x] Verified the runner's per-query 30s timeout reaps the partition-window hang
- [x] Verified no `--no-verify`, no force-push, only `test/sql-suite-expand` branch touched