### PR TITLE
chore(release): v0.3.0 — version bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(gpudb
-    VERSION 0.2.0
+    VERSION 0.3.0
     DESCRIPTION "GPU-accelerated operators for DuckDB (CUDA + Metal)"
     LANGUAGES CXX
 )


### PR DESCRIPTION
Bumps the project version to 0.3.0 (stamps extension_version in the loadable metadata). Feature content landed in #48; docs and benchmarks were updated there. Release notes and binaries follow on the v0.3.0 tag.