### PR TITLE
fix(ext): make .duckdb_extension loadable via stock DuckDB CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,31 @@ brew install cmake
 # -> backend=METAL
 ```
 
+### Loading the extension into stock DuckDB CLI
+
+The build produces a real `.duckdb_extension` file with the proper metadata
+footer — load it from any DuckDB CLI ≥ v1.5 that allows unsigned extensions:
+
+```bash
+# macOS / Apple Silicon (Metal backend)
+duckdb -unsigned -c "
+  LOAD '$(pwd)/build-macos/src/extension/gpudb_duckdb.duckdb_extension';
+  SELECT gpu_sum(value::BIGINT) FROM range(1000000) AS t(value);
+"
+# -> [gpudb] registered gpu_sum / gpu_min / gpu_max  (backend=Metal)
+# -> 499999500000
+
+# Linux (CUDA backend if a GPU is available, else CPU fallback)
+duckdb -unsigned -c "
+  LOAD '$(pwd)/build-linux/src/extension/gpudb_duckdb.duckdb_extension';
+  SELECT gpu_sum(value::BIGINT) FROM range(1000000) AS t(value);
+"
+```
+
+Inside an interactive DuckDB session: `SET allow_unsigned_extensions=true;`
+once, then `LOAD '...';`. Pre-built artifacts are attached to the
+[GitHub release](https://github.com/singhpratech/duckdbgpumetaldbram/releases/latest).
+
 ## What you get
 
 After build, five CLI tools:
@@ -139,7 +164,7 @@ xfail are now strict positive assertions (PR #22).
 
 ### In flight (v0.1.1)
 - [x] **All 4 known window/GROUP BY bugs fixed** (PR #18, #20, #21, #22 — see KNOWN_ISSUES.md)
-- [ ] DuckDB loadable extension metadata footer (required for `LOAD '...so'` from CLI)
+- [x] **DuckDB loadable extension metadata footer** — `.duckdb_extension` files are now loadable via stock `duckdb -unsigned -c "LOAD '...';"`
 - [ ] Submission to [DuckDB Community Extensions](https://github.com/duckdb/community-extensions) → `INSTALL gpudb FROM community`
 
 ### Roadmap (v0.2.0+)

--- a/scripts/append_extension_footer.py
+++ b/scripts/append_extension_footer.py
@@ -1,65 +1,65 @@
 #!/usr/bin/env python3
 """
-append_extension_footer.py — best-effort attempt to append a DuckDB
-extension metadata footer.
+append_extension_footer.py — append the DuckDB extension metadata footer
+so the .so/.dylib loads via DuckDB's `LOAD '<path>.duckdb_extension'`.
 
-⚠️ STATUS (2026-05-09): the manual format below is REJECTED by DuckDB
-1.4.x ("The metadata at the end of the file is invalid"). The exact
-field semantics have shifted in recent DuckDB versions and reverse-
-engineering them is fragile.
+Verified against the stock DuckDB CLI v1.5.2 on osx_arm64 — produces a
+file that loads end-to-end and runs `gpu_sum / gpu_min / gpu_max`.
 
-THE OFFICIAL PATHS THAT WORK:
-  1. Submit to https://github.com/duckdb/community-extensions — their
-     CI builds .duckdb_extension files for all platforms with the right
-     metadata + signing. After merge: INSTALL gpudb FROM community;
-  2. Clone https://github.com/duckdb/extension-template, adapt our build
-     to use its CMake macros which generate the footer correctly.
-     Then: SET allow_unsigned_extensions=true at startup; LOAD '...';
-
-This script is kept as a reference for the FORMAT we attempted, in case
-someone wants to dig further or DuckDB documents the format publicly.
-
-NOT FOR PRODUCTION USE.
-
-Usage:
+Usage (C API extension — what we build):
     python3 scripts/append_extension_footer.py \\
-        --in build-linux/src/extension/libgpudb_duckdb.so \\
-        --out build-linux/src/extension/gpudb.duckdb_extension \\
-        --name gpudb \\
-        --extension-version 0.1.0 \\
-        --duckdb-version 1.4.0 \\
-        --platform linux_amd64
+        --in build-macos/src/extension/libgpudb_duckdb.dylib \\
+        --out build-macos/src/extension/gpudb_duckdb.duckdb_extension \\
+        --extension-version v0.1.1 \\
+        --c-api-version v1.2.0 \\
+        --platform osx_arm64
 
-Format reference (DuckDB extension format v1):
-    The footer appended to the .so consists of:
-      - 256 bytes signature  (zeros for unsigned extensions)
-      - 8 fields x 32 bytes  (256 bytes of metadata)
-    Total appended: 512 bytes.
+Then load (DuckDB CLI must be invoked with -unsigned for community-built
+extensions, or the user can SET allow_unsigned_extensions=true):
+    duckdb -unsigned -c "LOAD '/abs/path/gpudb_duckdb.duckdb_extension'; \\
+                         SELECT gpu_sum(range::BIGINT) FROM range(10);"
 
-    Field layout (each field is exactly 32 bytes, NUL-padded):
-      Field 0: format version magic (literal "4")
-      Field 1: platform (e.g. "linux_amd64", "osx_arm64")
-      Field 2: duckdb version (e.g. "v1.4.0")
-      Field 3: extension version (e.g. "v0.1.0")
-      Field 4: signature mode (zeros for unsigned)
-      Field 5: extension ABI type ("C_STRUCTS" for C API extensions)
-      Field 6: reserved
-      Field 7: extension name (e.g. "gpudb")
+Footer format (reverse-engineered against DuckDB v1.5.2; matches the
+behavior of duckdb/main/extension/extension_load.cpp::ParseExtensionMetaData):
 
-NOTE: The exact field semantics have shifted between DuckDB versions.
-This script reflects DuckDB 1.4.x. If LOAD fails with a metadata error
-on a newer DuckDB, switch to the official extension-template build.
+    Last 512 bytes of the file are the footer:
+      - 256 bytes  metadata block: 8 fields x 32 bytes, NUL-padded ASCII
+          Field 0:  zeros (reserved)
+          Field 1:  zeros (reserved)
+          Field 2:  zeros (reserved)
+          Field 3:  ABI type
+                    "C_STRUCT" -> entrypoint <basename>_init_c_api  (what we use)
+                    "C_STRUCT_UNSTABLE" -> same entrypoint, no version check
+                    "CPP" -> entrypoint <basename>_duckdb_cpp_init  (DuckDB-internal)
+                    empty -> CPP
+          Field 4:  extension version  (informational; e.g. "v0.1.1")
+          Field 5:  semantics depends on Field 3:
+                    C_STRUCT -> DuckDB C API version (must satisfy the loader's
+                                acceptable range, currently "v1.x.y" with x<=2)
+                    CPP      -> DuckDB version (must equal the loader's version)
+          Field 6:  platform           ("osx_arm64", "linux_amd64", ...)
+          Field 7:  format magic       ("4" for the current footer format)
+      - 256 bytes  signature block: zeros for unsigned extensions
+
+The 512-byte footer is appended directly to the .so/.dylib body — no
+intermediate magic, no padding, no separator.
+
+The basename used to derive the entrypoint name is the .duckdb_extension
+file's basename (without the .duckdb_extension suffix). Our shared lib
+exports `gpudb_duckdb_init_c_api`, so the file MUST be named
+`gpudb_duckdb.duckdb_extension`.
 """
 import argparse
 import shutil
-import struct
 import sys
 from pathlib import Path
 
 FIELD_SIZE = 32
 NUM_FIELDS = 8
+METADATA_SIZE = FIELD_SIZE * NUM_FIELDS   # 256
 SIGNATURE_SIZE = 256
-FORMAT_VERSION = b"4"
+FOOTER_SIZE = METADATA_SIZE + SIGNATURE_SIZE   # 512
+FORMAT_VERSION_MAGIC = b"4"
 
 
 def pad_field(value: bytes) -> bytes:
@@ -68,17 +68,17 @@ def pad_field(value: bytes) -> bytes:
     return value + b"\0" * (FIELD_SIZE - len(value))
 
 
-def build_metadata(name: str, ext_version: str, duckdb_version: str,
-                   platform: str, abi_type: str = "C_STRUCTS") -> bytes:
+def build_metadata(ext_version: str, version_field5: str,
+                   platform: str, abi_type: str = "C_STRUCT") -> bytes:
     fields = [
-        FORMAT_VERSION,
-        platform.encode("ascii"),
-        duckdb_version.encode("ascii"),
-        ext_version.encode("ascii"),
-        b"\0",                       # signature mode = unsigned
-        abi_type.encode("ascii"),
-        b"\0",                       # reserved
-        name.encode("ascii"),
+        b"\0",                                   # 0: reserved
+        b"\0",                                   # 1: reserved
+        b"\0",                                   # 2: reserved
+        abi_type.encode("ascii"),                # 3: ABI type
+        ext_version.encode("ascii"),             # 4: extension version
+        version_field5.encode("ascii"),          # 5: C API version (C_STRUCT) or DuckDB version (CPP)
+        platform.encode("ascii"),                # 6: platform
+        FORMAT_VERSION_MAGIC,                    # 7: format magic
     ]
     if len(fields) != NUM_FIELDS:
         raise RuntimeError("internal: wrong field count")
@@ -87,13 +87,16 @@ def build_metadata(name: str, ext_version: str, duckdb_version: str,
 
 def main() -> int:
     p = argparse.ArgumentParser()
-    p.add_argument("--in", dest="src", required=True, help="input .so")
-    p.add_argument("--out", dest="dst", required=True, help="output .duckdb_extension")
-    p.add_argument("--name", required=True, help="extension name (e.g. gpudb)")
-    p.add_argument("--extension-version", default="v0.1.0")
-    p.add_argument("--duckdb-version", default="v1.4.0")
-    p.add_argument("--platform", default="linux_amd64")
-    p.add_argument("--abi-type", default="C_STRUCTS")
+    p.add_argument("--in", dest="src", required=True, help="input .so/.dylib")
+    p.add_argument("--out", dest="dst", required=True,
+                   help="output path; basename (minus .duckdb_extension) determines entrypoint name")
+    p.add_argument("--extension-version", required=True, help="e.g. v0.1.1")
+    p.add_argument("--c-api-version", help="DuckDB C API version, e.g. v1.2.0 (used when --abi-type=C_STRUCT)")
+    p.add_argument("--duckdb-version", help="DuckDB version, e.g. v1.5.2 (used when --abi-type=CPP)")
+    p.add_argument("--platform", required=True, help="osx_arm64 | osx_amd64 | linux_amd64 | linux_arm64")
+    p.add_argument("--abi-type", default="C_STRUCT",
+                   choices=["C_STRUCT", "C_STRUCT_UNSTABLE", "CPP"],
+                   help="default C_STRUCT (matches gpudb_duckdb_init_c_api entrypoint)")
     args = p.parse_args()
 
     src = Path(args.src)
@@ -102,17 +105,24 @@ def main() -> int:
         print(f"input not found: {src}", file=sys.stderr)
         return 1
 
+    if args.abi_type in ("C_STRUCT", "C_STRUCT_UNSTABLE"):
+        version_field5 = args.c_api_version or "v1.2.0"
+    else:
+        version_field5 = args.duckdb_version
+        if not version_field5:
+            print("--duckdb-version is required when --abi-type=CPP", file=sys.stderr)
+            return 1
+
     dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dst)
 
     metadata = build_metadata(
-        name=args.name,
         ext_version=args.extension_version,
-        duckdb_version=args.duckdb_version,
+        version_field5=version_field5,
         platform=args.platform,
         abi_type=args.abi_type,
     )
-    if len(metadata) != FIELD_SIZE * NUM_FIELDS:
+    if len(metadata) != METADATA_SIZE:
         print(f"internal: bad metadata length {len(metadata)}", file=sys.stderr)
         return 1
 
@@ -122,10 +132,10 @@ def main() -> int:
         f.write(metadata)
         f.write(signature)
 
-    print(f"wrote {dst}  ({src.stat().st_size} + {len(metadata)+len(signature)} footer = "
+    print(f"wrote {dst}  ({src.stat().st_size} + {FOOTER_SIZE} footer = "
           f"{dst.stat().st_size} bytes)")
-    print(f"  name={args.name}  ext_version={args.extension_version}  "
-          f"duckdb_version={args.duckdb_version}  platform={args.platform}")
+    print(f"  abi={args.abi_type}  ext_version={args.extension_version}  "
+          f"field5={version_field5}  platform={args.platform}")
     print()
     print("Test with:")
     print(f"  duckdb -unsigned -c \"LOAD '{dst.resolve()}'; "

--- a/src/extension/CMakeLists.txt
+++ b/src/extension/CMakeLists.txt
@@ -37,10 +37,49 @@ set_target_properties(gpudb_duckdb PROPERTIES
     INSTALL_RPATH "${DUCKDB_LIBS_DIR}"
 )
 
-# Also produce the same .so under the .duckdb_extension suffix DuckDB recognizes,
-# so users can do LOAD 'libgpudb_duckdb.duckdb_extension' or just LOAD '...so'.
+# Produce a real, LOADABLE .duckdb_extension by appending DuckDB's required
+# 512-byte metadata footer to the .so. Without this, DuckDB CLI rejects the
+# file as "The metadata at the end of the file is invalid".
+#
+# The basename `gpudb_duckdb.duckdb_extension` is load-bearing: DuckDB
+# derives the entrypoint name from it (basename + "_init_c_api" for the
+# C_STRUCT ABI, which is what we export as gpudb_duckdb_init_c_api).
+
+# Detect platform string DuckDB uses.
+if(APPLE)
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+        set(DUCKDB_PLATFORM "osx_arm64")
+    else()
+        set(DUCKDB_PLATFORM "osx_amd64")
+    endif()
+elseif(UNIX)
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+        set(DUCKDB_PLATFORM "linux_arm64")
+    else()
+        set(DUCKDB_PLATFORM "linux_amd64")
+    endif()
+else()
+    set(DUCKDB_PLATFORM "unknown")
+endif()
+
+# Make extension version "v<PROJECT_VERSION>" (e.g. v0.1.1).
+set(GPUDB_EXT_VERSION "v${PROJECT_VERSION}")
+# DuckDB C API version we target — must satisfy the loader's accepted range
+# (currently "v1.x.y" with x<=2 in DuckDB v1.5.x).
+set(GPUDB_DUCKDB_C_API_VERSION "v1.2.0")
+
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(NOT Python3_Interpreter_FOUND)
+    set(Python3_EXECUTABLE python3)
+endif()
+
 add_custom_command(TARGET gpudb_duckdb POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-        $<TARGET_FILE:gpudb_duckdb>
-        $<TARGET_FILE_DIR:gpudb_duckdb>/gpudb_duckdb.duckdb_extension
-    COMMENT "Aliasing .so as .duckdb_extension")
+    COMMAND ${Python3_EXECUTABLE}
+        ${CMAKE_SOURCE_DIR}/scripts/append_extension_footer.py
+        --in $<TARGET_FILE:gpudb_duckdb>
+        --out $<TARGET_FILE_DIR:gpudb_duckdb>/gpudb_duckdb.duckdb_extension
+        --extension-version ${GPUDB_EXT_VERSION}
+        --c-api-version ${GPUDB_DUCKDB_C_API_VERSION}
+        --platform ${DUCKDB_PLATFORM}
+        --abi-type C_STRUCT
+    COMMENT "Appending DuckDB extension footer (loadable via duckdb -unsigned -c \"LOAD '...';\")")


### PR DESCRIPTION
## Summary
The .duckdb_extension we shipped in v0.1.1 was just a renamed .dylib — DuckDB CLI rejected it ("metadata at the end of the file is invalid"). This PR makes it a real, loadable extension by appending the proper 512-byte metadata footer.

## Verified end-to-end on Apple M4 Max with stock DuckDB CLI v1.5.2

\`\`\`bash
duckdb -unsigned -c "LOAD '\$(pwd)/build-macos/src/extension/gpudb_duckdb.duckdb_extension';
                     SELECT gpu_sum(range::BIGINT) FROM range(1000000);"
\`\`\`

Output:
\`\`\`
[gpudb] registered gpu_sum / gpu_min / gpu_max  (backend=Metal)
499999500000
\`\`\`

All three SQL surfaces work through LOAD:
- \`gpu_sum(x)\` — scalar
- \`gpu_sum(x) OVER ()\` — unbounded frame
- \`gpu_sum(x) OVER (PARTITION BY g ORDER BY k)\` — partitioned running sum

## Footer format (reverse-engineered)
Last 512 bytes of file:
- 256 B metadata = 8 × 32 B NUL-padded ASCII fields
  - Fields 0-2: zeros (reserved)
  - Field 3: ABI type — \`C_STRUCT\` (our entrypoint is \`gpudb_duckdb_init_c_api\`)
  - Field 4: extension version (\`v0.1.1\`)
  - Field 5: DuckDB C API version target (\`v1.2.0\` — must satisfy loader's accepted range)
  - Field 6: platform (\`osx_arm64\`)
  - Field 7: format magic (\`4\`)
- 256 B signature = zeros (unsigned extension; pair with \`-unsigned\` CLI flag)

## What changed
- \`scripts/append_extension_footer.py\`: corrected field order + added \`--c-api-version\` arg + documented the format
- \`src/extension/CMakeLists.txt\`: POST_BUILD step auto-runs the footer-append, so CMake builds always produce a loadable .duckdb_extension
- \`README.md\`: added LOAD command for both macOS and Linux + updated v0.1.1 roadmap (footer is no longer in-flight)

## Test plan
- [x] \`cmake --build build-macos -j\` produces gpudb_duckdb.duckdb_extension with footer
- [x] \`duckdb -unsigned -c "LOAD '...'; SELECT gpu_sum(...);"\` returns correct answer
- [x] Window OVER () via stock CLI: correct
- [x] Window PARTITION BY ORDER BY via stock CLI: correct
- [x] Backend confirmed as Metal at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)