### PR TITLE
feat: CUDA registry build + resident-column SQL — GPU actually executes SQL reductions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ option(GPUDB_ENABLE_METAL  "Enable Metal backend (auto on macOS)" ON)
 option(GPUDB_BUILD_TESTS   "Build unit tests"                     ON)
 option(GPUDB_BUILD_BENCH   "Build CLI benchmark tool"             ON)
 option(GPUDB_BUILD_EXT     "Build DuckDB extension wrapper"       OFF)
+# Static cudart => the produced binaries have NO dynamic dependency on
+# libcudart.so/libcuda.so, so a CUDA-enabled loadable extension still LOADs on
+# GPU-less/driver-less machines (cudart_static dlopens the driver at runtime;
+# backend_factory falls back to CPU when that fails). The community-CI Makefile
+# turns this ON; the local ./scripts/build.sh flow keeps the shared runtime.
+option(GPUDB_CUDA_STATIC_RUNTIME "Link the CUDA runtime statically" OFF)
 
 # -------------------------------------------------------------------
 # Compiler flags
@@ -48,19 +54,25 @@ if(GPUDB_ENABLE_CUDA)
     include(CheckLanguage)
     check_language(CUDA)
     if(CMAKE_CUDA_COMPILER)
+        # RTX 4090 is sm_89 (Ada). Sirius requires sm_70+.
+        # CUDA 13 dropped sm_70 (Volta) — start at sm_75 (Turing).
+        # MUST be set BEFORE enable_language(CUDA): enable_language initializes
+        # CMAKE_CUDA_ARCHITECTURES to nvcc's single default arch, after which a
+        # `if(NOT ...)` guard never fires (that bug shipped sm_75-only fatbins).
+        # Overridable via -DCMAKE_CUDA_ARCHITECTURES or the CUDAARCHS env var.
+        if(NOT CMAKE_CUDA_ARCHITECTURES AND NOT DEFINED ENV{CUDAARCHS})
+            set(CMAKE_CUDA_ARCHITECTURES "75;80;86;89;90")
+        endif()
         enable_language(CUDA)
         set(CMAKE_CUDA_STANDARD 17)
         set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-        # RTX 4090 is sm_89 (Ada). Sirius requires sm_70+.
-        # CUDA 13 dropped sm_70 (Volta) — start at sm_75 (Turing).
-        # Build for a reasonable range; user can override via -DCMAKE_CUDA_ARCHITECTURES.
-        if(NOT CMAKE_CUDA_ARCHITECTURES)
-            set(CMAKE_CUDA_ARCHITECTURES "75;80;86;89;90")
-        endif()
         # Need the runtime library + headers for the .cpp host wrapper too.
         find_package(CUDAToolkit REQUIRED)
+        if(GPUDB_CUDA_STATIC_RUNTIME)
+            set(CMAKE_CUDA_RUNTIME_LIBRARY Static)
+        endif()
         set(GPUDB_HAS_CUDA ON)
-        message(STATUS "CUDA enabled (compiler: ${CMAKE_CUDA_COMPILER}, archs: ${CMAKE_CUDA_ARCHITECTURES}, toolkit: ${CUDAToolkit_VERSION})")
+        message(STATUS "CUDA enabled (compiler: ${CMAKE_CUDA_COMPILER}, archs: ${CMAKE_CUDA_ARCHITECTURES}, toolkit: ${CUDAToolkit_VERSION}, static runtime: ${GPUDB_CUDA_STATIC_RUNTIME})")
     else()
         message(STATUS "CUDA toolkit not found — CUDA backend disabled")
     endif()

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,29 @@ USE_UNSTABLE_C_API=0
 # into the extension metadata footer (FIELD3 duckdb_version).
 TARGET_DUCKDB_VERSION=v1.2.0
 
+# CUDA: auto-detected via nvcc. The registry's linux_amd64 build container
+# installs the CUDA toolchain when description.yml lists "cuda" in
+# requires_toolchains (extension-ci-tools docker/linux_amd64, ARG
+# extra_toolchains); plain containers and macOS have no nvcc and keep CUDA off,
+# so this is a no-op for every other job.
+#
+# GPUDB_CUDA_STATIC_RUNTIME=ON is the load-safety requirement, not an
+# optimization: the shipped .so must have NO dynamic dependency on
+# libcudart.so/libcuda.so (verify with ldd) so it LOADs on GPU-less machines;
+# cudart_static dlopens the driver at runtime and backend_factory falls back
+# to CPU when no device/driver is present. CUDA archs come from the CMake
+# default (75;80;86;89;90).
+NVCC := $(shell command -v nvcc 2>/dev/null)
+ifeq ($(NVCC),)
+GPUDB_CUDA_FLAGS=-DGPUDB_ENABLE_CUDA=OFF
+else
+GPUDB_CUDA_FLAGS=-DGPUDB_ENABLE_CUDA=ON -DGPUDB_CUDA_STATIC_RUNTIME=ON
+endif
+
 # CMake flags for the loadable-extension build path only.
 #   - GPUDB_BUILD_EXT=ON    : build the loadable extension target
 #   - TESTS/BENCH=OFF       : CI only wants the extension artifact
-#   - ENABLE_CUDA=OFF       : no CUDA toolchain wired into CI yet (phase 2);
-#                             Metal stays auto-on for APPLE (osx_arm64 job)
-CMAKE_EXTRA_BUILD_FLAGS=-DGPUDB_BUILD_EXT=ON -DGPUDB_BUILD_TESTS=OFF -DGPUDB_BUILD_BENCH=OFF -DGPUDB_ENABLE_CUDA=OFF
+CMAKE_EXTRA_BUILD_FLAGS=-DGPUDB_BUILD_EXT=ON -DGPUDB_BUILD_TESTS=OFF -DGPUDB_BUILD_BENCH=OFF $(GPUDB_CUDA_FLAGS)
 
 all: configure release
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,11 @@ if(GPUDB_HAS_CUDA)
     # calls, flip this to ON and add CUDA_RESOLVE_DEVICE_SYMBOLS to consumers.
     set_target_properties(gpudb PROPERTIES CUDA_SEPARABLE_COMPILATION OFF)
     # cudart is needed by the .cpp host wrapper (cuda_runtime.h, cudaMalloc, ...)
-    target_link_libraries(gpudb PUBLIC CUDA::cudart)
+    if(GPUDB_CUDA_STATIC_RUNTIME)
+        target_link_libraries(gpudb PUBLIC CUDA::cudart_static)
+    else()
+        target_link_libraries(gpudb PUBLIC CUDA::cudart)
+    endif()
     # Suppress diagnostics that nvcc's generated stubs trip on, only for .cu files.
     target_compile_options(gpudb PRIVATE
         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-Wno-pedantic>

--- a/src/backends/hybrid_planner.cpp
+++ b/src/backends/hybrid_planner.cpp
@@ -189,7 +189,19 @@ public:
             Backend::CPU, std::move(handle), n, Dtype::I64, /*on_gpu=*/false);
     }
     std::unique_ptr<ResidentColumn> upload_f64(const double* d, std::size_t n) override {
-        // f64 always lives on CPU side (no GPU dispatch for f64 anyway).
+        // CUDA supports f64 end-to-end (sum_f64 kernel + resident path), so
+        // f64 columns go to the device there. Metal has no IEEE-754 doubles —
+        // f64 stays CPU-side on that backend, same as before.
+        if (gpu_ && gpu_backend_ == Backend::CUDA) {
+            try {
+                auto handle = gpu_->upload_f64(d, n);
+                return std::make_unique<HybridResidentColumn>(
+                    Backend::CPU /* unused */, std::move(handle), n, Dtype::F64,
+                    /*on_gpu=*/true);
+            } catch (const std::exception&) {
+                // fall through to CPU upload
+            }
+        }
         auto handle = cpu_->upload_f64(d, n);
         return std::make_unique<HybridResidentColumn>(
             Backend::CPU, std::move(handle), n, Dtype::F64, /*on_gpu=*/false);
@@ -211,10 +223,13 @@ public:
         });
     }
     AggResult sum_resident_f64(const ResidentColumn& c) override {
-        const auto& h = check_hybrid(c);
-        last_ = make_decision(Backend::CPU, DispatchReason::F64_NoGpuDoubles,
-                              h.rows(), 0, /*resident*/true, /*borderline*/false);
-        return cpu_->sum_resident_f64(h.inner());
+        // The resident dispatch rule is dtype-agnostic: it routes to wherever
+        // the column lives. On Metal, upload_f64 never places data on the GPU
+        // (no doubles), so this still resolves to CPU there; on CUDA a
+        // GPU-resident f64 column dispatches GPU (Hot_GpuAlwaysWins).
+        return dispatch_resident_i64(c, [&](Aggregator& a, const ResidentColumn& cc){
+            return a.sum_resident_f64(cc);
+        });
     }
 
     // Multi-aggregate fusion (added in PR #8). Hybrid v1 delegates to CPU

--- a/src/extension/CMakeLists.txt
+++ b/src/extension/CMakeLists.txt
@@ -28,7 +28,8 @@ endif()
 
 add_library(gpudb_duckdb SHARED
     duckdb_loadable.cpp
-    gpu_sum_extension.cpp)
+    gpu_sum_extension.cpp
+    gpu_resident.cpp)
 
 target_include_directories(gpudb_duckdb PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -121,7 +122,7 @@ set(DUCKDB_LIBS_DIR "${CMAKE_SOURCE_DIR}/third_party/duckdb-libs")
 
 if(EXISTS "${DUCKDB_LIBS_DIR}/duckdb.h")
     # Compiled WITHOUT GPUDB_C_STRUCT_ABI: uses real duckdb.h + real libduckdb.
-    add_library(gpudb_ext STATIC gpu_sum_extension.cpp)
+    add_library(gpudb_ext STATIC gpu_sum_extension.cpp gpu_resident.cpp)
     target_include_directories(gpudb_ext PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${DUCKDB_LIBS_DIR})

--- a/src/extension/gpu_resident.cpp
+++ b/src/extension/gpu_resident.cpp
@@ -1,0 +1,481 @@
+// gpu_resident.cpp — resident-column SQL surface: the path where the GPU
+// actually wins.
+//
+// Public function:
+//   void register_gpu_resident(duckdb_connection con);   (called by
+//   register_gpu_sum, so both build paths pick these up automatically)
+//
+// Why this exists (and why the streaming aggregates in gpu_sum_extension.cpp
+// deliberately do NOT touch the GPU): a one-shot aggregate over cold data is
+// bounded by getting the data to the ALU — DuckDB's scan already streams the
+// column through the CPU caches, so copying it over PCIe just to reduce it
+// loses (BENCHMARK.md 2026-07-19, 3x-110x). The GPU's win is the HOT path:
+// pay the transfer ONCE, keep the column in device memory, and every
+// subsequent reduction runs at VRAM bandwidth with zero transfer. That is
+// exactly the ResidentColumn API in gpu_backend.hpp; these functions expose
+// it to SQL:
+//
+//   gpu_upload(name VARCHAR, v BIGINT) -> BIGINT     aggregate: buffer the
+//   gpu_upload(name VARCHAR, v DOUBLE) -> BIGINT     column, upload once,
+//                                                    return rows uploaded
+//   gpu_sum_resident(name)     -> BIGINT     reduce the resident column —
+//   gpu_min_resident(name)     -> BIGINT     no per-query transfer. i64 only:
+//   gpu_max_resident(name)     -> BIGINT     the v1 ABI has no resident f64
+//   gpu_sum_resident_f64(name) -> DOUBLE     min/max (see gpu_backend.hpp).
+//   gpu_resident_info(name)    -> VARCHAR    dtype/rows/device of a column
+//   gpu_last_stats()           -> VARCHAR    dispatch + timing of the last
+//                                            resident reduction (proof of
+//                                            which backend actually ran)
+//   gpu_drop_resident(name)    -> BOOLEAN    free the device memory
+//
+// Usage shape (single statement — the FROM subquery aggregates first, so the
+// upload completes before the projection reads it):
+//   SELECT gpu_sum_resident('l_qty') AS s
+//   FROM (SELECT gpu_upload('l_qty', l_quantity::BIGINT) FROM lineitem) u;
+// or interactively: upload once, then query the name many times.
+//
+// Dispatch goes through HybridAggregator: on a CUDA box the resident
+// reductions run on the GPU (DispatchReason::Hot_GpuAlwaysWins); on a
+// GPU-less machine everything transparently runs on the CPU backend — same
+// SQL, no errors, keeping the LOAD-anywhere guarantee.
+//
+// The gpu_upload aggregate state deliberately does NOT hold pointers: it is a
+// 16-byte POD {magic, buf_id} where buf_id keys a process-global pool. A
+// raw-byte state copy (contract #1 in gpu_sum_extension.cpp) duplicates the
+// id, not an owning pointer, so the copy still finds the buffer and a double
+// destroy is a harmless double-erase. combine() never mutates its source
+// (contract #3): it copies the source's buffered values into the target's
+// buffer.
+
+#include "gpu_sum_extension.hpp"
+#include "gpu_backend.hpp"
+
+#if defined(GPUDB_C_STRUCT_ABI)
+DUCKDB_EXTENSION_EXTERN
+#endif
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace gpudb_ext {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Process-global state. Function-local static => constructed on first use,
+// never at load time, so LOAD stays cheap and can't throw.
+// ---------------------------------------------------------------------------
+
+struct UploadBuf {
+    std::string               name;    // registry key, from the VARCHAR arg
+    gpudb::Dtype              dtype = gpudb::Dtype::I64;
+    std::vector<std::int64_t> i64;
+    std::vector<double>       f64;
+    std::size_t size() const { return dtype == gpudb::Dtype::I64 ? i64.size() : f64.size(); }
+};
+
+struct Globals {
+    std::mutex mu;
+    std::unique_ptr<gpudb::HybridAggregator> agg;                 // lazy
+    std::unordered_map<std::string,
+        std::unique_ptr<gpudb::ResidentColumn>> registry;         // name -> column
+    std::unordered_map<std::uint64_t, UploadBuf> pool;            // buf_id -> buffer
+    std::uint64_t next_id = 1;
+    std::string   last_stats = "no resident reduction has run yet";
+};
+
+Globals& g() {
+    static Globals instance;
+    return instance;
+}
+
+// Callers hold g().mu.
+gpudb::HybridAggregator& agg_locked() {
+    auto& G = g();
+    if (!G.agg) G.agg = gpudb::make_hybrid_aggregator();
+    return *G.agg;
+}
+
+void record_stats_locked(const char* op, const gpudb::AggResult& r) {
+    auto& G = g();
+    const auto& d = G.agg->last_decision();
+    char buf[256];
+    std::snprintf(buf, sizeof(buf),
+        "op=%s backend=%s reason=%s rows=%zu wall_ms=%.3f kernel_ms=%.3f transfer_ms=%.3f",
+        op, gpudb::to_string(d.chosen), gpudb::to_string(d.reason),
+        r.rows, r.wall_ms, r.kernel_ms, r.transfer_ms);
+    G.last_stats = buf;
+}
+
+// ---------------------------------------------------------------------------
+// gpu_upload aggregate.
+// ---------------------------------------------------------------------------
+
+struct UploadState {
+    static constexpr std::uint64_t kMagic = 0xB0FFE7C0FFEE0001ULL;
+    std::uint64_t magic;
+    std::uint64_t buf_id;   // 0 = no buffer yet; keys Globals::pool otherwise
+};
+
+idx_t upload_state_size(duckdb_function_info /*info*/) { return sizeof(UploadState); }
+
+void upload_state_init(duckdb_function_info /*info*/, duckdb_aggregate_state state) {
+    auto* s = reinterpret_cast<UploadState*>(state);
+    s->magic  = UploadState::kMagic;
+    s->buf_id = 0;
+}
+
+void upload_state_destroy(duckdb_aggregate_state* states, idx_t count) {
+    std::lock_guard<std::mutex> lock(g().mu);
+    for (idx_t i = 0; i < count; ++i) {
+        auto* s = reinterpret_cast<UploadState*>(states[i]);
+        if (!s || s->magic != UploadState::kMagic) continue;
+        if (s->buf_id != 0) g().pool.erase(s->buf_id);  // double-erase is a no-op
+        s->magic = 0;
+    }
+}
+
+inline UploadState* probe_upload_state(void* p) {
+    if (!p) return nullptr;
+    auto* s = reinterpret_cast<UploadState*>(p);
+    if (s->magic != UploadState::kMagic) return nullptr;
+    return s;
+}
+
+// Get (or create) the pool buffer for a state. Callers hold g().mu.
+UploadBuf& state_buf_locked(UploadState* s, gpudb::Dtype dt) {
+    auto& G = g();
+    if (s->buf_id == 0) {
+        s->buf_id = G.next_id++;
+        G.pool[s->buf_id].dtype = dt;
+    }
+    return G.pool[s->buf_id];
+}
+
+// Extract the row's VARCHAR cell as a std::string.
+inline std::string read_name(duckdb_string_t* names, idx_t row) {
+    return std::string(duckdb_string_t_data(&names[row]),
+                       duckdb_string_t_length(names[row]));
+}
+
+template <class T, gpudb::Dtype DT>
+void upload_update_t(duckdb_function_info /*info*/, duckdb_data_chunk input,
+                     duckdb_aggregate_state* states) {
+    duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
+    duckdb_vector val_vec  = duckdb_data_chunk_get_vector(input, 1);
+    auto* names = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(name_vec));
+    const T* data = reinterpret_cast<const T*>(duckdb_vector_get_data(val_vec));
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    if (!names || !data || n == 0) return;
+
+    uint64_t* name_validity = duckdb_vector_get_validity(name_vec);
+    uint64_t* val_validity  = duckdb_vector_get_validity(val_vec);
+
+    UploadState* s0 = probe_upload_state(states[0]);
+    if (!s0) return;
+
+    // Same constant-vector defense as gpu_sum_extension.cpp update_t: probe a
+    // few indices; any magic-word miss means only states[0] is real.
+    bool per_row = true;
+    if (n > 1) {
+        const idx_t probes[3] = { 1, n / 2, n - 1 };
+        for (idx_t k = 0; k < 3 && per_row; ++k) {
+            const idx_t i = probes[k];
+            if (i == 0) continue;
+            if (probe_upload_state(states[i]) == nullptr) per_row = false;
+        }
+    }
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    auto append_row = [&](UploadState* s, idx_t i) {
+        if (val_validity && !duckdb_validity_row_is_valid(val_validity, i)) return;
+        UploadBuf& b = state_buf_locked(s, DT);
+        if (b.name.empty() &&
+            (!name_validity || duckdb_validity_row_is_valid(name_validity, i))) {
+            b.name = read_name(names, i);
+        }
+        if (DT == gpudb::Dtype::I64) b.i64.push_back(static_cast<std::int64_t>(data[i]));
+        else                         b.f64.push_back(static_cast<double>(data[i]));
+    };
+
+    if (n == 1 || !per_row) {
+        for (idx_t i = 0; i < n; ++i) append_row(s0, i);
+    } else {
+        for (idx_t i = 0; i < n; ++i) {
+            UploadState* s = probe_upload_state(states[i]);
+            if (s) append_row(s, i);
+        }
+    }
+}
+
+void upload_combine(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
+                    duckdb_aggregate_state* target, idx_t count) {
+    // Contract #3: source is read-only (window donor states are combined into
+    // many targets). We COPY the source buffer's contents into the target's.
+    std::lock_guard<std::mutex> lock(g().mu);
+    auto& G = g();
+    for (idx_t i = 0; i < count; ++i) {
+        UploadState* src = probe_upload_state(source[i]);
+        UploadState* dst = probe_upload_state(target[i]);
+        if (!src || !dst || src == dst || src->buf_id == 0) continue;
+        auto it = G.pool.find(src->buf_id);
+        if (it == G.pool.end() || it->second.size() == 0) continue;
+        const UploadBuf& sb = it->second;
+        UploadBuf& db = state_buf_locked(dst, sb.dtype);
+        if (db.name.empty()) db.name = sb.name;
+        db.i64.insert(db.i64.end(), sb.i64.begin(), sb.i64.end());
+        db.f64.insert(db.f64.end(), sb.f64.begin(), sb.f64.end());
+    }
+}
+
+void upload_finalize(duckdb_function_info info, duckdb_aggregate_state* source,
+                     duckdb_vector result, idx_t count, idx_t offset) {
+    if (count == 0) return;
+    auto* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(result));
+    duckdb_vector_ensure_validity_writable(result);
+    uint64_t* validity = duckdb_vector_get_validity(result);
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    auto& G = g();
+    for (idx_t i = 0; i < count; ++i) {
+        UploadState* s = probe_upload_state(source[i]);
+        auto it = (s && s->buf_id != 0) ? G.pool.find(s->buf_id) : G.pool.end();
+        if (it == G.pool.end() || it->second.size() == 0) {
+            // No values buffered (empty input / all NULL) -> SQL NULL, no column.
+            out[offset + i] = 0;
+            duckdb_validity_set_row_invalid(validity, offset + i);
+            continue;
+        }
+        UploadBuf& b = it->second;
+        try {
+            auto& a = agg_locked();
+            std::unique_ptr<gpudb::ResidentColumn> col;
+            if (b.dtype == gpudb::Dtype::I64) col = a.upload_i64(b.i64.data(), b.i64.size());
+            else                              col = a.upload_f64(b.f64.data(), b.f64.size());
+            G.registry[b.name] = std::move(col);  // re-upload under a name replaces
+            out[offset + i] = static_cast<std::int64_t>(b.size());
+        } catch (const std::exception& e) {
+            duckdb_aggregate_function_set_error(info,
+                (std::string("gpu_upload failed: ") + e.what()).c_str());
+            return;
+        }
+        // Buffer stays in the pool until state_destroy — finalize must not
+        // mutate state, and destroy handles cleanup unconditionally.
+    }
+}
+
+duckdb_aggregate_function make_upload_fn(duckdb_type value_type,
+                                         duckdb_aggregate_update_t update) {
+    duckdb_aggregate_function fn = duckdb_create_aggregate_function();
+    duckdb_aggregate_function_set_name(fn, "gpu_upload");
+    duckdb_logical_type t_name = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+    duckdb_logical_type t_val  = duckdb_create_logical_type(value_type);
+    duckdb_logical_type t_ret  = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+    duckdb_aggregate_function_add_parameter(fn, t_name);
+    duckdb_aggregate_function_add_parameter(fn, t_val);
+    duckdb_aggregate_function_set_return_type(fn, t_ret);
+    duckdb_destroy_logical_type(&t_name);
+    duckdb_destroy_logical_type(&t_val);
+    duckdb_destroy_logical_type(&t_ret);
+    duckdb_aggregate_function_set_functions(fn,
+        upload_state_size, upload_state_init, update, upload_combine, upload_finalize);
+    duckdb_aggregate_function_set_destructor(fn, upload_state_destroy);
+    duckdb_aggregate_function_set_special_handling(fn);
+    return fn;
+}
+
+// ---------------------------------------------------------------------------
+// Resident scalar functions.
+// ---------------------------------------------------------------------------
+
+// Look up a registry column by the VARCHAR cell in input vector 0, row `row`.
+// Returns nullptr after setting a function error. Callers hold g().mu.
+gpudb::ResidentColumn* lookup_locked(duckdb_function_info info,
+                                     duckdb_string_t* names, uint64_t* validity,
+                                     idx_t row) {
+    if (validity && !duckdb_validity_row_is_valid(validity, row)) {
+        duckdb_scalar_function_set_error(info, "resident column name may not be NULL");
+        return nullptr;
+    }
+    std::string name = read_name(names, row);
+    auto it = g().registry.find(name);
+    if (it == g().registry.end()) {
+        duckdb_scalar_function_set_error(info,
+            ("no resident column named '" + name +
+             "' — create one with gpu_upload('" + name + "', <col>)").c_str());
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+// One body for the three BIGINT reductions, parameterized by member call.
+using ResidentOpI64 = gpudb::AggResult (gpudb::Aggregator::*)(const gpudb::ResidentColumn&);
+
+template <ResidentOpI64 OP>
+void resident_i64_exec(duckdb_function_info info, duckdb_data_chunk input,
+                       duckdb_vector output) {
+    duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
+    auto* names = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(name_vec));
+    uint64_t* validity = duckdb_vector_get_validity(name_vec);
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    auto* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(output));
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    for (idx_t i = 0; i < n; ++i) {
+        gpudb::ResidentColumn* col = lookup_locked(info, names, validity, i);
+        if (!col) return;
+        if (col->dtype() != gpudb::Dtype::I64) {
+            duckdb_scalar_function_set_error(info,
+                "resident column is DOUBLE — use gpu_sum_resident_f64 "
+                "(resident f64 min/max are not in the v1 backend ABI)");
+            return;
+        }
+        auto& a = agg_locked();
+        gpudb::AggResult r = (a.*OP)(*col);
+        record_stats_locked("resident_i64", r);
+        out[i] = r.value_i64;
+    }
+}
+
+void sum_resident_f64_exec(duckdb_function_info info, duckdb_data_chunk input,
+                           duckdb_vector output) {
+    duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
+    auto* names = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(name_vec));
+    uint64_t* validity = duckdb_vector_get_validity(name_vec);
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    auto* out = reinterpret_cast<double*>(duckdb_vector_get_data(output));
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    for (idx_t i = 0; i < n; ++i) {
+        gpudb::ResidentColumn* col = lookup_locked(info, names, validity, i);
+        if (!col) return;
+        if (col->dtype() != gpudb::Dtype::F64) {
+            duckdb_scalar_function_set_error(info,
+                "resident column is BIGINT — use gpu_sum_resident");
+            return;
+        }
+        auto& a = agg_locked();
+        gpudb::AggResult r = a.sum_resident_f64(*col);
+        record_stats_locked("sum_resident_f64", r);
+        out[i] = r.value_f64;
+    }
+}
+
+void resident_info_exec(duckdb_function_info info, duckdb_data_chunk input,
+                        duckdb_vector output) {
+    duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
+    auto* names = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(name_vec));
+    uint64_t* validity = duckdb_vector_get_validity(name_vec);
+    const idx_t n = duckdb_data_chunk_get_size(input);
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    for (idx_t i = 0; i < n; ++i) {
+        gpudb::ResidentColumn* col = lookup_locked(info, names, validity, i);
+        if (!col) return;
+        char buf[256];
+        std::snprintf(buf, sizeof(buf), "dtype=%s rows=%zu device=%s",
+            col->dtype() == gpudb::Dtype::I64 ? "I64" : "F64",
+            col->rows(), agg_locked().device_name().c_str());
+        duckdb_vector_assign_string_element(output, i, buf);
+    }
+}
+
+void last_stats_exec(duckdb_function_info /*info*/, duckdb_data_chunk input,
+                     duckdb_vector output) {
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    std::lock_guard<std::mutex> lock(g().mu);
+    for (idx_t i = 0; i < n; ++i) {
+        duckdb_vector_assign_string_element(output, i, g().last_stats.c_str());
+    }
+}
+
+void drop_resident_exec(duckdb_function_info info, duckdb_data_chunk input,
+                        duckdb_vector output) {
+    duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
+    auto* names = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(name_vec));
+    uint64_t* validity = duckdb_vector_get_validity(name_vec);
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    auto* out = reinterpret_cast<bool*>(duckdb_vector_get_data(output));
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    for (idx_t i = 0; i < n; ++i) {
+        if (validity && !duckdb_validity_row_is_valid(validity, i)) {
+            duckdb_scalar_function_set_error(info, "resident column name may not be NULL");
+            return;
+        }
+        out[i] = g().registry.erase(read_name(names, i)) > 0;
+    }
+}
+
+// Build + register one scalar function. All of these are volatile: their
+// result depends on the mutable resident registry, so DuckDB must not
+// constant-fold or cache them across calls.
+void register_scalar(duckdb_connection con, const char* name,
+                     duckdb_scalar_function_t exec,
+                     duckdb_type ret, bool takes_name) {
+    duckdb_scalar_function fn = duckdb_create_scalar_function();
+    duckdb_scalar_function_set_name(fn, name);
+    if (takes_name) {
+        duckdb_logical_type t_name = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+        duckdb_scalar_function_add_parameter(fn, t_name);
+        duckdb_destroy_logical_type(&t_name);
+    }
+    duckdb_logical_type t_ret = duckdb_create_logical_type(ret);
+    duckdb_scalar_function_set_return_type(fn, t_ret);
+    duckdb_destroy_logical_type(&t_ret);
+    duckdb_scalar_function_set_volatile(fn);
+    duckdb_scalar_function_set_function(fn, exec);
+    duckdb_state st = duckdb_register_scalar_function(con, fn);
+    duckdb_destroy_scalar_function(&fn);
+    if (st == DuckDBError) {
+        throw std::runtime_error(std::string(name) + " registration failed");
+    }
+}
+
+} // namespace
+
+void register_gpu_resident(duckdb_connection con) {
+    // gpu_upload overload set: (VARCHAR, BIGINT) and (VARCHAR, DOUBLE).
+    duckdb_aggregate_function_set set = duckdb_create_aggregate_function_set("gpu_upload");
+    duckdb_aggregate_function fn_i64 =
+        make_upload_fn(DUCKDB_TYPE_BIGINT, upload_update_t<std::int64_t, gpudb::Dtype::I64>);
+    duckdb_aggregate_function fn_f64 =
+        make_upload_fn(DUCKDB_TYPE_DOUBLE, upload_update_t<double, gpudb::Dtype::F64>);
+    duckdb_state a1 = duckdb_add_aggregate_function_to_set(set, fn_i64);
+    duckdb_state a2 = duckdb_add_aggregate_function_to_set(set, fn_f64);
+    duckdb_destroy_aggregate_function(&fn_i64);
+    duckdb_destroy_aggregate_function(&fn_f64);
+    if (a1 == DuckDBError || a2 == DuckDBError) {
+        duckdb_destroy_aggregate_function_set(&set);
+        throw std::runtime_error("gpu_upload overload set assembly failed");
+    }
+    duckdb_state st = duckdb_register_aggregate_function_set(con, set);
+    duckdb_destroy_aggregate_function_set(&set);
+    if (st == DuckDBError) {
+        throw std::runtime_error("gpu_upload function set registration failed");
+    }
+
+    register_scalar(con, "gpu_sum_resident",
+        resident_i64_exec<&gpudb::Aggregator::sum_resident_i64>, DUCKDB_TYPE_BIGINT, true);
+    register_scalar(con, "gpu_min_resident",
+        resident_i64_exec<&gpudb::Aggregator::min_resident_i64>, DUCKDB_TYPE_BIGINT, true);
+    register_scalar(con, "gpu_max_resident",
+        resident_i64_exec<&gpudb::Aggregator::max_resident_i64>, DUCKDB_TYPE_BIGINT, true);
+    register_scalar(con, "gpu_sum_resident_f64",
+        sum_resident_f64_exec, DUCKDB_TYPE_DOUBLE, true);
+    register_scalar(con, "gpu_resident_info",
+        resident_info_exec, DUCKDB_TYPE_VARCHAR, true);
+    register_scalar(con, "gpu_drop_resident",
+        drop_resident_exec, DUCKDB_TYPE_BOOLEAN, true);
+    register_scalar(con, "gpu_last_stats",
+        last_stats_exec, DUCKDB_TYPE_VARCHAR, false);
+}
+
+} // namespace gpudb_ext

--- a/src/extension/gpu_sum_extension.cpp
+++ b/src/extension/gpu_sum_extension.cpp
@@ -424,8 +424,10 @@ void register_gpu_sum(duckdb_connection con) {
     register_set<OpSumI64, OpSumF64>(con, "gpu_sum");
     register_set<OpMinI64, OpMinF64>(con, "gpu_min");
     register_set<OpMaxI64, OpMaxF64>(con, "gpu_max");
+    register_gpu_resident(con);
     std::fprintf(stderr,
-        "[gpudb] registered gpu_sum / gpu_min / gpu_max (BIGINT,DOUBLE) streaming aggregates (backend=%s)\n",
+        "[gpudb] registered gpu_sum / gpu_min / gpu_max streaming aggregates "
+        "+ resident-column functions (gpu_upload, gpu_*_resident) (backend=%s)\n",
         gpudb::to_string(gpudb::default_backend()));
 }
 

--- a/src/extension/gpu_sum_extension.hpp
+++ b/src/extension/gpu_sum_extension.hpp
@@ -28,4 +28,12 @@ namespace gpudb_ext {
 // std::runtime_error if registration fails.
 void register_gpu_sum(duckdb_connection con);
 
+// Register the resident-column SQL surface (gpu_upload, gpu_sum_resident,
+// gpu_min_resident, gpu_max_resident, gpu_sum_resident_f64, gpu_resident_info,
+// gpu_last_stats, gpu_drop_resident) — the upload-once/query-many path where
+// reductions actually run on the GPU (via HybridAggregator; transparently CPU
+// on GPU-less machines). Called by register_gpu_sum; exposed separately for
+// tests. Implementation: gpu_resident.cpp.
+void register_gpu_resident(duckdb_connection con);
+
 } // namespace gpudb_ext

--- a/test/sql/gpu_resident.test
+++ b/test/sql/gpu_resident.test
@@ -1,0 +1,66 @@
+# gpu_resident SQL test — resident-column SQL surface (gpu_upload +
+# gpu_*_resident + gpu_drop_resident).
+#
+# The suite runs each query in a FRESH gpudb-sql process, so the resident
+# registry does not survive between queries. Every test therefore uploads and
+# queries in ONE statement: the FROM subquery aggregates (upload completes)
+# before the outer projection reads the resident column.
+#
+# IMPORTANT: every outer query MUST reference the subquery's upload count `u`.
+# If `u` is unused, DuckDB's unused-column elimination prunes the gpu_upload
+# aggregate expression entirely and the resident column is never created.
+#
+# Run via: ./scripts/run_sql_tests.sh gpu_resident
+
+-- 1. Upload + resident SUM over 100k rows (matches native sum(range) value)
+SELECT gpu_sum_resident('t1') AS s, u AS uploaded
+FROM (SELECT gpu_upload('t1', range::BIGINT) AS u FROM range(100000)) up;
+-- expect: 4999950000  100000
+
+-- 2. Resident MIN and MAX in one projection (both read the same column)
+SELECT gpu_min_resident('t2') AS mn, gpu_max_resident('t2') AS mx, u AS uploaded
+FROM (SELECT gpu_upload('t2', (range - 500)::BIGINT) AS u FROM range(1000)) up;
+-- expect: -500  499  1000
+
+-- 3. DOUBLE column: upload + resident f64 SUM (sum of 0..999 halved = 249750)
+SELECT gpu_sum_resident_f64('t3')::BIGINT AS s, u AS uploaded
+FROM (SELECT gpu_upload('t3', (range / 2.0)::DOUBLE) AS u FROM range(1000)) up;
+-- expect: 249750  1000
+
+-- 4. NULLs are skipped at upload: only non-NULL values reach the column
+SELECT gpu_sum_resident('t4') AS s, u AS uploaded
+FROM (SELECT gpu_upload('t4', CASE WHEN range % 2 = 0 THEN range ELSE NULL END::BIGINT) AS u
+      FROM range(10)) up;
+-- expect: 20  5
+
+-- 5. Resident result equals the native aggregate over the same data
+SELECT gpu_sum_resident('t5') = (SELECT sum(range::BIGINT) FROM range(50000)) AS matches,
+       u AS uploaded
+FROM (SELECT gpu_upload('t5', range::BIGINT) AS u FROM range(50000)) up;
+-- expect: true  50000
+
+-- 6. gpu_resident_info reports dtype and row count (prefix-checked via LIKE)
+SELECT gpu_resident_info('t6') LIKE 'dtype=I64 rows=777 %' AS ok, u AS uploaded
+FROM (SELECT gpu_upload('t6', range::BIGINT) AS u FROM range(777)) up;
+-- expect: true  777
+
+-- 7. gpu_drop_resident frees the column and reports whether it existed
+SELECT gpu_drop_resident('t7') AS dropped,
+       gpu_drop_resident('never_uploaded') AS missing,
+       u AS uploaded
+FROM (SELECT gpu_upload('t7', range::BIGINT) AS u FROM range(10)) up;
+-- expect: true  false  10
+
+-- 8. gpu_last_stats records the dispatch of the most recent resident reduction
+--    (100k rows: CUDA box → backend=CUDA reason=Hot_GpuAlwaysWins; GPU-less →
+--    backend=CPU. Only assert the stats string has the expected shape.)
+SELECT s AS sum_100k, gpu_last_stats() LIKE 'op=resident_i64 backend=%' AS stats_ok,
+       u AS uploaded
+FROM (SELECT gpu_sum_resident('t8') AS s, u
+      FROM (SELECT gpu_upload('t8', (range + 1)::BIGINT) AS u FROM range(100000)) up) q;
+-- expect: 5000050000  true  100000
+
+-- 9. Empty upload (zero non-NULL values) returns SQL NULL and registers nothing
+SELECT u IS NULL AS was_null
+FROM (SELECT gpu_upload('t9', range::BIGINT) AS u FROM range(0)) up;
+-- expect: true


### PR DESCRIPTION
## What

Two commits that together make the registry-shipped Linux extension genuinely GPU-powered:

### 1. CUDA-enabled community-CI build (`3a3b311`)
- **Root Makefile**: auto-detects `nvcc` and enables the CUDA backend for the loadable-extension build when present. No nvcc → identical CPU-only build as today (macOS job and plain containers untouched). This is what lets the registry ship a CUDA-enabled `gpudb.linux_amd64.duckdb_extension` once Phase B (`description.yml` `requires_toolchains`) lands.
- **New CMake option `GPUDB_CUDA_STATIC_RUNTIME`** (Makefile path turns it ON): links `CUDA::cudart_static`, so the shipped `.so` has **no dynamic dependency on libcudart.so/libcuda.so**. On GPU-less/driver-less machines `cuda_runtime_available()` returns false and everything falls back to CPU. LOAD never fails.
- **Bug fix**: `CMAKE_CUDA_ARCHITECTURES` default was set *after* `enable_language(CUDA)` — the guard never fired and every build shipped **sm_75-only** fatbins. Now all five archs (75/80/86/89/90) are embedded; `CUDAARCHS` env (the registry hook) and `-D` override respected. Wipe local `build-linux/` once to pick up all archs.

### 2. Resident-column SQL surface (`db758a9`) — the actual CUDA execution
The streaming `gpu_sum/min/max` aggregates stay CPU-side **by design** (per-query buffering lost 3x–110x, BENCHMARK.md 2026-07-19). The GPU's real win is upload-once/query-many, now exposed to SQL:

```sql
SELECT gpu_upload('v', v) FROM t;          -- one-time: buffer + upload to VRAM
SELECT gpu_sum_resident('v');              -- every query after: VRAM-bandwidth reduction,
SELECT gpu_min_resident('v');              --   zero transfer
SELECT gpu_last_stats();                   -- proof: backend/reason/kernel_ms
SELECT gpu_drop_resident('v');             -- free device memory
```
Plus `gpu_max_resident`, `gpu_sum_resident_f64`, `gpu_resident_info`. Dispatch via `HybridAggregator` (`Hot_GpuAlwaysWins` when device-resident; transparent CPU when no GPU). `hybrid_planner.cpp` (shared, minimal diff): f64 upload/resident-sum now dispatch to CUDA (full f64 support there); **Metal behavior unchanged** — f64 stays CPU on that backend.

State safety: `gpu_upload`'s state is a 16-byte POD `{magic, buf_id}` keying a process-global pool — raw-byte state copies (contract #1) duplicate an id, not an owning pointer; `combine()` never mutates its source (contract #3).

## Measured (RTX 4090, DuckDB CLI v1.5.2, 10M-row BIGINT column)

| Query | Time |
|---|---|
| native `sum(v)` | 14 ms |
| `gpu_sum_resident('v')` (after upload) | **1 ms** wall — kernel 0.154 ms, transfer 0.000 ms |
| dispatch | `backend=CUDA reason=Hot_GpuAlwaysWins` |

## Verification matrix

- **Registry container reproduction**: exact extension-ci-tools `docker/linux_amd64` image (`extra_toolchains=";cuda;python3;"`), `make configure && make release` inside — artifact 1.62 MB, fatbins for all 5 archs, `readelf` NEEDED has **no CUDA libs**.
- **Driver-less container** (no libcuda on disk): LOAD ok, full resident workflow runs on CPU (`reason=GpuUnavailable`), correct results.
- **4090 host**: LOAD ok, `backend=CUDA`, resident + streaming results correct.
- **Test suites**: unit 77/77; SQL 69/69 across 6 files including new `test/sql/gpu_resident.test` (9 queries: upload, sum/min/max, f64, NULL-skip, native-match, info, drop, stats, empty input).

Phase B (community-extensions `description.yml`: `requires_toolchains: "python3;cuda"` + ref bump) is a separate follow-up PR, gated on approval.
