### PR TITLE
feat(ext): empty/all-NULL aggregates return SQL NULL, not 0

### DIFF
--- a/.sync/duckdbgpumetaldbram.md
+++ b/.sync/duckdbgpumetaldbram.md
@@ -1,6 +1,6 @@
 # duckdbgpumetaldbram
 - branch: main
-- working on: shipping v0.1.0: bumping CMake version, tagging, GitHub release
+- working on: Implementing v0.2.0 item 1: NULL semantics fix on feat/ext-null-semantics (empty/all-NULL aggregates -> SQL NULL)
 - status: in_progress
 - blocked on: nothing
-- last update: 2026-05-10T00:41:14Z
+- last update: 2026-07-19T05:35:49Z

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -14,14 +14,9 @@ None.
 
 ## Documented intentional divergences from SQL spec
 
-These are **not** bugs — explicit design choices for v0.1.0. Will be revisited in v0.2.0.
-
-| Behavior | Native DuckDB | Our extension |
-|---|---|---|
-| `MIN/MAX/SUM(empty input)` | NULL | 0 |
-| `MIN/MAX/SUM(all NULLs)` | NULL | 0 |
-
-Returning `0` is the C++ aggregator's natural behavior; properly returning SQL `NULL` requires using `duckdb_validity_set_row_invalid` on the output vector. SQL queries that test for `IS NULL` on a fully-empty/all-NULL aggregate result currently get `false`.
+None. The `MIN/MAX/SUM` empty-input / all-NULL → `0` divergence was resolved in
+`v0.2.0` (see the resolved table below); those aggregates now return SQL `NULL`,
+matching native DuckDB, and `IS NULL` on such a result is now `true`.
 
 ### Hardware-imposed limits (won't fix)
 
@@ -31,10 +26,12 @@ Returning `0` is the C++ aggregator's natural behavior; properly returning SQL `
 
 ---
 
-## Resolved issues (fixed in `v0.1.0`)
+## Resolved issues
 
 | Issue | Fixed in |
 |---|---|
+| `MIN/MAX/SUM(empty input)` returned `0` instead of SQL `NULL` | v0.2.0 (pending PR) — finalize marks the output row invalid via `duckdb_vector_ensure_validity_writable` + `duckdb_validity_set_row_invalid` when a state accumulated zero non-NULL values; `set_special_handling` registered so DuckDB does not short-circuit our NULL handling |
+| `MIN/MAX/SUM(all NULLs)` returned `0` instead of SQL `NULL` | v0.2.0 (pending PR) — same fix; empty state buffer (all input rows NULL) now yields SQL `NULL`, including per-group in GROUP BY (single, batched-GPU, and per-state paths) |
 | `gpu_sum(v) OVER ()` unbounded-frame SIGSEGV | PR #22 (BufferPool POD state + magic-word probe defends update() against `WindowConstantAggregator`'s CONSTANT_VECTOR state) |
 | `gpu_sum(v) OVER (PARTITION BY g ORDER BY k)` non-determinism / wrong values | PR #18 (combine() copy-not-move) + PR #22 (POD state) |
 | `gpu_sum(v) OVER (ORDER BY k)` running-sum chunk-boundary state loss | PR #18 |

--- a/src/extension/gpu_sum_extension.cpp
+++ b/src/extension/gpu_sum_extension.cpp
@@ -467,27 +467,42 @@ void finalize(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
               duckdb_vector result, idx_t count, idx_t offset) {
     std::int64_t* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(result));
 
+    // SUM over zero non-NULL values (empty input, or a group whose every row
+    // was NULL) is SQL NULL, not 0. A state's buffer is empty in exactly that
+    // case (update() skips NULL rows). Make the output validity mask writable
+    // once up front; the paths below mark the relevant rows invalid.
+    duckdb_vector_ensure_validity_writable(result);
+    uint64_t* validity = duckdb_vector_get_validity(result);
+
     // ---- Single-state fast path: ungrouped SELECT gpu_sum(x) FROM tbl,
     //      and per-row finalize calls from window functions without
     //      PARTITION BY. ----
     if (count == 1) {
         const std::uint64_t bid = probe_buf_id(source[0]);
-        if (bid == 0) { out[offset] = 0; return; }
-        auto vals = buffer_pool().snapshot(bid);
-        out[offset] = safe_sum_i64(vals.data(), vals.size());
+        auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+        if (vals.empty()) {
+            out[offset] = 0;
+            duckdb_validity_set_row_invalid(validity, offset);
+        } else {
+            out[offset] = safe_sum_i64(vals.data(), vals.size());
+        }
         return;
     }
 
     // ---- Constant-state finalize: WindowConstantAggregator passes a
     //      CONSTANT_VECTOR for source. Only source[0] is real; broadcast. ----
     if (!finalize_is_per_state(source, count)) {
-        std::int64_t v = 0;
         const std::uint64_t bid = probe_buf_id(source[0]);
-        if (bid != 0) {
-            auto vals = buffer_pool().snapshot(bid);
-            v = safe_sum_i64(vals.data(), vals.size());
+        auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+        if (vals.empty()) {
+            for (idx_t i = 0; i < count; ++i) {
+                out[offset + i] = 0;
+                duckdb_validity_set_row_invalid(validity, offset + i);
+            }
+        } else {
+            std::int64_t v = safe_sum_i64(vals.data(), vals.size());
+            for (idx_t i = 0; i < count; ++i) out[offset + i] = v;
         }
-        for (idx_t i = 0; i < count; ++i) out[offset + i] = v;
         return;
     }
 
@@ -527,8 +542,13 @@ void finalize(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
                 auto r = gb->groupby_sum_i64(flat_keys.data(), flat_values.data(),
                                               flat_keys.size(), count);
 
-                // Default outputs to 0 for empty groups; then fill those that had data.
-                for (idx_t i = 0; i < count; ++i) out[offset + i] = 0;
+                // A group with zero non-NULL values (empty state buffer) is
+                // SQL NULL; the rest are filled from the kernel result below.
+                for (idx_t i = 0; i < count; ++i) {
+                    out[offset + i] = 0;
+                    if (snaps[i].empty())
+                        duckdb_validity_set_row_invalid(validity, offset + i);
+                }
                 for (std::size_t i = 0; i < r.keys.size(); ++i) {
                     const std::int64_t k = r.keys[i];
                     if (k >= 0 && static_cast<idx_t>(k) < count)
@@ -536,7 +556,11 @@ void finalize(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
                 }
                 used_batched = true;
             } else {
-                for (idx_t i = 0; i < count; ++i) out[offset + i] = 0;
+                // Every group was empty (all-NULL / empty input) → all NULL.
+                for (idx_t i = 0; i < count; ++i) {
+                    out[offset + i] = 0;
+                    duckdb_validity_set_row_invalid(validity, offset + i);
+                }
                 used_batched = true;
             }
         } catch (const std::exception&) {
@@ -578,9 +602,13 @@ void finalize(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
         // also still benefit when individual partition buffers are big.
         for (idx_t i = 0; i < count; ++i) {
             const std::uint64_t bid = probe_buf_id(source[i]);
-            if (bid == 0) { out[offset + i] = 0; continue; }
-            auto vals = buffer_pool().snapshot(bid);
-            out[offset + i] = safe_sum_i64(vals.data(), vals.size());
+            auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+            if (vals.empty()) {
+                out[offset + i] = 0;
+                duckdb_validity_set_row_invalid(validity, offset + i);
+            } else {
+                out[offset + i] = safe_sum_i64(vals.data(), vals.size());
+            }
         }
     }
 }
@@ -593,56 +621,86 @@ void finalize(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
 void finalize_min(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
                   duckdb_vector result, idx_t count, idx_t offset) {
     std::int64_t* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(result));
+    // MIN over zero non-NULL values is SQL NULL, not 0 (see finalize()).
+    duckdb_vector_ensure_validity_writable(result);
+    uint64_t* validity = duckdb_vector_get_validity(result);
     if (count == 1) {
         const std::uint64_t bid = probe_buf_id(source[0]);
-        if (bid == 0) { out[offset] = 0; return; }
-        auto vals = buffer_pool().snapshot(bid);
-        out[offset] = safe_min_i64(vals.data(), vals.size());
+        auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+        if (vals.empty()) {
+            out[offset] = 0;
+            duckdb_validity_set_row_invalid(validity, offset);
+        } else {
+            out[offset] = safe_min_i64(vals.data(), vals.size());
+        }
         return;
     }
     if (!finalize_is_per_state(source, count)) {
-        std::int64_t v = 0;
         const std::uint64_t bid = probe_buf_id(source[0]);
-        if (bid != 0) {
-            auto vals = buffer_pool().snapshot(bid);
-            v = safe_min_i64(vals.data(), vals.size());
+        auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+        if (vals.empty()) {
+            for (idx_t i = 0; i < count; ++i) {
+                out[offset + i] = 0;
+                duckdb_validity_set_row_invalid(validity, offset + i);
+            }
+        } else {
+            std::int64_t v = safe_min_i64(vals.data(), vals.size());
+            for (idx_t i = 0; i < count; ++i) out[offset + i] = v;
         }
-        for (idx_t i = 0; i < count; ++i) out[offset + i] = v;
         return;
     }
     for (idx_t i = 0; i < count; ++i) {
         const std::uint64_t bid = probe_buf_id(source[i]);
-        if (bid == 0) { out[offset + i] = 0; continue; }
-        auto vals = buffer_pool().snapshot(bid);
-        out[offset + i] = safe_min_i64(vals.data(), vals.size());
+        auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+        if (vals.empty()) {
+            out[offset + i] = 0;
+            duckdb_validity_set_row_invalid(validity, offset + i);
+        } else {
+            out[offset + i] = safe_min_i64(vals.data(), vals.size());
+        }
     }
 }
 
 void finalize_max(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
                   duckdb_vector result, idx_t count, idx_t offset) {
     std::int64_t* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(result));
+    // MAX over zero non-NULL values is SQL NULL, not 0 (see finalize()).
+    duckdb_vector_ensure_validity_writable(result);
+    uint64_t* validity = duckdb_vector_get_validity(result);
     if (count == 1) {
         const std::uint64_t bid = probe_buf_id(source[0]);
-        if (bid == 0) { out[offset] = 0; return; }
-        auto vals = buffer_pool().snapshot(bid);
-        out[offset] = safe_max_i64(vals.data(), vals.size());
+        auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+        if (vals.empty()) {
+            out[offset] = 0;
+            duckdb_validity_set_row_invalid(validity, offset);
+        } else {
+            out[offset] = safe_max_i64(vals.data(), vals.size());
+        }
         return;
     }
     if (!finalize_is_per_state(source, count)) {
-        std::int64_t v = 0;
         const std::uint64_t bid = probe_buf_id(source[0]);
-        if (bid != 0) {
-            auto vals = buffer_pool().snapshot(bid);
-            v = safe_max_i64(vals.data(), vals.size());
+        auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+        if (vals.empty()) {
+            for (idx_t i = 0; i < count; ++i) {
+                out[offset + i] = 0;
+                duckdb_validity_set_row_invalid(validity, offset + i);
+            }
+        } else {
+            std::int64_t v = safe_max_i64(vals.data(), vals.size());
+            for (idx_t i = 0; i < count; ++i) out[offset + i] = v;
         }
-        for (idx_t i = 0; i < count; ++i) out[offset + i] = v;
         return;
     }
     for (idx_t i = 0; i < count; ++i) {
         const std::uint64_t bid = probe_buf_id(source[i]);
-        if (bid == 0) { out[offset + i] = 0; continue; }
-        auto vals = buffer_pool().snapshot(bid);
-        out[offset + i] = safe_max_i64(vals.data(), vals.size());
+        auto vals = bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+        if (vals.empty()) {
+            out[offset + i] = 0;
+            duckdb_validity_set_row_invalid(validity, offset + i);
+        } else {
+            out[offset + i] = safe_max_i64(vals.data(), vals.size());
+        }
     }
 }
 
@@ -657,6 +715,11 @@ void register_one(duckdb_connection con, const char* name,
     duckdb_aggregate_function_set_functions(fn,
         state_size, state_init, update, combine, fin);
     duckdb_aggregate_function_set_destructor(fn, state_destroy);
+    // We handle NULL semantics ourselves (empty / all-NULL input -> SQL NULL
+    // via the output validity mask in finalize). Special handling tells DuckDB
+    // not to short-circuit our aggregate on NULL input; update() already skips
+    // NULL rows via the input validity bitmap.
+    duckdb_aggregate_function_set_special_handling(fn);
     duckdb_state st = duckdb_register_aggregate_function(con, fn);
     duckdb_destroy_aggregate_function(&fn);
     if (st == DuckDBError) {

--- a/test/sql/gpu_min_max.test
+++ b/test/sql/gpu_min_max.test
@@ -1,6 +1,6 @@
 # gpu_min_max SQL test — verifies gpu_min / gpu_max produce identical results
 # to DuckDB's native MIN / MAX on integer ranges, NULL-bearing data, and
-# pseudo-random samples; pins the documented "empty / all-NULL → 0" sentinel.
+# pseudo-random samples; empty / all-NULL input returns SQL NULL (v0.2.0).
 #
 # Run via:
 #   ./scripts/run_sql_tests.sh gpu_min_max
@@ -47,19 +47,19 @@ SELECT gpu_min(x) gmin, min(x) nmin, gpu_max(x) gmax, max(x) nmax
 FROM (SELECT CASE WHEN range % 3 = 0 THEN NULL ELSE range::BIGINT END AS x FROM range(100));
 -- expect: 1  1  98  98
 
--- 8. MIN(empty) — gpu_min returns 0; native returns NULL.
---    Documented divergence, same as gpu_sum on empty (see gpu_sum.test).
+-- 8. MIN(empty) — gpu_min and native MIN both return NULL (v0.2.0).
+--    Empty-state finalize marks the output row invalid, same as gpu_sum.
 SELECT gpu_min(x) gmin, min(x) nmin FROM (SELECT NULL::BIGINT WHERE FALSE) t(x);
--- expect: 0  NULL
+-- expect: NULL  NULL
 
--- 9. MAX(empty) — same divergence as MIN.
+-- 9. MAX(empty) — same as MIN.
 SELECT gpu_max(x) gmax, max(x) nmax FROM (SELECT NULL::BIGINT WHERE FALSE) t(x);
--- expect: 0  NULL
+-- expect: NULL  NULL
 
--- 10. MIN/MAX over an all-NULL column — same divergence (gpu returns 0).
+-- 10. MIN/MAX over an all-NULL column — both return NULL.
 SELECT gpu_min(x) gmin, min(x) nmin, gpu_max(x) gmax, max(x) nmax
 FROM (VALUES (NULL::BIGINT), (NULL::BIGINT), (NULL::BIGINT)) t(x);
--- expect: 0  NULL  0  NULL
+-- expect: NULL  NULL  NULL  NULL
 
 -- 11. 1M-row range — wide span correctness
 SELECT gpu_min(range::BIGINT) gmin, min(range::BIGINT) nmin,

--- a/test/sql/gpu_sum.test
+++ b/test/sql/gpu_sum.test
@@ -40,16 +40,15 @@ SELECT
 FROM (VALUES (-100::BIGINT), (50::BIGINT), (-25::BIGINT), (75::BIGINT), (0::BIGINT)) t(x);
 -- expect: 0  0
 
--- 4. Empty table — gpu_sum returns 0; native returns NULL.
---    This is a documented divergence: extension returns a 0 sentinel for
---    the empty-state finalize, while DuckDB's native SUM follows the SQL
---    spec and returns NULL. See src/extension/gpu_sum_extension.cpp.
+-- 4. Empty table — gpu_sum and native SUM both return NULL (SQL spec).
+--    Fixed in v0.2.0: the empty-state finalize marks the output row invalid
+--    via the validity mask instead of writing a 0 sentinel.
 SELECT gpu_sum(x) AS gpu, sum(x) AS native FROM (SELECT NULL::BIGINT WHERE FALSE) t(x);
--- expect: 0  NULL
+-- expect: NULL  NULL
 
--- 5. All-NULL column — gpu_sum returns 0; native returns NULL (same rationale as #4).
+-- 5. All-NULL column — gpu_sum and native SUM both return NULL (same as #4).
 SELECT gpu_sum(x) AS gpu, sum(x) AS native FROM (VALUES (NULL::BIGINT), (NULL::BIGINT), (NULL::BIGINT)) t(x);
--- expect: 0  NULL
+-- expect: NULL  NULL
 
 -- 6. Large NULL mix — every even row is NULL, odds carry the value.
 --    1 + 3 + 5 + ... + 99 = 50^2 = 2500

--- a/test/sqllogic/gpudb.test
+++ b/test/sqllogic/gpudb.test
@@ -55,3 +55,57 @@ SELECT gpu_sum(v::BIGINT)
 FROM (VALUES (1), (NULL), (3), (NULL), (6)) t(v);
 ----
 10
+
+# Empty input — SUM over zero rows is SQL NULL (v0.2.0), matching native SUM.
+query I
+SELECT gpu_sum(v::BIGINT) FROM (SELECT 1 AS v WHERE false) t;
+----
+NULL
+
+# All-NULL input — SUM over zero non-NULL values is SQL NULL.
+query I
+SELECT gpu_sum(NULL::BIGINT);
+----
+NULL
+
+# Mixed NULL + values — NULLs skipped, sum of the remainder.
+query I
+SELECT gpu_sum(v::BIGINT) FROM (VALUES (1), (2), (NULL)) t(v);
+----
+3
+
+# GROUP BY with an all-NULL group — that group is NULL; others aggregate normally.
+query II
+SELECT k, gpu_sum(v) FROM (VALUES (1, NULL), (1, NULL), (2, 10)) t(k, v)
+GROUP BY k ORDER BY k;
+----
+1	NULL
+2	10
+
+# MIN / MAX over empty input — SQL NULL.
+query I
+SELECT gpu_min(v::BIGINT) FROM (SELECT 1 AS v WHERE false) t;
+----
+NULL
+
+query I
+SELECT gpu_max(v::BIGINT) FROM (SELECT 1 AS v WHERE false) t;
+----
+NULL
+
+# MIN / MAX over all-NULL input — SQL NULL.
+query I
+SELECT gpu_min(NULL::BIGINT);
+----
+NULL
+
+query I
+SELECT gpu_max(NULL::BIGINT);
+----
+NULL
+
+# IS NULL is true for an empty / all-NULL aggregate (was false before v0.2.0).
+query T
+SELECT gpu_sum(NULL::BIGINT) IS NULL;
+----
+true


### PR DESCRIPTION
Fixes the last documented SQL-spec divergence (KNOWN_ISSUES): `gpu_sum`/`gpu_min`/`gpu_max` over empty input or all-NULL groups returned `0`; they now return SQL `NULL` like native aggregates.

## How
- The empty signal is an **empty state buffer** — `update()` already skips NULL rows via the input validity bitmap, so zero non-NULL values ⇔ empty buffer. (Not `bid == 0`, which only means the magic-word probe failed.)
- Every finalize path (single, constant-broadcast for `WindowConstantAggregator`, batched-GPU prefill + all-empty fallback, per-state CPU) writes a deterministic 0 **and** marks the row invalid via `duckdb_vector_ensure_validity_writable` + `duckdb_validity_set_row_invalid` — both confirmed present in the C_STRUCT entrypoint struct at C API v1.2.0 stable.
- `register_one` now declares `duckdb_aggregate_function_set_special_handling`.
- **No aggregate state layout change** — the PR #22 POD-state/magic-word defense is untouched.

## Tests
- 96/96 cpp unit tests, 46/46 custom SQL suite
- `test/sqllogic/gpudb.test` +10 blocks (runs in **community CI**): empty→NULL, all-NULL→NULL, mixed→3, GROUP BY all-NULL group, min/max variants, `IS NULL`→true
- Real `duckdb -unsigned` LOAD e2e on osx_arm64/Metal: empty, all-NULL, mixed, GROUP BY with all-NULL group, 100-group batched path, `OVER ()`/`OVER (ORDER BY)` window regression, 1M-row sum = 499999500000
- Stale `0` expectations in `test/sql/` flipped to `NULL` (gpu_sum q4/q5, gpu_min_max q8/q9/q10)

Zero risk to community-extensions PR #1898 — it builds the tag-anchored ref `018d8a3`; this ships in a later description.yml bump as part of v0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)