### PR TITLE
docs: CI recipes + Colab quickstart notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/singhpratech/duckdbgpumetaldbram/actions/workflows/ci.yml/badge.svg)](https://github.com/singhpratech/duckdbgpumetaldbram/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Apple_Silicon_Metal_%7C_Linux_CUDA-8A2BE2)](#quick-start)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/singhpratech/duckdbgpumetaldbram/blob/main/examples/gpudb_quickstart.ipynb)
 [![GitHub stars](https://img.shields.io/github/stars/singhpratech/duckdbgpumetaldbram?style=social)](https://github.com/singhpratech/duckdbgpumetaldbram/stargazers)
 
 > **The first SQL execution engine for Apple Silicon GPUs**, built as a DuckDB extension that *also* runs on NVIDIA CUDA. One codebase, two backends, your existing DuckDB queries.
@@ -137,6 +138,19 @@ duckdb -unsigned -c "LOAD '$(pwd)/build-linux/src/extension/gpudb.linux_amd64.du
   SELECT gpu_sum(v) FROM read_parquet('data/tpch_sf1/lineitem_orderkey.parquet') t(v);"
 # -> 18005322964949
 ```
+
+## Run it in CI or a notebook
+
+GitHub's `macos-14`/`macos-15` hosted runners are **Apple Silicon machines** —
+gpudb's Metal path runs in free GitHub Actions with zero setup, which makes it
+(as far as we know) the only DuckDB extension that does anything special
+there. Copy-paste workflows for Apple Silicon runners, Linux runners, Docker,
+and self-hosted CUDA boxes: **[docs/CI_RECIPES.md](docs/CI_RECIPES.md)**.
+
+Prefer a notebook? **[examples/gpudb_quickstart.ipynb](examples/gpudb_quickstart.ipynb)**
+opens directly in Google Colab — registry install + parity checks anywhere,
+plus an optional build-from-source section that runs the CUDA benchmarks on
+Colab's free T4 GPU.
 
 ## What you get
 

--- a/docs/CI_RECIPES.md
+++ b/docs/CI_RECIPES.md
@@ -1,0 +1,161 @@
+# gpudb in CI — copy-paste recipes
+
+GitHub's `macos-14` and `macos-15` hosted runners are **Apple Silicon (M1/M2)
+machines**. That means the GPU path of `gpudb` — the Metal backend — runs in
+plain, free GitHub Actions with zero setup. As far as we know, gpudb is the
+only DuckDB extension that does anything special on those runners.
+
+All recipes below install from the community registry (`INSTALL gpudb FROM
+community;`), so they work on any DuckDB ≥ 1.5.5 with no extra flags. If a
+runner has no usable GPU, gpudb falls back to CPU cleanly — same SQL surface,
+same results — so none of these jobs can break just because the GPU is
+missing.
+
+---
+
+## 1. GitHub Actions on Apple Silicon (the fun one)
+
+Data checks with the Metal backend on a free hosted runner:
+
+```yaml
+name: data-checks
+on: [push, schedule]
+
+jobs:
+  gpu-data-checks:
+    runs-on: macos-15          # Apple Silicon (M-series) hosted runner
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install DuckDB CLI
+        run: brew install duckdb
+
+      - name: GPU-accelerated checks
+        run: |
+          duckdb -c "
+            INSTALL gpudb FROM community;
+            LOAD gpudb;
+            -- example: validate a dataset with GPU aggregates
+            SELECT
+              gpu_sum(amount::BIGINT)  AS total,
+              gpu_min(amount::BIGINT)  AS lo,
+              gpu_max(amount::BIGINT)  AS hi
+            FROM read_parquet('data/*.parquet');
+          "
+```
+
+Useful patterns on top of this skeleton:
+
+- **Parity assertion** — run `gpu_sum` and native `sum` side by side and fail
+  the job if they differ. Cheap correctness gate for your own data:
+
+  ```sql
+  SELECT CASE
+    WHEN gpu_sum(x::BIGINT) = sum(x::BIGINT) THEN 'ok'
+    ELSE error('gpu/native mismatch')
+  END FROM read_parquet('data/*.parquet') AS t(x);
+  ```
+
+- **Scheduled runs** — add a `schedule:` trigger (cron) and the job re-runs
+  nightly against fresh data. This is how most production DuckDB extension
+  usage actually looks: unattended, on a timer.
+
+  ```yaml
+  on:
+    schedule:
+      - cron: "17 4 * * *"   # nightly 04:17 UTC
+  ```
+
+Note on virtualized Metal: hosted macOS runners expose the GPU through
+Apple's paravirtualized Metal device. The Metal backend initializes and runs
+there; if a particular runner image ever doesn't expose it, gpudb logs the
+fallback and the job still passes on CPU.
+
+## 2. GitHub Actions on Linux (correctness fallback)
+
+The community `linux_amd64` binary is built without the CUDA toolchain
+(registry CI has no GPUs), so on `ubuntu-latest` gpudb runs its CPU fallback.
+Still useful as a portability/correctness check — and it exercises the exact
+binary your Linux users get:
+
+```yaml
+  cpu-fallback-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install DuckDB CLI
+        run: |
+          curl -sL https://github.com/duckdb/duckdb/releases/latest/download/duckdb_cli-linux-amd64.zip -o duckdb.zip
+          unzip duckdb.zip && sudo mv duckdb /usr/local/bin/
+      - name: gpudb smoke
+        run: |
+          duckdb -c "
+            INSTALL gpudb FROM community;
+            LOAD gpudb;
+            SELECT gpu_sum(value::BIGINT) FROM range(1000000) AS t(value);
+          "
+```
+
+For the real CUDA backend on Linux, build from source on a machine with
+`nvcc` (see recipe 4).
+
+## 3. Docker
+
+Bake the extension into an image so containers don't re-download at runtime
+— or install at container start if you always want the latest registry build:
+
+```dockerfile
+FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y curl unzip \
+ && curl -sL https://github.com/duckdb/duckdb/releases/latest/download/duckdb_cli-linux-amd64.zip -o /tmp/duckdb.zip \
+ && unzip /tmp/duckdb.zip -d /usr/local/bin && rm /tmp/duckdb.zip
+# pre-install gpudb into the image's extension directory
+RUN duckdb -c "INSTALL gpudb FROM community;"
+ENTRYPOINT ["duckdb"]
+```
+
+```bash
+docker build -t duckdb-gpudb .
+docker run --rm duckdb-gpudb -c "LOAD gpudb; SELECT gpu_sum(value::BIGINT) FROM range(1e6::BIGINT) t(value);"
+```
+
+## 4. Self-hosted CUDA runner (full GPU on Linux)
+
+If you have a self-hosted runner with an NVIDIA GPU (sm_70+), build once and
+cache the artifact:
+
+```yaml
+  cuda-build-and-check:
+    runs-on: [self-hosted, gpu]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: singhpratech/duckdbgpumetaldbram
+          submodules: recursive
+      - name: Build with CUDA
+        run: ./scripts/build.sh          # auto-detects nvcc
+      - name: GPU checks
+        run: |
+          ./build-linux/test/test_gpudb
+```
+
+## 5. Colab / Jupyter
+
+There is a ready-made notebook at
+[`examples/gpudb_quickstart.ipynb`](../examples/gpudb_quickstart.ipynb) —
+one-click quick start on Google Colab, including an optional
+build-from-source section that compiles the CUDA backend on Colab's free GPU
+runtime.
+
+---
+
+## Semantics worth knowing before you gate CI on gpudb
+
+- Empty input and all-NULL groups return SQL `NULL`, matching native DuckDB.
+- `DOUBLE` min/max use DuckDB's NaN-aware total order (NaN sorts greatest).
+- `gpu_sum(BIGINT)` wraps on int64 overflow where native `sum()` promotes to
+  `HUGEINT` — don't gate on columns that can exceed int64 range.
+- `HUGEINT`/`DECIMAL`/`FLOAT` arguments cast to the `DOUBLE` overload; use
+  native aggregates where exactness beyond 2^53 matters.
+
+Full details: [KNOWN_ISSUES.md](../KNOWN_ISSUES.md) and the
+[community extension page](https://duckdb.org/community_extensions/extensions/gpudb).

--- a/examples/gpudb_quickstart.ipynb
+++ b/examples/gpudb_quickstart.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# gpudb quick start\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/singhpratech/duckdbgpumetaldbram/blob/main/examples/gpudb_quickstart.ipynb)\n",
+    "\n",
+    "**gpudb** is a DuckDB community extension: GPU-accelerated `gpu_sum` / `gpu_min` / `gpu_max`\n",
+    "aggregates with a CUDA backend (NVIDIA) and a Metal backend (Apple Silicon —\n",
+    "the first SQL execution engine targeting Apple Silicon GPUs).\n",
+    "\n",
+    "This notebook has two parts:\n",
+    "\n",
+    "1. **Quick start (runs anywhere, ~30 seconds)** — install gpudb from the DuckDB\n",
+    "   community registry and use the SQL aggregates. Honest note: the registry's\n",
+    "   Linux binary is built without the CUDA toolchain, so on Colab this part runs\n",
+    "   gpudb's clean CPU fallback — same SQL surface, same results, exactly what\n",
+    "   Linux users get from `INSTALL gpudb FROM community`. (On an Apple Silicon\n",
+    "   Mac the same install runs the full Metal path.)\n",
+    "2. **Real CUDA on Colab's free GPU (optional, a few minutes)** — switch the\n",
+    "   runtime to a T4 GPU and build the engine from source, then run the\n",
+    "   operator-level benchmarks on actual CUDA.\n",
+    "\n",
+    "Project: <https://github.com/singhpratech/duckdbgpumetaldbram> ·\n",
+    "Extension page: <https://duckdb.org/community_extensions/extensions/gpudb>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 1 — install from the community registry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q --upgrade duckdb\n",
+    "import duckdb\n",
+    "print(\"DuckDB\", duckdb.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con = duckdb.connect()\n",
+    "con.sql(\"INSTALL gpudb FROM community;\")\n",
+    "con.sql(\"LOAD gpudb;\")\n",
+    "con.sql(\"SELECT gpu_sum(value::BIGINT) AS s FROM range(1000000) AS t(value)\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parity with native DuckDB\n",
+    "\n",
+    "The aggregates match native semantics (empty input / all-NULL groups return\n",
+    "`NULL`; `DOUBLE` min/max use DuckDB's NaN-aware total order). Verify on the\n",
+    "spot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "SELECT\n",
+    "  gpu_sum(value::BIGINT) AS gpu,\n",
+    "  sum(value::BIGINT)     AS native,\n",
+    "  gpu_sum(value::BIGINT) = sum(value::BIGINT) AS match\n",
+    "FROM range(10000000) AS t(value)\n",
+    "\"\"\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GROUP BY and window frames work too\n",
+    "con.sql(\"\"\"\n",
+    "SELECT\n",
+    "  value % 4                                        AS bucket,\n",
+    "  gpu_sum(value::BIGINT)                           AS bucket_sum,\n",
+    "  gpu_max(value::BIGINT)                           AS bucket_max\n",
+    "FROM range(1000000) AS t(value)\n",
+    "GROUP BY bucket ORDER BY bucket\n",
+    "\"\"\").show()\n",
+    "\n",
+    "con.sql(\"\"\"\n",
+    "SELECT value, gpu_sum(value::BIGINT) OVER (ORDER BY value) AS running\n",
+    "FROM range(5) AS t(value)\n",
+    "\"\"\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Part 2 (optional) — real CUDA on Colab's free T4\n",
+    "\n",
+    "**Runtime → Change runtime type → T4 GPU**, then run the cells below. This\n",
+    "builds the gpudb engine from source (the core build needs only cmake + nvcc,\n",
+    "both preinstalled on Colab GPU runtimes — no submodules, no DuckDB build) and\n",
+    "runs the operator-level benchmarks on the GPU. Takes a few minutes on Colab's\n",
+    "2-core VM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!nvidia-smi\n",
+    "!nvcc --version | tail -2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone --depth 1 https://github.com/singhpratech/duckdbgpumetaldbram.git\n",
+    "!cd duckdbgpumetaldbram && ./scripts/build.sh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# unit tests — CPU reference vs CUDA results\n",
+    "!cd duckdbgpumetaldbram && ./build-linux/test/test_gpudb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# resident-column aggregate benchmark: CPU vs CUDA on this T4\n",
+    "!cd duckdbgpumetaldbram && ./build-linux/bin/gpudb-bench"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GROUP BY at high cardinality — where the GPU path shines\n",
+    "!cd duckdbgpumetaldbram && ./build-linux/bin/gpudb-groupby-bench --rows 50000000 --groups 10000000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "- **CI recipes** — run gpudb's Metal path on GitHub's free Apple Silicon\n",
+    "  runners: [`docs/CI_RECIPES.md`](https://github.com/singhpratech/duckdbgpumetaldbram/blob/main/docs/CI_RECIPES.md)\n",
+    "- **Benchmarks with reproduction steps** — append-only\n",
+    "  [`BENCHMARK.md`](https://github.com/singhpratech/duckdbgpumetaldbram/blob/main/BENCHMARK.md)\n",
+    "- **Known limitations** — [`KNOWN_ISSUES.md`](https://github.com/singhpratech/duckdbgpumetaldbram/blob/main/KNOWN_ISSUES.md)\n",
+    "  (int64 overflow wraps; HUGEINT/DECIMAL/FLOAT cast to DOUBLE)\n",
+    "- Star the repo if this was useful:\n",
+    "  <https://github.com/singhpratech/duckdbgpumetaldbram>"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "gpudb_quickstart.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Two additions aimed at recurring machine installs:

**docs/CI_RECIPES.md** — copy-paste recipes for running gpudb in CI:
- GitHub Actions on `macos-15` hosted runners (Apple Silicon → real Metal path, free)
- `ubuntu-latest` CPU-fallback smoke (the exact binary Linux users get from the registry)
- Docker image with gpudb pre-baked
- self-hosted CUDA runner build
- parity-gate pattern (`gpu_sum` vs native `sum`, fail on mismatch) and nightly `schedule:` pattern
- honest semantics caveats (int64 wrap, DOUBLE casts) so nobody gates CI on the wrong column

**examples/gpudb_quickstart.ipynb** — opens directly in Google Colab:
- Part 1: `INSTALL gpudb FROM community` + parity checks; honest about the registry Linux binary being the CPU fallback
- Part 2 (optional): T4 runtime, build from source (core build needs only cmake+nvcc, no submodules), run `test_gpudb` + `gpudb-bench` + `gpudb-groupby-bench` on real CUDA

**README** — Colab badge in the badge row + a short 'Run it in CI or a notebook' section after Quick start.

Verification: every SQL snippet in both files was run against the actual registry `osx_arm64` v0.3.0 binary with DuckDB CLI v1.5.5 (backend=Metal) — parity check, GROUP BY, window frame, and the error-gate pattern all pass. Notebook JSON validates (nbformat 4, 14 cells). Docs-only change, no code touched.