### PR TITLE
docs: mark all 4 known bugs resolved post PR #22

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known issues
 
-Pre-alpha. Status as of 2026-05-09 night, post-`v0.1.0` launch candidate.
+Status as of 2026-05-09 night, post-`v0.1.0` and post-PR #22.
 
 If you are bitten by something here, fall back to native DuckDB `sum()` / `min()` / `max()` / window functions for that query — the hybrid planner inside the extension already does this automatically wherever it can.
 
@@ -8,18 +8,7 @@ If you are bitten by something here, fall back to native DuckDB `sum()` / `min()
 
 ## Open issues
 
-### `gpu_sum(v) OVER ()` — unbounded frame SEGFAULTS
-
-```sql
-SELECT k, gpu_sum(v) OVER () FROM (SELECT range AS k, range::BIGINT AS v FROM range(20));
-```
-
-Expected: every row shows the constant `190`.
-Actual: SIGSEGV.
-
-Workaround: use native `sum() OVER ()`. The query has been commented out from `test/sql/gpu_window.test` for v0.1; a parallel agent on `fix/window-bugs-followup` is investigating the root cause (suspected: state lifecycle for the unbounded window frame is different from the standard aggregate path).
-
-Target fix: v0.1.1 (within 1 week of launch).
+None blocking `v0.1.0`. Window functions and GROUP BY at all tested cardinalities pass on both backends.
 
 ---
 
@@ -36,15 +25,22 @@ Returning `0` is the C++ aggregator's natural behavior; properly returning SQL `
 
 ---
 
-## Resolved issues (fixed in `v0.1.0` candidate)
+## Resolved issues (fixed in `v0.1.0`)
 
 | Issue | Fixed in |
 |---|---|
 | Window+PARTITION BY non-determinism | PR #18 (combine() copy-not-move) + PR #20 |
 | Window OVER (ORDER BY) running-sum chunk-boundary state loss | PR #18 |
+| `gpu_sum(v) OVER ()` unbounded-frame SEGFAULT | PR #22 (POD state + global BufferPool, magic-word probe) |
 | Mid-cardinality (50-63 groups) GROUP BY wrong totals | PR #21 (CPU per-state in mid-card regime) |
 | metal_aggregator.mm duplicate decls (build broken on macOS) | PR #20 |
 | `scripts/run_sql_tests.sh` couldn't run on macOS (missing `timeout`) | PR #20 |
+
+### Why PR #22 needed a process-global BufferPool
+
+DuckDB's `RadixPartitionedTupleData::Repartition()` raw-`memcpy`s aggregate state bytes between partitions without calling `state_init()` or any move/copy callback. Our previous layout — `struct GpuSumState { std::vector<int64_t> buf; }` — had its `buf.data()` pointer duplicated across partitions: both copies pointed at the same heap allocation, and when one was destroyed the other was left dangling. Plus `WindowConstantAggregator` (used for `OVER ()`) passes a `CONSTANT_VECTOR` state pointer that the C API doesn't flatten; reading `states[1..N-1]` is OOB → segfault.
+
+The fix collapses state to a 16-byte POD `{uint64_t magic; uint64_t buf_id;}` indexing into a process-global mutex-guarded `unordered_map<uint64_t, vector<int64_t>>`. The magic word lets `update()` reject CONSTANT_VECTOR OOB reads. State bytes can now be freely copied; the actual data lives outside DuckDB's view.
 
 ---
 
@@ -56,5 +52,5 @@ cd duckdbgpumetaldbram
 ./scripts/get_duckdb_libs.sh
 ./scripts/build.sh
 ./scripts/local_check.sh        # builds + 77 unit tests + smoke benchmarks
-./scripts/run_sql_tests.sh      # 5 .test files, 44 queries, 0 fail / 0 xfail
+./scripts/run_sql_tests.sh      # 5 .test files, 46 queries, 0 fail / 0 xfail
 ```

--- a/README.md
+++ b/README.md
@@ -116,10 +116,9 @@ Backend selection is automatic: CUDA if a device is found at runtime, else Metal
 
 The SQL test suite lives in `test/sql/*.test`. Each file is plain SQL with
 `-- expect:` lines after each query; the runner reports per-query
-PASS / FAIL / XFAIL (expected fail) / SKIP. A few cases are currently
-documented as expected fails and are tracked on `fix/window-partition-bug`:
-the partitioned running-sum window, the unbounded `OVER ()` window, the
-running-sum across chunk boundaries, and mid-cardinality GROUP BY totals.
+PASS / FAIL / XFAIL (expected fail) / SKIP. As of v0.1.0: 46 / 46 pass,
+0 fail, 0 expected fail. The window-function bugs that were previously
+xfail are now strict positive assertions (PR #22).
 
 CI runs on every push: Linux (Ubuntu 24.04, CPU-only) + macOS-14 (CPU + Metal scaffold).
 
@@ -136,8 +135,8 @@ CI runs on every push: Linux (Ubuntu 24.04, CPU-only) + macOS-14 (CPU + Metal sc
 - [x] DuckDB extension: gpu_sum / gpu_min / gpu_max with NULL handling + GPUDB_FORCE_BACKEND env var
 - [x] CLI: gpudb-bench, gpudb-groupby-bench, gpudb-window-bench, gpudb-hashjoin-bench, gpudb-sql
 
-### In flight (v0.1.1, target one week from launch)
-- [ ] Fixes for the 4 bugs in `KNOWN_ISSUES.md` (window+PARTITION BY non-determinism, OVER () segfault, OVER (ORDER BY) chunk-boundary state loss, mid-cardinality GROUP BY wrong totals)
+### In flight (v0.1.1)
+- [x] **Fixes for all 4 window/GROUP BY bugs** (PR #18, #20, #21, #22 — see KNOWN_ISSUES.md)
 - [ ] DuckDB loadable extension metadata footer (required for `LOAD '...so'` from CLI)
 - [ ] Submission to [DuckDB Community Extensions](https://github.com/duckdb/community-extensions) → `INSTALL gpudb FROM community`
 


### PR DESCRIPTION
## Summary
- KNOWN_ISSUES.md: open-issues section empty for v0.1.0; OVER () segfault moved to resolved with root-cause writeup
- README.md: roadmap In-flight ticks the 4 bug fixes; SQL test suite line updated to "46/46 pass, 0 fail, 0 xfail"

## Test plan
- [x] All 4 reproducers pass locally on post-PR #22 main
- [x] 77/77 unit tests, 46/46 SQL queries, 0 fail / 0 xfail

🤖 Generated with [Claude Code](https://claude.com/claude-code)