### PR TITLE
chore(release): v0.1.1 — close last open bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(gpudb
-    VERSION 0.1.0
+    VERSION 0.1.1
     DESCRIPTION "GPU-accelerated operators for DuckDB (CUDA + Metal)"
     LANGUAGES CXX
 )

--- a/docs/COMMUNITY_EXTENSION_DESCRIPTION.yml
+++ b/docs/COMMUNITY_EXTENSION_DESCRIPTION.yml
@@ -14,7 +14,7 @@ extension:
     Backends: NVIDIA CUDA (Linux/Windows) and Apple Metal (macOS).
     First-class Apple Silicon support — no other GPU SQL engine ships
     Metal numbers.
-  version: 0.1.0
+  version: 0.1.1
   language: C++
   build: cmake
   license: Apache-2.0
@@ -24,7 +24,7 @@ extension:
 
 repo:
   github: singhpratech/duckdbgpumetaldbram
-  ref: v0.1.0
+  ref: v0.1.1
 
 docs:
   hello_world: |


### PR DESCRIPTION
## Summary
v0.1.1 = v0.1.0 + window-function fixes. Bumps version + pins description.yml.

## What changed since v0.1.0
- \`gpu_sum(...) OVER ()\` now works on macOS+Metal (PR #22 + #26)
- \`gpu_sum(...) OVER (PARTITION BY g ORDER BY k)\` deterministic & correct (PR #22)
- KNOWN_ISSUES.md: **zero open functional bugs**
- SQL suite: 46/46 pass (was 44/44 in v0.1.0)

## Test plan
- [x] All 96/96 cpp tests pass
- [x] All 46/46 SQL tests pass on macOS+Metal
- [x] CMake reports new version 0.1.1 in configure summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)