### PR TITLE
docs: bump v0.1.1 → v0.1.2 in README + community description.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The honest finding: for **streaming SUM on cold data**, CPU wins (DDR5 already s
 
 ### Option A — load the prebuilt extension into DuckDB CLI
 
-Download the platform binary from the [v0.1.1 release](https://github.com/singhpratech/duckdbgpumetaldbram/releases/tag/v0.1.1), then:
+Download the platform binary from the [v0.1.2 release](https://github.com/singhpratech/duckdbgpumetaldbram/releases/tag/v0.1.2), then:
 
 ```bash
 # Linux (RTX/CUDA)
@@ -156,10 +156,12 @@ xfail are now strict positive assertions (PR #22).
 - [x] DuckDB extension: gpu_sum / gpu_min / gpu_max with NULL handling + GPUDB_FORCE_BACKEND env var
 - [x] CLI: gpudb-bench, gpudb-groupby-bench, gpudb-window-bench, gpudb-hashjoin-bench, gpudb-sql
 
-### In flight (v0.1.1)
+### Shipped in v0.1.2
 - [x] **All 4 known window/GROUP BY bugs fixed** (PR #18, #20, #21, #22 — see KNOWN_ISSUES.md)
-- [x] **DuckDB loadable extension metadata footer** — works with `duckdb -unsigned -c "LOAD '/path/to/gpudb.linux_amd64.duckdb_extension'"`
-- [ ] [DuckDB Community Extensions PR #1898](https://github.com/duckdb/community-extensions/pull/1898) merged → `INSTALL gpudb FROM community`
+- [x] **DuckDB loadable extension actually loads** — `duckdb -unsigned -c "LOAD '/path/to/gpudb.<platform>.duckdb_extension'"` works on Linux (CUDA) and macOS (Metal). Prebuilt binaries attached to [v0.1.2 release](https://github.com/singhpratech/duckdbgpumetaldbram/releases/tag/v0.1.2).
+
+### In flight (v0.1.3)
+- [ ] [DuckDB Community Extensions PR #1898](https://github.com/duckdb/community-extensions/pull/1898) merged → `INSTALL gpudb FROM community` (no `-unsigned` flag needed)
 
 ### Roadmap (v0.2.0+)
 - [ ] Real Metal hash-join sort-merge (currently a CPU-fallback scaffold; CUDA hash-join is real)

--- a/docs/COMMUNITY_EXTENSION_DESCRIPTION.yml
+++ b/docs/COMMUNITY_EXTENSION_DESCRIPTION.yml
@@ -14,7 +14,7 @@ extension:
     Backends: NVIDIA CUDA (Linux/Windows) and Apple Metal (macOS).
     First-class Apple Silicon support — no other GPU SQL engine ships
     Metal numbers.
-  version: 0.1.1
+  version: 0.1.2
   language: C++
   build: cmake
   license: Apache-2.0
@@ -24,7 +24,7 @@ extension:
 
 repo:
   github: singhpratech/duckdbgpumetaldbram
-  ref: v0.1.1
+  ref: 87e70adcee913d721e8d029a6d5b99911799405f  # v0.1.2
 
 docs:
   hello_world: |


### PR DESCRIPTION
v0.1.2 ships the loadable extension fix. Updates README install URLs and source-of-truth description.yml to match the fork's PR #1898.