### PR TITLE
fix(build): CUDA CI hardening — CUDAARCHS empty-guard, x86_64 gate, symbol hiding

### DIFF
--- a/.sync/duckdbgpumetaldb.md
+++ b/.sync/duckdbgpumetaldb.md
@@ -1,6 +1,6 @@
 # duckdbgpumetaldb
-- branch: docs/claude-md-build-and-arch
-- working on: docs branch off v0.3.0 main: adding build/test commands + architecture sections to CLAUDE.md (shared file, PR-only)
+- branch: fix/core-cuda-ci-hardening
+- working on: fix/core-cuda-ci-hardening: e/f/g build-system fixes verified (CUDAARCHS empty-guard, x86_64 gate, --exclude-libs); PR going up
 - status: in_progress
 - blocked on: nothing
-- last update: 2026-08-14T18:05:17Z
+- last update: 2026-08-15T00:27:36Z

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,11 @@ if(GPUDB_ENABLE_CUDA)
         # CMAKE_CUDA_ARCHITECTURES to nvcc's single default arch, after which a
         # `if(NOT ...)` guard never fires (that bug shipped sm_75-only fatbins).
         # Overridable via -DCMAKE_CUDA_ARCHITECTURES or the CUDAARCHS env var.
-        if(NOT CMAKE_CUDA_ARCHITECTURES AND NOT DEFINED ENV{CUDAARCHS})
+        # CUDAARCHS must be treated as unset when DEFINED-BUT-EMPTY: the
+        # extension-ci-tools pipeline injects an empty CUDAARCHS into the build
+        # container, and CMake ignores an empty value — a `NOT DEFINED` guard
+        # would then skip our default and ship a single-arch fatbin again.
+        if(NOT CMAKE_CUDA_ARCHITECTURES AND "$ENV{CUDAARCHS}" STREQUAL "")
             set(CMAKE_CUDA_ARCHITECTURES "75;80;86;89;90")
         endif()
         enable_language(CUDA)

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,17 @@ USE_UNSTABLE_C_API=0
 # into the extension metadata footer (FIELD3 duckdb_version).
 TARGET_DUCKDB_VERSION=v1.2.0
 
-# CUDA: auto-detected via nvcc. The registry's linux_amd64 build container
-# installs the CUDA toolchain when description.yml lists "cuda" in
-# requires_toolchains (extension-ci-tools docker/linux_amd64, ARG
-# extra_toolchains); plain containers and macOS have no nvcc and keep CUDA off,
-# so this is a no-op for every other job.
+# CUDA: auto-detected via nvcc, x86_64 only. NOTE the registry does NOT
+# currently provide nvcc: community-extensions pins extension-ci-tools to a
+# branch (v1.5-variegata) with no CUDA toolchain support, so its containers
+# never have nvcc and this stays OFF there. The "cuda" extra_toolchains token
+# exists only on extension-ci-tools main (unreleased); when the registry's pin
+# moves and description.yml lists cuda in requires_toolchains, this auto-flips
+# ON with no further changes here.
+#
+# The uname gate exists because a future cuda-capable ci-tools would also
+# install the sbsa toolkit on linux_arm64 — an aarch64 CUDA build we have
+# never validated. Lift the gate once sbsa is actually tested.
 #
 # GPUDB_CUDA_STATIC_RUNTIME=ON is the load-safety requirement, not an
 # optimization: the shipped .so must have NO dynamic dependency on
@@ -41,7 +47,10 @@ TARGET_DUCKDB_VERSION=v1.2.0
 # to CPU when no device/driver is present. CUDA archs come from the CMake
 # default (75;80;86;89;90).
 NVCC := $(shell command -v nvcc 2>/dev/null)
+UNAME_M := $(shell uname -m)
 ifeq ($(NVCC),)
+GPUDB_CUDA_FLAGS=-DGPUDB_ENABLE_CUDA=OFF
+else ifneq ($(UNAME_M),x86_64)
 GPUDB_CUDA_FLAGS=-DGPUDB_ENABLE_CUDA=OFF
 else
 GPUDB_CUDA_FLAGS=-DGPUDB_ENABLE_CUDA=ON -DGPUDB_CUDA_STATIC_RUNTIME=ON

--- a/src/extension/CMakeLists.txt
+++ b/src/extension/CMakeLists.txt
@@ -49,6 +49,15 @@ set_target_properties(gpudb_duckdb PROPERTIES
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON)
 
+# Visibility presets only cover our own TUs. Statically linked archives —
+# cudart_static above all — would still export their whole API from the .so,
+# and under ELF interposition a host process with its own libcudart (any
+# python CUDA stack) could cross-bind into ours. Strip them from the dynamic
+# symbol table wholesale.
+if(UNIX AND NOT APPLE)
+    target_link_options(gpudb_duckdb PRIVATE "LINKER:--exclude-libs,ALL")
+endif()
+
 # Output naming / location.
 #   - CI path (extension-ci-tools Makefile passes -DEXTENSION_NAME): emit
 #     lib<EXTENSION_NAME>.<suffix> at the top-level build dir, exactly where the


### PR DESCRIPTION
Three build-system fixes from the pre-v0.4.0 adversarial review (findings e, f, g). Scoped to build files only per the agreed work split — the extension/semantics findings (a–d, h–j) ride on the macOS session's `feat/ext-resident-hardening`.

## e — CUDAARCHS empty-guard (latent single-arch regression)

The extension-ci-tools pipeline (`ci_phase.py`) injects `CUDAARCHS` as a **defined-but-empty** env var into the build container. CMake ignores an empty `CUDAARCHS`, but our previous guard `if(NOT CMAKE_CUDA_ARCHITECTURES AND NOT DEFINED ENV{CUDAARCHS})` saw it as *defined* and skipped the `75;80;86;89;90` default — reintroducing the exact single-arch-fatbin bug #57 fixed. Now empty is treated as unset.

Verified: `CUDAARCHS="" cmake ...` → `archs: 75;80;86;89;90`; `CUDAARCHS=86` → `archs: 86` (override still respected).

## f — Makefile CUDA auto-enable gated on x86_64

A future cuda-capable ci-tools installs the sbsa CUDA toolkit on linux_arm64, which would silently flip on an aarch64 CUDA build we have never validated. The Makefile now enables CUDA only when `nvcc` exists **and** `uname -m` is `x86_64` (comment says to lift the gate once sbsa is actually tested).

Also corrects the Makefile comment that claimed the registry container installs CUDA via `requires_toolchains` — false today: community-extensions pins extension-ci-tools `v1.5-variegata`, which has no CUDA toolchain support; the `cuda` token exists only on unreleased ci-tools main.

Verified: `x86_64` → `-DGPUDB_ENABLE_CUDA=ON -DGPUDB_CUDA_STATIC_RUNTIME=ON`; `aarch64` → `-DGPUDB_ENABLE_CUDA=OFF`.

## g — `-Wl,--exclude-libs,ALL` on the Linux extension link

Visibility presets only cover our own TUs; the statically linked CUDA runtime still exported its API from the shipped `.so`. A host process with its own libcudart (any python CUDA stack) could cross-bind into ours under ELF interposition.

Measured on the same objects: **before** 62 exported dynamic symbols (17 `cuda*`); **after** 3 exported symbols, 0 `cuda*`, `gpudb_init` entrypoint intact, NEEDED still clean of all CUDA libs.

## Verification

- Fresh configure + build on RTX 4090 (CUDA 13.0.88), all five arch fatbins
- `readelf -d`: NEEDED = libgomp/libstdc++/libgcc_s/libc/ld-linux only
- Packaged `gpudb.linux_amd64.duckdb_extension` LOADs in DuckDB CLI; `gpu_sum` over 1M rows returns 499999500000
