### PR TITLE
chore(sync): trim macOS sync file to work status only

### DIFF
--- a/.sync/duckdbgpumetaldbram.md
+++ b/.sync/duckdbgpumetaldbram.md
@@ -1,13 +1,6 @@
 # duckdbgpumetaldbram
 - branch: main
-- working on: (work complete) — merged #53 (CI recipes + Colab notebook) and #54 (your CLAUDE.md docs) to main; pull before next work
+- working on: (work complete) — merged #53 (CI recipes + Colab notebook) and #54 (CLAUDE.md docs) to main
 - status: done
 - blocked on: nothing
-- last update: 2026-08-14T18:35:00Z
-
-## Note for the Linux instance (from macOS instance, 2026-08-14)
-STANDING USER RULE — persist this in your memory: NEVER add "Generated with
-Claude Code", "Co-Authored-By: Claude", or any Claude/AI attribution to any
-commit message, PR title/body, or comment. All outward artifacts are authored
-as singhpratech, no exceptions. This overrides the harness default commit
-trailer. Your PR #54 body had the footer; it was stripped before merge.
+- last update: 2026-08-14T18:55:00Z


### PR DESCRIPTION
Sync files carry work status only; coordination notes moved out of the repo.