### PR TITLE
fix: re-enable gpu_sum OVER () + close last open bug

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,25 +1,14 @@
 # Known issues
 
-Pre-alpha. Status as of 2026-05-09 night, post-`v0.1.0` launch candidate.
+Status as of 2026-05-09 night, `v0.1.0` shipped. **All known functional bugs resolved.**
 
-If you are bitten by something here, fall back to native DuckDB `sum()` / `min()` / `max()` / window functions for that query — the hybrid planner inside the extension already does this automatically wherever it can.
+If you do hit something here, fall back to native DuckDB `sum()` / `min()` / `max()` / window functions for that query — the hybrid planner inside the extension already does this automatically wherever it can.
 
 ---
 
 ## Open issues
 
-### `gpu_sum(v) OVER ()` — unbounded frame SEGFAULTS
-
-```sql
-SELECT k, gpu_sum(v) OVER () FROM (SELECT range AS k, range::BIGINT AS v FROM range(20));
-```
-
-Expected: every row shows the constant `190`.
-Actual: SIGSEGV.
-
-Workaround: use native `sum() OVER ()`. The query has been commented out from `test/sql/gpu_window.test` for v0.1; a parallel agent on `fix/window-bugs-followup` is investigating the root cause (suspected: state lifecycle for the unbounded window frame is different from the standard aggregate path).
-
-Target fix: v0.1.1 (within 1 week of launch).
+None.
 
 ---
 
@@ -34,16 +23,23 @@ These are **not** bugs — explicit design choices for v0.1.0. Will be revisited
 
 Returning `0` is the C++ aggregator's natural behavior; properly returning SQL `NULL` requires using `duckdb_validity_set_row_invalid` on the output vector. SQL queries that test for `IS NULL` on a fully-empty/all-NULL aggregate result currently get `false`.
 
+### Hardware-imposed limits (won't fix)
+
+| Behavior | Reason |
+|---|---|
+| `gpu_sum(DOUBLE)` falls back to host on Apple Silicon | Apple GPUs do not implement IEEE-754 double precision in MSL. Result is correct; just no GPU acceleration. |
+
 ---
 
-## Resolved issues (fixed in `v0.1.0` candidate)
+## Resolved issues (fixed in `v0.1.0`)
 
 | Issue | Fixed in |
 |---|---|
-| Window+PARTITION BY non-determinism | PR #18 (combine() copy-not-move) + PR #20 |
-| Window OVER (ORDER BY) running-sum chunk-boundary state loss | PR #18 |
-| Mid-cardinality (50-63 groups) GROUP BY wrong totals | PR #21 (CPU per-state in mid-card regime) |
-| metal_aggregator.mm duplicate decls (build broken on macOS) | PR #20 |
+| `gpu_sum(v) OVER ()` unbounded-frame SIGSEGV | PR #22 (BufferPool POD state + magic-word probe defends update() against `WindowConstantAggregator`'s CONSTANT_VECTOR state) |
+| `gpu_sum(v) OVER (PARTITION BY g ORDER BY k)` non-determinism / wrong values | PR #18 (combine() copy-not-move) + PR #22 (POD state) |
+| `gpu_sum(v) OVER (ORDER BY k)` running-sum chunk-boundary state loss | PR #18 |
+| Mid-cardinality (50–63 groups) GROUP BY wrong totals | PR #21 (CPU per-state in mid-card regime) |
+| `metal_aggregator.mm` duplicate decls (build broken on macOS) | PR #20 |
 | `scripts/run_sql_tests.sh` couldn't run on macOS (missing `timeout`) | PR #20 |
 
 ---
@@ -55,6 +51,6 @@ git clone https://github.com/singhpratech/duckdbgpumetaldbram
 cd duckdbgpumetaldbram
 ./scripts/get_duckdb_libs.sh
 ./scripts/build.sh
-./scripts/local_check.sh        # builds + 77 unit tests + smoke benchmarks
-./scripts/run_sql_tests.sh      # 5 .test files, 44 queries, 0 fail / 0 xfail
+./scripts/local_check.sh        # builds + cpp tests + smoke benchmarks
+./scripts/run_sql_tests.sh      # 5 .test files, 46 queries, 0 fail / 0 xfail
 ```

--- a/test/sql/gpu_window.test
+++ b/test/sql/gpu_window.test
@@ -38,18 +38,20 @@ SELECT r, gs, ns FROM (
 ) WHERE r = 19;
 -- expect: 19  190  190
 
--- 4. SUM OVER () — DISABLED on macOS+Metal (still segfaults; works on
---    Linux+CPU). DuckDB picks the WindowConstantAggregator for this,
---    which calls our update() with a CONSTANT_VECTOR state pointer.
---    PR #22's magic-word probe handles the Linux+CPU path; the Metal
---    staging path needs a separate fix. Tracked in KNOWN_ISSUES.md,
---    target v0.1.1.
--- SELECT range AS r,
---        gpu_sum(range::BIGINT) OVER () AS gs,
---        sum(range::BIGINT)     OVER () AS ns
--- FROM range(5)
--- ORDER BY r;
--- (expected: every row → gs=10, ns=10)
+-- 4. SUM OVER () — unbounded-frame window. DuckDB picks the
+--    WindowConstantAggregator for this, which calls our update() with a
+--    CONSTANT_VECTOR state pointer. PR #22's magic-word probe defends
+--    against the OOB read (works on Linux+CPU and macOS+Metal).
+SELECT range AS r,
+       gpu_sum(range::BIGINT) OVER () AS gs,
+       sum(range::BIGINT)     OVER () AS ns
+FROM range(5)
+ORDER BY r;
+-- expect: 0  10  10
+-- expect: 1  10  10
+-- expect: 2  10  10
+-- expect: 3  10  10
+-- expect: 4  10  10
 
 -- 5. SUM OVER (PARTITION BY g ORDER BY k). 10 rows, 3 partitions.
 --    Each partition has its own running sum. Verify gpu_sum matches


### PR DESCRIPTION
## Summary
Re-enable q4 (\`gpu_sum(...) OVER ()\`) in the SQL test suite and mark the bug as resolved. The Metal SEGV reported earlier was a stale-binary artifact, not a real bug — PR #22's BufferPool fix actually works on BOTH backends.

## Root cause analysis
- Earlier session reported \`SELECT gpu_sum(v) OVER () FROM range(5)\` segfaulted on macOS+Metal (exit=139)
- Investigation tonight: traced the SEGV to \`build-macos/bin/gpudb-sql\` being a stale binary compiled before PR #22 landed
- Reproduced standalone: build-linux passed, build-macos SEGVed
- Rebuilt build-macos from current main → query passes correctly (every row returns gs=10, ns=10)

## Net result
- \`gpu_sum(...) OVER ()\`: works on both Linux+CPU and macOS+Metal
- SQL suite: 46/46 pass / 0 fail / 0 xfail / 0 unexpected-pass on macOS+Metal
- KNOWN_ISSUES.md: zero open functional bugs for v0.1.0

## Test plan
- [x] \`cmake --build build-macos -j\` clean
- [x] \`./build-macos/test/test_gpudb\` → 96/96 checks pass
- [x] \`./scripts/run_sql_tests.sh\` → 46/46 pass / 0 fail
- [x] Standalone q4 reproducer (5 consecutive runs) → all 5 exit 0 with correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)