### PR TITLE
build(cmake): wire upstream footer helper into POST_BUILD

### DIFF
--- a/src/extension/CMakeLists.txt
+++ b/src/extension/CMakeLists.txt
@@ -37,10 +37,51 @@ set_target_properties(gpudb_duckdb PROPERTIES
     INSTALL_RPATH "${DUCKDB_LIBS_DIR}"
 )
 
-# Also produce the same .so under the .duckdb_extension suffix DuckDB recognizes,
-# so users can do LOAD 'libgpudb_duckdb.duckdb_extension' or just LOAD '...so'.
-add_custom_command(TARGET gpudb_duckdb POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-        $<TARGET_FILE:gpudb_duckdb>
-        $<TARGET_FILE_DIR:gpudb_duckdb>/gpudb_duckdb.duckdb_extension
-    COMMENT "Aliasing .so as .duckdb_extension")
+# Produce a real, LOADABLE .duckdb_extension by appending DuckDB's required
+# metadata footer to the .so. Without this, DuckDB CLI rejects the file as
+# "The metadata at the end of the file is invalid".
+#
+# Implementation: call scripts/build_helpers/append_extension_metadata.py
+# (the upstream DuckDB extension-template helper, vendored at PR #36) so
+# both `cmake --build` and `./scripts/build.sh` produce the same loadable
+# artifact at gpudb.<platform>.duckdb_extension.
+
+if(APPLE)
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+        set(DUCKDB_PLATFORM "osx_arm64")
+    else()
+        set(DUCKDB_PLATFORM "osx_amd64")
+    endif()
+elseif(UNIX)
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
+        set(DUCKDB_PLATFORM "linux_arm64")
+    else()
+        set(DUCKDB_PLATFORM "linux_amd64")
+    endif()
+else()
+    set(DUCKDB_PLATFORM "unknown")
+endif()
+
+set(GPUDB_EXT_VERSION "v${PROJECT_VERSION}")
+set(GPUDB_DUCKDB_C_API_VERSION "v1.2.0")
+
+find_package(Python3 COMPONENTS Interpreter QUIET)
+if(NOT Python3_Interpreter_FOUND)
+    set(Python3_EXECUTABLE python3)
+endif()
+
+set(GPUDB_HELPER "${CMAKE_SOURCE_DIR}/scripts/build_helpers/append_extension_metadata.py")
+set(GPUDB_LOADABLE_OUT "$<TARGET_FILE_DIR:gpudb_duckdb>/gpudb.${DUCKDB_PLATFORM}.duckdb_extension")
+
+if(EXISTS "${GPUDB_HELPER}" AND NOT "${DUCKDB_PLATFORM}" STREQUAL "unknown")
+    add_custom_command(TARGET gpudb_duckdb POST_BUILD
+        COMMAND ${Python3_EXECUTABLE} ${GPUDB_HELPER}
+            --library-file       $<TARGET_FILE:gpudb_duckdb>
+            --extension-name     gpudb
+            --duckdb-platform    ${DUCKDB_PLATFORM}
+            --duckdb-version     ${GPUDB_DUCKDB_C_API_VERSION}
+            --extension-version  ${GPUDB_EXT_VERSION}
+            --abi-type           C_STRUCT
+            --out-file           ${GPUDB_LOADABLE_OUT}
+        COMMENT "Packaging gpudb.${DUCKDB_PLATFORM}.duckdb_extension (loadable via duckdb -unsigned -c \"LOAD '...';\")")
+endif()


### PR DESCRIPTION
## Summary
PR #36 vendored the upstream DuckDB extension-template's append_extension_metadata.py helper and wired it into \`scripts/build.sh\`. But running \`cmake --build\` directly (without build.sh) still produced an unloadable .duckdb_extension because the CMake POST_BUILD step was just doing a file rename.

This PR makes the CMake POST_BUILD step run the same upstream helper, so both build paths produce the same loadable artifact.

## Verified on Apple M4 Max (Metal)

\`\`\`bash
rm -rf build-macos && cmake -S . -B build-macos -DGPUDB_BUILD_EXT=ON
cmake --build build-macos -j
duckdb -unsigned -c "LOAD '\$(pwd)/build-macos/src/extension/gpudb.osx_arm64.duckdb_extension';
                     SELECT gpu_sum(value::BIGINT) FROM range(1000000) AS t(value);"
\`\`\`

Output:
\`\`\`
[gpudb] registered gpu_sum / gpu_min / gpu_max  (backend=Metal)
499999500000
\`\`\`

## What changed
- \`src/extension/CMakeLists.txt\` POST_BUILD: replaced the file-rename with a python invocation of the upstream helper
- Auto-detects platform string (osx_arm64 / osx_amd64 / linux_amd64 / linux_arm64) from CMAKE_HOST_SYSTEM_PROCESSOR
- Output filename matches what \`scripts/build.sh\` produces: \`gpudb.<platform>.duckdb_extension\`
- Picks up extension version from \`PROJECT_VERSION\` (currently 0.1.1)

## Test plan
- [x] \`cmake --build build-macos -j\` produces gpudb.osx_arm64.duckdb_extension
- [x] \`duckdb -unsigned -c "LOAD '...'; SELECT gpu_sum(...);"\` returns correct answer
- [x] Backend at runtime = Metal

🤖 Generated with [Claude Code](https://claude.com/claude-code)