### PR TITLE
feat: extension actually loads via duckdb CLI now (CUDA-tested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,36 +38,55 @@ The honest finding: for **streaming SUM on cold data**, CPU wins (DDR5 already s
 
 ## Quick start
 
-### Linux (CUDA)
+### Option A — load the prebuilt extension into DuckDB CLI
+
+Download the platform binary from the [v0.1.1 release](https://github.com/singhpratech/duckdbgpumetaldbram/releases/tag/v0.1.1), then:
+
+```bash
+# Linux (RTX/CUDA)
+duckdb -unsigned -c "LOAD '/path/to/gpudb.linux_amd64.duckdb_extension'; \
+  SELECT gpu_sum(value::BIGINT) FROM range(1000000) AS t(value);"
+# -> [gpudb] registered gpu_sum / gpu_min / gpu_max  (backend=CUDA)
+# -> 499999500000
+```
+
+Requires DuckDB v1.5.x (C API v1.2.0). `LOAD` needs `-unsigned` because the
+extension is unsigned community code; `INSTALL gpudb FROM community`
+(no `-unsigned` needed) lights up after [community-extensions PR #1898](https://github.com/duckdb/community-extensions/pull/1898) merges.
+
+### Option B — build from source
+
 ```bash
 git clone https://github.com/singhpratech/duckdbgpumetaldbram.git
 cd duckdbgpumetaldbram
 
-# one-time: CUDA toolkit
-# wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-# sudo dpkg -i cuda-keyring_1.1-1_all.deb && sudo apt update
+# Linux (CUDA): one-time toolkit install if needed
 # sudo apt install -y cuda-toolkit-13-0
-# ~/.bashrc: export PATH=/usr/local/cuda/bin:$PATH
+# export PATH=/usr/local/cuda/bin:$PATH
 
-# build (auto-detects CUDA; falls back to CPU-only if absent)
+# macOS (Metal): brew install cmake
+
+# build (auto-detects CUDA on Linux, Metal on macOS, CPU-only otherwise).
+# Produces a loadable .duckdb_extension with metadata footer attached.
 ./scripts/build.sh
 
+# load + query via DuckDB CLI
+duckdb -unsigned -c "LOAD '$(pwd)/build-linux/src/extension/gpudb.linux_amd64.duckdb_extension'; \
+  SELECT gpu_sum(range::BIGINT) FROM range(1000000);"
+
+# OR run via the embedded SQL CLI shipped in this repo
+./build-linux/bin/gpudb-sql --sql "SELECT gpu_sum(range::BIGINT) FROM range(1000000);"
+```
+
+### Option C (TPC-H reproducibility)
+
+```bash
 # get TPC-H SF1 data (downloads DuckDB CLI to .tools/, ~1 GB lineitem)
 SF=1 ./scripts/gen_tpch.sh
 
-# run a SQL query against the GPU
-./build-linux/bin/gpudb-sql --sql \
-  "SELECT gpu_sum(v) FROM read_parquet('data/tpch_sf1/lineitem_orderkey.parquet');"
-# -> [gpudb] registered gpu_sum / gpu_min / gpu_max  (backend=CUDA)
+duckdb -unsigned -c "LOAD '$(pwd)/build-linux/src/extension/gpudb.linux_amd64.duckdb_extension'; \
+  SELECT gpu_sum(v) FROM read_parquet('data/tpch_sf1/lineitem_orderkey.parquet') t(v);"
 # -> 18005322964949
-```
-
-### macOS (Metal)
-```bash
-brew install cmake
-./scripts/build.sh
-./build-macos/bin/gpudb-sql --sql "SELECT gpu_sum(range::BIGINT) FROM range(100000000);"
-# -> backend=METAL
 ```
 
 ## What you get
@@ -139,8 +158,8 @@ xfail are now strict positive assertions (PR #22).
 
 ### In flight (v0.1.1)
 - [x] **All 4 known window/GROUP BY bugs fixed** (PR #18, #20, #21, #22 — see KNOWN_ISSUES.md)
-- [ ] DuckDB loadable extension metadata footer (required for `LOAD '...so'` from CLI)
-- [ ] Submission to [DuckDB Community Extensions](https://github.com/duckdb/community-extensions) → `INSTALL gpudb FROM community`
+- [x] **DuckDB loadable extension metadata footer** — works with `duckdb -unsigned -c "LOAD '/path/to/gpudb.linux_amd64.duckdb_extension'"`
+- [ ] [DuckDB Community Extensions PR #1898](https://github.com/duckdb/community-extensions/pull/1898) merged → `INSTALL gpudb FROM community`
 
 ### Roadmap (v0.2.0+)
 - [ ] Real Metal hash-join sort-merge (currently a CPU-fallback scaffold; CUDA hash-join is real)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,9 +43,41 @@ cmake "${CMAKE_ARGS[@]}"
 echo "==> build"
 cmake --build "$BUILD_DIR" -j
 
+# Append DuckDB extension metadata footer so the .duckdb_extension is
+# loadable from the duckdb CLI via `LOAD '<path>'`. Skipped if the build
+# didn't produce the .so (e.g. -DGPUDB_BUILD_EXT=OFF).
+LOADABLE_SO="$BUILD_DIR/src/extension/libgpudb_duckdb.so"
+LOADABLE_DYLIB="$BUILD_DIR/src/extension/libgpudb_duckdb.dylib"
+RAW_EXT=""
+if [ -f "$LOADABLE_SO" ];   then RAW_EXT="$LOADABLE_SO";   fi
+if [ -f "$LOADABLE_DYLIB" ]; then RAW_EXT="$LOADABLE_DYLIB"; fi
+
+if [ -n "$RAW_EXT" ] && [ -f "$(dirname "$0")/build_helpers/append_extension_metadata.py" ]; then
+    case "$OS" in
+        Linux*)  PLATFORM="linux_amd64" ;;
+        Darwin*) PLATFORM="osx_arm64"   ;;
+        *)       PLATFORM="" ;;
+    esac
+    DUCKDB_C_API_VERSION="${DUCKDB_C_API_VERSION:-v1.2.0}"
+    EXT_VERSION="${EXT_VERSION:-v0.1.1}"
+    OUT_FILE="$BUILD_DIR/src/extension/gpudb.${PLATFORM}.duckdb_extension"
+    if [ -n "$PLATFORM" ]; then
+        echo "==> packaging loadable extension ($PLATFORM, ABI=$DUCKDB_C_API_VERSION, ext=$EXT_VERSION)"
+        python3 "$(dirname "$0")/build_helpers/append_extension_metadata.py" \
+            --library-file "$RAW_EXT" \
+            --extension-name gpudb \
+            --duckdb-platform "$PLATFORM" \
+            --duckdb-version "$DUCKDB_C_API_VERSION" \
+            --extension-version "$EXT_VERSION" \
+            --out-file "$OUT_FILE" >/dev/null
+        echo "    -> $OUT_FILE"
+    fi
+fi
+
 echo
 echo "Built artifacts:"
-find "$BUILD_DIR" -maxdepth 4 -type f \( -name 'gpudb-bench' -o -name 'test_gpudb' -o -name 'libgpudb*' \) 2>/dev/null | sed 's/^/  /'
+find "$BUILD_DIR" -maxdepth 4 -type f \( -name 'gpudb-bench' -o -name 'test_gpudb' -o -name 'libgpudb*' -o -name 'gpudb*.duckdb_extension' \) 2>/dev/null | sed 's/^/  /'
 echo
 echo "Run tests:    ./$BUILD_DIR/test/test_gpudb"
 echo "Run bench:    ./$BUILD_DIR/bin/gpudb-bench --rows 10000000"
+echo "Load in CLI:  duckdb -unsigned -c \"LOAD '$(pwd)/$BUILD_DIR/src/extension/gpudb.<platform>.duckdb_extension'; SELECT gpu_sum(range::BIGINT) FROM range(1000);\""

--- a/scripts/build_helpers/append_extension_metadata.py
+++ b/scripts/build_helpers/append_extension_metadata.py
@@ -1,0 +1,121 @@
+import argparse
+import shutil
+
+def start_signature():
+    # This is needed so that Wasm binaries are valid
+    encoded_string = ''.encode('ascii')
+    # 0 for custom section
+    encoded_string += int(0).to_bytes(1, byteorder='big')
+    # 213 in hex = 531 in decimal, total lenght of what follows (1 + 16 + 2 + 8x32 + 256)
+    # [1(continuation) + 0010011(payload) = \x93 -> 147, 0(continuation) + 10(payload) = \x04 -> 4]
+    encoded_string += int(147).to_bytes(1, byteorder='big')
+    encoded_string += int(4).to_bytes(1, byteorder='big')
+    # 10 in hex = 16 in decimal, lenght of name, 1 byte
+    encoded_string += int(16).to_bytes(1, byteorder='big')
+    # the name of the WebAssembly custom section, 16 bytes
+    encoded_string += b'duckdb_signature'
+    # 1000 in hex, 512 in decimal
+    # [1(continuation) + 0000000(payload) = -> 128, 0(continuation) + 100(payload) -> 4],
+    encoded_string += int(128).to_bytes(1, byteorder='big')
+    encoded_string += int(4).to_bytes(1, byteorder='big')
+    return encoded_string
+
+def padded_byte_string(input):
+    encoded_string = input.encode('ascii')
+    encoded_string += b'\x00' * (32 - len(encoded_string))
+    return encoded_string
+
+def main():
+    arg_parser = argparse.ArgumentParser(description='Append extension metadata to loadable DuckDB extensions')
+
+    arg_parser.add_argument('-l','--library-file', type=str, help='Path to the raw shared library', required=True)
+    arg_parser.add_argument('-n', '--extension-name', type=str, help='Extension name to use', required=True)
+
+    arg_parser.add_argument('-o', '--out-file', type=str, help='Explicit path for the output file', default='')
+
+    # The platform
+    arg_parser.add_argument('-p', '--duckdb-platform', type=str, help='The DuckDB platform to encode')
+    arg_parser.add_argument('-pf', '--duckdb-platform-file', type=str, help='The file containing the DuckDB platform to encode')
+
+    arg_parser.add_argument('-dv', '--duckdb-version', type=str, help='The DuckDB version to encode, depending on the ABI type '
+                                                               'this encodes the duckdb version or the C API version', required=True)
+    arg_parser.add_argument('-ev', '--extension-version', type=str, help='The Extension version to encode')
+    arg_parser.add_argument('-evf', '--extension-version-file', type=str, help='The file containing the Extension version to encode')
+
+    arg_parser.add_argument('--abi-type', type=str, help='The ABI type to encode, set to C_STRUCT by default', default='C_STRUCT')
+
+    args = arg_parser.parse_args()
+
+    OUTPUT_FILE = args.out_file if args.out_file else args.extension_name + '.duckdb_extension'
+    OUTPUT_FILE_TMP = OUTPUT_FILE + ".tmp"
+
+    print("Creating extension binary:")
+
+    # Start with copying the library to a tmp file
+    print(f" - Input file: {args.library_file}")
+    print(f" - Output file: {OUTPUT_FILE}")
+    shutil.copyfile(args.library_file, OUTPUT_FILE_TMP)
+
+    # Handle the platform
+    PLATFORM = ""
+    if args.duckdb_platform:
+        PLATFORM = args.duckdb_platform
+    elif args.duckdb_platform_file:
+        try:
+            with open(args.duckdb_platform_file, 'r') as file:
+                PLATFORM = file.read().strip()
+        except Exception as e:
+            print(f"Failed to read platform from file {args.duckdb_platform_file}")
+            raise
+        if not PLATFORM:
+            raise Exception(f"Platform file passed to script is empty: {args.duckdb_platform_file}")
+    else:
+        raise Exception(f"Neither --duckdb-platform nor --duckdb-platform-file found, please specify the platform using either")
+
+    EXTENSION_VERSION = ""
+    if args.extension_version:
+        EXTENSION_VERSION = args.extension_version
+    elif args.extension_version_file:
+        try:
+            with open(args.extension_version_file, 'r') as file:
+                EXTENSION_VERSION = file.read().strip()
+        except Exception as e:
+            print(f"Failed to read extension version from file {args.extension_version_file}")
+            raise
+        if not EXTENSION_VERSION:
+            raise Exception(f"Extension version file passed to script is empty: {args.extension_version_file}")
+    else:
+        raise Exception(f"Neither --extension-version nor --extension-version-file found, please specify the extension version using either")
+
+
+
+    # Then append the metadata to the tmp file
+    print(f" - Metadata:")
+    with open(OUTPUT_FILE_TMP, 'ab') as file:
+        file.write(start_signature())
+        print(f"   - FIELD8 (unused)            = EMPTY")
+        file.write(padded_byte_string(""))
+        print(f"   - FIELD7 (unused)            = EMPTY")
+        file.write(padded_byte_string(""))
+        print(f"   - FIELD6 (unused)            = EMPTY")
+        file.write(padded_byte_string(""))
+        print(f"   - FIELD5 (abi_type)          = {args.abi_type}")
+        file.write(padded_byte_string(args.abi_type))
+        print(f"   - FIELD4 (extension_version) = {EXTENSION_VERSION}")
+        file.write(padded_byte_string(EXTENSION_VERSION))
+        print(f"   - FIELD3 (duckdb_version)    = {args.duckdb_version}")
+        file.write(padded_byte_string(args.duckdb_version))
+        print(f"   - FIELD2 (duckdb_platform)   = {PLATFORM}")
+        file.write(padded_byte_string(PLATFORM))
+        print(f"   - FIELD1 (header signature)  = 4 (special value to identify a duckdb extension)")
+        file.write(padded_byte_string("4"))
+
+        # Write some empty space for the signature
+        file.write(b"\x00" * 256)
+
+
+    # Finally we mv the tmp file to complete the process
+    shutil.move(OUTPUT_FILE_TMP, OUTPUT_FILE)
+
+if __name__ == '__main__':
+    main()

--- a/src/extension/duckdb_loadable.cpp
+++ b/src/extension/duckdb_loadable.cpp
@@ -1,17 +1,15 @@
 // duckdb_loadable.cpp — DuckDB C API loadable-extension entry point.
 //
-// Status: the entry point function compiles and is exported from the .so,
-// BUT direct `LOAD '...'` from the DuckDB CLI requires a metadata footer
-// (296 bytes: signature + length + 8x32-byte fields) appended to the .so.
-// That packaging is normally done by the official DuckDB extension-template
-// build pipeline. We ship the entry point + .duckdb_extension alias so it's
-// ready for that template; the next PR will add the footer-append step.
+// LOADABLE: yes. The .duckdb_extension file is produced by appending the
+// 528-byte metadata footer (scripts/build_helpers/append_extension_metadata.py)
+// to the libgpudb_duckdb.so. Resulting file works with `LOAD '/path/...'`
+// from the DuckDB CLI when launched with `-unsigned`.
 //
-// In the meantime, the working demo is the `gpudb-sql` CLI (benchmark/
-// sql_demo_main.cpp) which embeds DuckDB in-process and registers the
-// same functions via gpudb_ext::register_gpu_sum. The PUBLIC-facing way
-// (INSTALL FROM community + LOAD) lights up once the metadata footer is
-// added and we submit to https://github.com/duckdb/community-extensions.
+// DuckDB looks up two C symbols by extension-name convention:
+//   <name>_init_c_api   — registers the extension's functions
+//   <name>_version      — DuckDB-version compatibility stamp
+// The extension name in description.yml is `gpudb`, so the symbols are
+// gpudb_init_c_api and gpudb_version (NOT gpudb_duckdb_*).
 
 #include "gpu_sum_extension.hpp"
 #include "duckdb.h"
@@ -22,7 +20,7 @@
 extern "C" {
 
 // Standard C API extension entry. DuckDB calls this once on LOAD.
-DUCKDB_EXTENSION_API bool gpudb_duckdb_init_c_api(
+DUCKDB_EXTENSION_API bool gpudb_init_c_api(
         duckdb_extension_info info,
         const struct duckdb_extension_access *access) {
     if (!access || !access->get_database) {
@@ -56,7 +54,7 @@ DUCKDB_EXTENSION_API bool gpudb_duckdb_init_c_api(
 }
 
 // Required version stamp for unsigned-LOAD compatibility checks.
-DUCKDB_EXTENSION_API const char *gpudb_duckdb_version() {
+DUCKDB_EXTENSION_API const char *gpudb_version() {
     return duckdb_library_version();
 }
 


### PR DESCRIPTION
Fixes the launch-day blocker the user caught: `LOAD '/path/to/gpudb_duckdb.so'` was failing with 'metadata at the end of the file is invalid' because the duckdb extension footer was missing.

3 changes:
1. Renamed C entry symbols gpudb_duckdb_init_c_api/_version → gpudb_init_c_api/_version (DuckDB looks up by extension name from description.yml = 'gpudb').
2. Vendored append_extension_metadata.py from duckdb/extension-ci-tools — appends the 528-byte footer encoding ABI=v1.2.0, platform, ext-version.
3. scripts/build.sh now produces gpudb.{linux_amd64|osx_arm64}.duckdb_extension automatically.

Verified end-to-end on RTX 4090 — gpu_sum, gpu_min, gpu_max, GROUP BY, OVER () all return correct values via stock duckdb CLI.