### PR TITLE
feat(ext): gpu_sum(DOUBLE) -> DOUBLE overload via aggregate function set

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -24,6 +24,13 @@ matching native DuckDB, and `IS NULL` on such a result is now `true`.
 |---|---|
 | `gpu_sum(DOUBLE)` falls back to host on Apple Silicon | Apple GPUs do not implement IEEE-754 double precision in MSL. Result is correct; just no GPU acceleration. |
 
+### Type support (v0.2.0)
+
+| Aggregate | Supported input types | Notes |
+|---|---|---|
+| `gpu_sum` | `BIGINT`, `DOUBLE` (and `INTEGER`/`SMALLINT`/`TINYINT` via DuckDB's implicit widening to the `BIGINT` overload) | `gpu_sum(DOUBLE) -> DOUBLE` added in v0.2.0 as a real second overload (a function set). Smaller integer types carry no dedicated overload — they widen to `BIGINT`, which is why the result type of `gpu_sum(INTEGER)` is `BIGINT`. `DOUBLE` sums run on the host on Apple Silicon (see the row above); the result is correct on every backend. |
+| `gpu_min` / `gpu_max` | `BIGINT` only (and smaller integers via implicit widening) | **No `DOUBLE` overload yet.** The backend interface exposes `sum_f64` but no `min_f64` / `max_f64`, so a floating-point `gpu_min` / `gpu_max` cannot be wired up without an interface change. Deferred to v0.3.0. For `MIN` / `MAX` over `DOUBLE`, fall back to native DuckDB `min()` / `max()`. |
+
 ---
 
 ## Resolved issues

--- a/src/extension/gpu_sum_extension.cpp
+++ b/src/extension/gpu_sum_extension.cpp
@@ -80,6 +80,7 @@ DUCKDB_EXTENSION_EXTERN
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -160,6 +161,32 @@ std::int64_t safe_max_i64(const std::int64_t* data, std::size_t n) {
         return shared_agg().max_i64(data, n).value_i64;
     } catch (const std::exception&) {
         return cpu_max(data, n);
+    }
+}
+
+// DOUBLE sum. Plain (non-Kahan) accumulation, matching DuckDB's native SUM
+// semantics. Used by the gpu_sum(DOUBLE) overload's finalize.
+inline double cpu_sum_f64(const double* data, std::size_t n) {
+    double acc = 0.0;
+    for (std::size_t i = 0; i < n; ++i) acc += data[i];
+    return acc;
+}
+
+// Thread-safe f64 sum, mirroring safe_sum_i64: tiny inputs short-circuit to
+// CPU; larger inputs dispatch through the singleton aggregator under the
+// shared lock. On Apple Silicon the Metal backend's sum_f64 is itself a host
+// fallback (Apple GPUs lack IEEE-754 doubles — see metal_aggregator.mm), so
+// this is host summation there; on CUDA it is a real device reduction. Either
+// way the result is a plain double sum, and any backend exception falls back
+// to cpu_sum_f64.
+double safe_sum_f64(const double* data, std::size_t n) {
+    if (n == 0) return 0.0;
+    if (n < kSumGpuMinRows) return cpu_sum_f64(data, n);
+    try {
+        std::lock_guard<std::mutex> lock(gpu_call_mutex());
+        return shared_agg().sum_f64(data, n).value_f64;
+    } catch (const std::exception&) {
+        return cpu_sum_f64(data, n);
     }
 }
 
@@ -613,6 +640,91 @@ void finalize(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
     }
 }
 
+// ==========================================================================
+//  gpu_sum(DOUBLE) -> DOUBLE overload
+//
+// The DOUBLE overload reuses the ENTIRE i64 state machinery unchanged:
+// state_size / state_init / state_destroy / update / combine are shared. The
+// trick is that a double and an int64 are both 8 bytes, so update() appends
+// the raw 8-byte bit patterns of the incoming doubles into the same
+// BufferPool<int64> (reinterpreting the DOUBLE vector's data as int64 copies
+// the bits verbatim; NULL-skipping via the validity bitmap is byte-width
+// agnostic and works identically). combine() shuffles those bit patterns
+// between buffers without interpreting them. Only finalize differs: it must
+// read the stored bits back AS doubles and sum in double precision.
+//
+// This means zero change to the POD-state layout / magic-word probe / window
+// (CONSTANT_VECTOR) defences that PR #22 hardened — the DOUBLE path inherits
+// all of it for free.
+// ==========================================================================
+
+// Snapshot a state's buffer and reinterpret the stored int64 bit patterns
+// back into doubles via a blessed memcpy bit-cast (correct regardless of
+// strict-aliasing). Empty exactly when the state accumulated zero non-NULL
+// values (empty input / all-NULL group) — the SQL-NULL case.
+inline std::vector<double> snapshot_as_f64(std::uint64_t bid) {
+    std::vector<std::int64_t> raw =
+        bid ? buffer_pool().snapshot(bid) : std::vector<std::int64_t>{};
+    std::vector<double> vals(raw.size());
+    if (!raw.empty())
+        std::memcpy(vals.data(), raw.data(), raw.size() * sizeof(double));
+    return vals;
+}
+
+void finalize_f64(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
+                  duckdb_vector result, idx_t count, idx_t offset) {
+    double* out = reinterpret_cast<double*>(duckdb_vector_get_data(result));
+
+    // SUM over zero non-NULL values is SQL NULL, not 0 — identical semantics
+    // to the i64 finalize(). Empty state buffer <=> that case.
+    duckdb_vector_ensure_validity_writable(result);
+    uint64_t* validity = duckdb_vector_get_validity(result);
+
+    // ---- Single-state fast path: ungrouped gpu_sum(x), and per-row window
+    //      finalize calls without PARTITION BY. ----
+    if (count == 1) {
+        auto vals = snapshot_as_f64(probe_buf_id(source[0]));
+        if (vals.empty()) {
+            out[offset] = 0.0;
+            duckdb_validity_set_row_invalid(validity, offset);
+        } else {
+            out[offset] = safe_sum_f64(vals.data(), vals.size());
+        }
+        return;
+    }
+
+    // ---- Constant-state finalize: WindowConstantAggregator passes a
+    //      CONSTANT_VECTOR for source. Only source[0] is real; broadcast. ----
+    if (!finalize_is_per_state(source, count)) {
+        auto vals = snapshot_as_f64(probe_buf_id(source[0]));
+        if (vals.empty()) {
+            for (idx_t i = 0; i < count; ++i) {
+                out[offset + i] = 0.0;
+                duckdb_validity_set_row_invalid(validity, offset + i);
+            }
+        } else {
+            double v = safe_sum_f64(vals.data(), vals.size());
+            for (idx_t i = 0; i < count; ++i) out[offset + i] = v;
+        }
+        return;
+    }
+
+    // ---- Grouped path: count > 1 with all distinct registered states. ----
+    // There is no groupby_sum_f64 in the backend interface (deferred), so we
+    // do NOT take the batched-GPU branch the i64 path uses. Sum each group's
+    // buffer independently — trivially correct, and the mid-cardinality regime
+    // the i64 path also handles on the host.
+    for (idx_t i = 0; i < count; ++i) {
+        auto vals = snapshot_as_f64(probe_buf_id(source[i]));
+        if (vals.empty()) {
+            out[offset + i] = 0.0;
+            duckdb_validity_set_row_invalid(validity, offset + i);
+        } else {
+            out[offset + i] = safe_sum_f64(vals.data(), vals.size());
+        }
+    }
+}
+
 // MIN / MAX share state + update + combine with SUM; only finalize differs.
 //
 // Both honour the same constant-state defence as sum's finalize(): if the
@@ -704,14 +816,21 @@ void finalize_max(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
     }
 }
 
-void register_one(duckdb_connection con, const char* name,
-                  duckdb_aggregate_finalize_t fin) {
+// Build (but do not register) one aggregate overload: (param_type) ->
+// param_type, wired to the shared state/update/combine machinery and the
+// given finalize. The return type mirrors the parameter type (BIGINT->BIGINT,
+// DOUBLE->DOUBLE); update/combine/state are byte-width agnostic and shared
+// across both overloads (see the gpu_sum(DOUBLE) section above). Caller owns
+// the returned handle and must duckdb_destroy_aggregate_function() it.
+duckdb_aggregate_function make_agg_function(const char* name,
+                                            duckdb_type param_type,
+                                            duckdb_aggregate_finalize_t fin) {
     duckdb_aggregate_function fn = duckdb_create_aggregate_function();
     duckdb_aggregate_function_set_name(fn, name);
-    duckdb_logical_type bigint = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
-    duckdb_aggregate_function_add_parameter(fn, bigint);
-    duckdb_aggregate_function_set_return_type(fn, bigint);
-    duckdb_destroy_logical_type(&bigint);
+    duckdb_logical_type t = duckdb_create_logical_type(param_type);
+    duckdb_aggregate_function_add_parameter(fn, t);
+    duckdb_aggregate_function_set_return_type(fn, t);
+    duckdb_destroy_logical_type(&t);
     duckdb_aggregate_function_set_functions(fn,
         state_size, state_init, update, combine, fin);
     duckdb_aggregate_function_set_destructor(fn, state_destroy);
@@ -720,6 +839,13 @@ void register_one(duckdb_connection con, const char* name,
     // not to short-circuit our aggregate on NULL input; update() already skips
     // NULL rows via the input validity bitmap.
     duckdb_aggregate_function_set_special_handling(fn);
+    return fn;
+}
+
+// Register a single BIGINT-typed aggregate (gpu_min / gpu_max).
+void register_one(duckdb_connection con, const char* name,
+                  duckdb_aggregate_finalize_t fin) {
+    duckdb_aggregate_function fn = make_agg_function(name, DUCKDB_TYPE_BIGINT, fin);
     duckdb_state st = duckdb_register_aggregate_function(con, fn);
     duckdb_destroy_aggregate_function(&fn);
     if (st == DuckDBError) {
@@ -727,13 +853,42 @@ void register_one(duckdb_connection con, const char* name,
     }
 }
 
+// Register gpu_sum as an aggregate function SET carrying two overloads:
+//   gpu_sum(BIGINT) -> BIGINT   (existing i64 finalize)
+//   gpu_sum(DOUBLE) -> DOUBLE   (new f64 finalize)
+// A function set is the C API's mechanism for same-name overloads; DuckDB's
+// binder then resolves the overload per call (INTEGER/SMALLINT/TINYINT keep
+// widening to the BIGINT overload as before — that implicit integer widening
+// is cheaper than the integer->double cast, so it wins overload resolution).
+void register_sum_overloads(duckdb_connection con) {
+    duckdb_aggregate_function_set set =
+        duckdb_create_aggregate_function_set("gpu_sum");
+    duckdb_aggregate_function fn_i64 =
+        make_agg_function("gpu_sum", DUCKDB_TYPE_BIGINT, finalize);
+    duckdb_aggregate_function fn_f64 =
+        make_agg_function("gpu_sum", DUCKDB_TYPE_DOUBLE, finalize_f64);
+    duckdb_state a1 = duckdb_add_aggregate_function_to_set(set, fn_i64);
+    duckdb_state a2 = duckdb_add_aggregate_function_to_set(set, fn_f64);
+    duckdb_destroy_aggregate_function(&fn_i64);
+    duckdb_destroy_aggregate_function(&fn_f64);
+    if (a1 == DuckDBError || a2 == DuckDBError) {
+        duckdb_destroy_aggregate_function_set(&set);
+        throw std::runtime_error("gpu_sum overload set assembly failed");
+    }
+    duckdb_state st = duckdb_register_aggregate_function_set(con, set);
+    duckdb_destroy_aggregate_function_set(&set);
+    if (st == DuckDBError) {
+        throw std::runtime_error("gpu_sum function set registration failed");
+    }
+}
+
 } // namespace
 
 void register_gpu_sum(duckdb_connection con) {
-    register_one(con, "gpu_sum", finalize);
-    register_one(con, "gpu_min", finalize_min);
-    register_one(con, "gpu_max", finalize_max);
-    std::fprintf(stderr, "[gpudb] registered gpu_sum / gpu_min / gpu_max  (backend=%s)\n",
+    register_sum_overloads(con);            // gpu_sum: BIGINT + DOUBLE overloads
+    register_one(con, "gpu_min", finalize_min);  // BIGINT only (v0.2.0)
+    register_one(con, "gpu_max", finalize_max);  // BIGINT only (v0.2.0)
+    std::fprintf(stderr, "[gpudb] registered gpu_sum (BIGINT,DOUBLE) / gpu_min / gpu_max  (backend=%s)\n",
                  gpudb::to_string(shared_agg().backend()));
 }
 

--- a/src/extension/gpu_sum_extension.hpp
+++ b/src/extension/gpu_sum_extension.hpp
@@ -17,8 +17,12 @@
 
 namespace gpudb_ext {
 
-// Register gpu_sum / gpu_min / gpu_max (BIGINT) -> BIGINT on the given open
-// DuckDB connection. Throws std::runtime_error if registration fails.
+// Register gpu_sum / gpu_min / gpu_max on the given open DuckDB connection.
+//   gpu_sum: overload set — (BIGINT) -> BIGINT and (DOUBLE) -> DOUBLE.
+//   gpu_min / gpu_max: (BIGINT) -> BIGINT only (v0.2.0; DOUBLE deferred).
+// Smaller integer types (INTEGER/SMALLINT/TINYINT) resolve to the BIGINT
+// overloads via DuckDB's implicit integer widening. Throws std::runtime_error
+// if registration fails.
 void register_gpu_sum(duckdb_connection con);
 
 } // namespace gpudb_ext

--- a/test/sql/gpu_sum.test
+++ b/test/sql/gpu_sum.test
@@ -91,3 +91,38 @@ SELECT
     sum((range - 50000)::BIGINT)     AS native
 FROM range(100000);
 -- expect: -50000  -50000
+
+-- ---------------------------------------------------------------------------
+-- gpu_sum(DOUBLE) overload (v0.2.0). DOUBLE does not implicitly cast to BIGINT
+-- (lossy), so this is a real second overload — gpu_sum(DOUBLE) -> DOUBLE. All
+-- values below are exact in IEEE-754 binary so the assertions are stable.
+-- On Apple Silicon the double sum runs on the host (Apple GPUs lack doubles);
+-- the result matches native SUM on every backend.
+-- ---------------------------------------------------------------------------
+
+-- 13. DOUBLE sum with a NULL mixed in — NULL skipped, 1.5 + 2.25 = 3.75.
+SELECT
+    gpu_sum(v)             AS gpu,
+    sum(v)                 AS native
+FROM (VALUES (1.5::DOUBLE), (NULL), (2.25::DOUBLE)) t(v);
+-- expect: 3.75  3.75
+
+-- 14. DOUBLE mixed sign — exact cancellation: -0.5 + 1.25 - 0.25 = 0.5.
+SELECT
+    gpu_sum(v)             AS gpu,
+    sum(v)                 AS native
+FROM (VALUES (-0.5::DOUBLE), (1.25::DOUBLE), (-0.25::DOUBLE)) t(v);
+-- expect: 0.5  0.5
+
+-- 15. Empty DOUBLE input — SUM over zero rows is SQL NULL (matches native).
+SELECT gpu_sum(v) AS gpu, sum(v) AS native
+FROM (SELECT 1.0::DOUBLE AS v WHERE FALSE) t(v);
+-- expect: NULL  NULL
+
+-- 16. Large DOUBLE set — 100k values in 0.5 steps (each exact). The sum path
+--     goes through the host reduction; result matches native SUM exactly.
+SELECT
+    gpu_sum(v)             AS gpu,
+    sum(v)                 AS native
+FROM (SELECT (range * 0.5)::DOUBLE AS v FROM range(100000)) t(v);
+-- expect: 2499975000.0  2499975000.0

--- a/test/sqllogic/gpudb.test
+++ b/test/sqllogic/gpudb.test
@@ -109,3 +109,49 @@ query T
 SELECT gpu_sum(NULL::BIGINT) IS NULL;
 ----
 true
+
+# ---------------------------------------------------------------------------
+# Type widening (v0.2.0)
+# ---------------------------------------------------------------------------
+
+# Smaller integer types (INTEGER here) carry NO dedicated overload — they
+# widen to the gpu_sum(BIGINT) overload via DuckDB's implicit integer cast, so
+# the result type is BIGINT. 1 + 2 + 3 = 6.
+query I
+SELECT gpu_sum(v) FROM (VALUES (1::INTEGER), (2::INTEGER), (3::INTEGER)) t(v);
+----
+6
+
+# ...and the widened result is BIGINT, not the input's INTEGER.
+query T
+SELECT typeof(gpu_sum(1::INTEGER));
+----
+BIGINT
+
+# gpu_sum(DOUBLE) — the second, real overload. Returns DOUBLE. 1.5 + 2.25 =
+# 3.75 (both exact in binary). On Apple Silicon the double sum runs on the host
+# (Apple GPUs lack IEEE-754 doubles); the result is identical on every backend.
+query R
+SELECT gpu_sum(v) FROM (VALUES (1.5::DOUBLE), (2.25::DOUBLE)) t(v);
+----
+3.75
+
+# All-NULL DOUBLE input — SUM over zero non-NULL values is SQL NULL.
+query R
+SELECT gpu_sum(NULL::DOUBLE);
+----
+NULL
+
+# Empty DOUBLE input — SQL NULL via the output validity mask, matching native SUM.
+query R
+SELECT gpu_sum(v::DOUBLE) FROM (SELECT 1.0 AS v WHERE false) t;
+----
+NULL
+
+# GROUP BY over DOUBLE — group 1 sums to 3.75; group 2 is all-NULL -> NULL.
+query IR
+SELECT k, gpu_sum(v) FROM (VALUES (1, 1.5::DOUBLE), (1, 2.25::DOUBLE), (2, NULL::DOUBLE)) t(k, v)
+GROUP BY k ORDER BY k;
+----
+1	3.75
+2	NULL


### PR DESCRIPTION
**Stacked on #44** (NULL semantics) — merge #44 first; this PR's base is `feat/ext-null-semantics` so it shows only the DOUBLE work. Roadmap item #2 (type widening) for v0.2.0.

## What

- **`gpu_sum(DOUBLE) -> DOUBLE`** as a real second overload, registered via the C API **aggregate function set** (`duckdb_create/add/register_aggregate_function_set` — all present in the C_STRUCT entrypoint struct, `third_party/duckdb_capi/duckdb_capi/duckdb_extension.h:341-345`).
- **Zero state-layout change**: doubles and int64 are both 8 bytes, so the shared `update()`/`combine()` append/shuffle raw double bit patterns through the existing `BufferPool<int64>` untouched. Only `finalize_f64` is new — it memcpy-bit-casts the stored bits back to doubles and sums in double precision. All PR #22 defences (POD state, magic-word probe, `CONSTANT_VECTOR` window handling) apply to the DOUBLE path for free.
- `finalize_f64` mirrors the i64 finalize on all three paths (single-state, WindowConstantAggregator broadcast, per-state GROUP BY), **including empty/all-NULL → SQL NULL** via the output validity mask — the DOUBLE overload inherits #44's semantics from birth.
- GROUP BY uses the per-state host path (no `groupby_sum_f64` in the backend interface). On Apple Silicon `sum_f64` is the documented host fallback (no IEEE-754 doubles in MSL); on CUDA it is a real device reduction.

## Verified, not built

- `INTEGER`/`SMALLINT`/`TINYINT` **already work** via DuckDB's implicit widening to the BIGINT overload (result type `BIGINT`) — locked in by tests, no code needed. Widening beats int→double in overload resolution, so integer inputs keep hitting the BIGINT overload.
- `gpu_min`/`gpu_max` stay BIGINT-only: `gpu_backend.hpp` has `sum_f64` but no `min_f64`/`max_f64`; deferred to v0.3.0 and documented in `KNOWN_ISSUES.md`. `gpu_min(1.5::DOUBLE)` gives a clean binder error listing the BIGINT candidate.

## Testing

- 96/96 unit checks (Metal backend), 50/50 SQL comparison cases (4 new DOUBLE cases, q13–q16), +6 sqllogic blocks (INTEGER widening + typeof, DOUBLE sum/all-NULL/empty/GROUP BY).
- Independent e2e against the real DuckDB CLI (`-unsigned`, Metal): `gpu_sum(1.5::DOUBLE)` → 1.5/DOUBLE; NULL-mixed → 3.75; empty → `IS NULL` true; GROUP BY all-NULL group → NULL; `OVER ()` → 3.75 broadcast; 100k×0.5 sum = 2499975000.0 exact vs native; 100-group GROUP BY has **zero** groups differing from native `sum()`; BIGINT regression 1M-row sum = 499999500000.
- All test values chosen exact-in-binary (0.5 steps, 1.5/2.25) so assertions are stable across platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)