### PR TITLE
docs(bench): correct 1B GROUP BY kernel bandwidth — was mis-attributed 467 GiB/s

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -100,24 +100,38 @@ hit it, where we don't, and the structural reason for each.
 
 ### Why the 1B GROUP BY drops to 1.5×
 
-At 1B rows, the wall breaks down approximately as:
-- GPU radix sort kernel: ~1.6 s (467 GiB/s, near peak, similar to SUM)
-- Host segment-reduce (parallel 8-thread, scanning 1B sorted i64): ~3 s
-- Memcpy of input + small bookkeeping: ~1 s
-- Total: ~5.6 s
+Re-measured 2026-05-09 night on M4 Max (`gpudb-groupby-bench --rows 1000000000
+--groups 1000000 --runs 3 --backend all`):
 
-The kernel is fine. **The bottleneck is host-side work on 1B elements**.
-This is the same lesson the host-scan for radix offsets taught us
-earlier — when the dataset gets huge, anything sequential on the host
-caps the wins.
+- CPU wall: **8800 ms**
+- Metal wall: **6115 ms** (speedup **1.44×**)
+- Metal kernel time: **1668 ms** (radix sort + GPU scan)
+- Host work (wall − kernel): **4447 ms = 73% of wall**
+
+The radix kernel processes 1B int64 keys + 1B int64 values across 8
+LSD passes; each pass reads + writes both buffers (~40 GB of memory
+traffic per pass × 8 passes ≈ 320 GB total). Effective memory bandwidth
+is ~190 GB/s — about 35% of the M4 Max LPDDR5X ceiling.
+
+**Important: this is NOT the 467 GiB/s figure from the 1B SUM kernel
+above.** Radix sort is multi-pass and more compute-heavy than streaming
+SUM, so the per-kernel sustained bandwidth is roughly 40% of SUM's
+single-pass ceiling. Earlier revisions of this doc mis-attributed
+SUM's 467 GiB/s to the GROUP BY kernel; that was wrong.
+
+**The kernel is fast; the real bottleneck is host work.** 73% of Metal
+wall is the post-kernel host parallel segment-reduce on 1B sorted
+(k,v) pairs. Same lesson the host-scan for radix offsets taught us —
+when the dataset gets huge, anything sequential on the host caps the
+wins.
 
 **The fix:** GPU-resident segment-reduce. After radix sort produces
 sorted (key, value) pairs, run a second compute kernel that walks the
 sorted output in parallel, identifies run boundaries via a prefix scan,
 and emits unique (key, sum) pairs. Same pattern as what we already do
 for the bucket-major scan inside radix — just one more stage. Estimated
-3-4 hours of focused work; would push 1B GROUP BY from 5.6 s → ~2 s,
-flipping the 1.51× into ~4×.
+3-4 hours of focused work; would push 1B GROUP BY from 6.1 s → ~2 s,
+flipping the 1.44× into ~4×.
 
 Filed as the next-step ticket.
 


### PR DESCRIPTION
## Summary
The "Why the 1B GROUP BY drops to 1.5×" section claimed the radix kernel sustains "467 GiB/s, near peak, similar to SUM". That number actually belongs to the **SUM** kernel; the radix-sort kernel runs at ~190 GB/s effective memory bandwidth (35% of LPDDR5X ceiling, not 92%).

## Re-measurement on M4 Max tonight
\`gpudb-groupby-bench --rows 1000000000 --groups 1000000 --runs 3 --backend all\`

| Metric | Old claim | Re-measured |
|---|---:|---:|
| Metal speedup | 1.51× | **1.44×** (within noise) |
| Metal kernel | "~1.6 s, 467 GiB/s" | **1668 ms, ~190 GB/s effective** |
| Host work share | "~3 s of ~5.6 s ≈ 54%" | **4447 ms of 6115 ms = 73%** ✓ host-bottleneck claim verified |

## What changed
- Removed mis-attributed 467 GiB/s from the GROUP BY breakdown
- Added explicit "this is NOT SUM's number" note so the figure doesn't get re-pasted by mistake
- Updated the projection: kernel-bound 6115 ms wall → ~2 s with GPU-resident segment-reduce → ~4× over CPU

## Why it matters
The blog post at theaivibe.org/blog/why-i-built-gpudb-gpu-sql-engine-cuda-apple-silicon reads from this file. The wrong 467 number was propagating from here.

## Test plan
- [x] grep for remaining "467" references — all are in SUM / multi-agg fusion contexts (correct)
- [x] Numbers verified against tonight's bench run

🤖 Generated with [Claude Code](https://claude.com/claude-code)