### PR TITLE
fix(ext): resident-surface hardening — pool cap, name guards, truthful stats, parallel host f64

### DIFF
--- a/.sync/duckdbgpumetaldbram.md
+++ b/.sync/duckdbgpumetaldbram.md
@@ -1,6 +1,6 @@
 # duckdbgpumetaldbram
 - branch: main
-- working on: (work complete) — merged #53 (CI recipes + Colab notebook) and #54 (CLAUDE.md docs) to main
-- status: done
-- blocked on: nothing
-- last update: 2026-08-14T18:55:00Z
+- working on: adversarial review of c7e0db5 complete (3 reviewers); findings dispatched to Linux instance's fix branch; v0.4.0 tag held until fixes merge
+- status: in_progress
+- blocked on: linux instance fix PR
+- last update: 2026-08-15T01:20:00Z

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -17,6 +17,8 @@ Built from `feat/ext-resident-hardening` (includes the parallel host f64 path).
 
 | Query (whole column) | Scale | native | resident e2e | internal wall / kernel | ratio |
 |---|---|---:|---:|---|:---:|
+| `sum(l_quantity::BIGINT)` | SF25 (150.0M) | 23 ms | **3 ms** | 2.88 ms / 2.69 ms (Metal) | **7.7×** |
+| `sum(l_extendedprice::DOUBLE)` | SF25 | 28 ms | **8 ms** | 9.1 ms (host, parallel) | **3.5×** |
 | `sum(l_quantity::BIGINT)` | SF10 (60.0M) | 9 ms | **2 ms** | 1.48 ms / 1.31 ms (Metal) | **4.5×** |
 | `sum(l_extendedprice::DOUBLE)` | SF10 | 11 ms | **3 ms** | 3.46 ms (host, parallel) | **3.4×** |
 | `sum(l_quantity::BIGINT)` | SF1 (6.0M) | 1 ms | 1 ms | 0.34 ms / 0.20 ms (Metal) | parity e2e* |
@@ -25,9 +27,14 @@ Built from `feat/ext-resident-hardening` (includes the parallel host f64 path).
 \* at SF1 both sides finish ≈1 ms — per-statement CLI overhead dominates; the
 internal wall shows the reduction itself is ~3–5× faster.
 
-One-time `gpu_upload` cost: SF1 70 ms · SF10 i64 725 ms / f64 725 ms →
-break-even vs native ≈ **110 repeated sums at SF10**, then every query is
-~7–8 ms cheaper forever. Honest losing rows: unfiltered `min`/`max` on
+The gap WIDENS with scale — native's scan grows linearly while the Metal
+kernel tracks VRAM bandwidth: SF25's 150M-row sum runs the kernel at
+~446 GB/s (2.69 ms for 1.2 GB), approaching the M4 Max's ~546 GB/s ceiling.
+Ratio progression: ~1× (SF1, overhead-bound) → 4.5× (SF10) → 7.7× (SF25).
+
+One-time `gpu_upload` cost: SF1 70 ms · SF10 725 ms · SF25 i64 1.99 s /
+f64 2.09 s → break-even vs native ≈ **110 repeated sums at SF10, ~100 at
+SF25**, then every query is ~7–20 ms cheaper forever. Honest losing rows: unfiltered `min`/`max` on
 persistent tables (native answers from zonemap statistics without scanning —
 resident min/max still run a real 1–2 ms reduction) and any one-shot query
 (that is what the streaming parity path is for).

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -2,6 +2,66 @@
 
 Append-only. Reproducible runs only — include hardware, CUDA toolkit, build flags.
 
+## 2026-08-15 (v0.4.0) — resident-column SQL surface: the GPU wins from SQL
+
+First benchmark of the `gpu_upload` / `gpu_*_resident` SQL functions (merged in
+PR #57, hardened in the follow-up PRs). Methodology as always: DuckDB CLI
+`-unsigned -readonly`, `SET threads TO 16`, `.timer on`, warm OS cache, median
+of 5 timed runs after 1 warm-up. The resident model: `gpu_upload` pays the
+transfer once; every later reduction runs against device/host-resident memory
+with `transfer_ms=0.000` (assert with `gpu_last_stats()`).
+
+### Apple M4 Max (Metal), DuckDB CLI v1.5.5, TPC-H `lineitem`
+
+Built from `feat/ext-resident-hardening` (includes the parallel host f64 path).
+
+| Query (whole column) | Scale | native | resident e2e | internal wall / kernel | ratio |
+|---|---|---:|---:|---|:---:|
+| `sum(l_quantity::BIGINT)` | SF10 (60.0M) | 9 ms | **2 ms** | 1.48 ms / 1.31 ms (Metal) | **4.5×** |
+| `sum(l_extendedprice::DOUBLE)` | SF10 | 11 ms | **3 ms** | 3.46 ms (host, parallel) | **3.4×** |
+| `sum(l_quantity::BIGINT)` | SF1 (6.0M) | 1 ms | 1 ms | 0.34 ms / 0.20 ms (Metal) | parity e2e* |
+| `sum(l_extendedprice::DOUBLE)` | SF1 | 1 ms | 1 ms | 0.39 ms (host, parallel) | parity e2e* |
+
+\* at SF1 both sides finish ≈1 ms — per-statement CLI overhead dominates; the
+internal wall shows the reduction itself is ~3–5× faster.
+
+One-time `gpu_upload` cost: SF1 70 ms · SF10 i64 725 ms / f64 725 ms →
+break-even vs native ≈ **110 repeated sums at SF10**, then every query is
+~7–8 ms cheaper forever. Honest losing rows: unfiltered `min`/`max` on
+persistent tables (native answers from zonemap statistics without scanning —
+resident min/max still run a real 1–2 ms reduction) and any one-shot query
+(that is what the streaming parity path is for).
+
+f64-on-Metal note: resident f64 runs on the host (no doubles in MSL). Before
+the parallel host path this LOST to native 29 ms vs 11 ms; the chunked
+parallel reduction in this branch flipped it to 3 ms. `gpu_last_stats()` now
+reports `reason=Resident_OnCpu` for this case (was misleadingly
+`Hot_GpuAlwaysWins`).
+
+### NVIDIA RTX 4090 Laptop (sm_89, 16 GB, CUDA 13), DuckDB CLI v1.5.2
+
+Reported by the Linux instance from `fix/core-cuda-ci-hardening` (extension
+code identical to `main` @ c7e0db5); same methodology, 5-run medians.
+
+| Query (whole column) | Rows | native | resident e2e | internal wall / kernel | ratio |
+|---|---|---:|---:|---|:---:|
+| `sum(BIGINT)` | 100M | 40 ms | **2 ms** | 1.48 ms / 1.45 ms | **~20×** |
+| TPC-H SF1 `sum(l_quantity)` | 6M | 10 ms | **~1 ms** | 0.087 ms / 0.042 ms | **~10×** |
+| `sum(DOUBLE)` | 10M | 10 ms | **~1 ms** | 0.20 ms / 0.17 ms | **~10×** (f64 on-GPU, unlike Metal) |
+| `min`+`max(BIGINT)` | 10M | 10–22 ms | **~1 ms** | — | **~10–20×** |
+| `sum(BIGINT)` | 10M | 8 ms | ~6 ms | 0.20 ms / 0.16 ms | parity e2e* |
+
+\* same SF1-class caveat: ~5 ms per-statement CLI overhead hides a 40× kernel win.
+
+Upload cost: 6M 196 ms · 10M i64 618 ms · 10M f64 390 ms · 100M 3.39 s →
+break-even ≈ 22 queries (6M) to ≈ 90 queries (100M).
+
+Library-level (`gpudb-bench`, no SQL overhead): 100M HOT CPU (OpenMP, 20T)
+30–42 ms vs CUDA 1.44 ms at 522 GiB/s ≈ spec VRAM bandwidth — **21–29×**.
+COLD still loses on CUDA exactly as documented since v0.2.0 (100M: 81.5 ms,
+of which 80 ms is PCIe) — the hybrid planner correctly dispatches cold
+one-shot reductions to the CPU.
+
 ## 2026-07-19 (v0.3.0) — streaming aggregate rewrite: end-to-end parity with native
 
 Re-run of the exact end-to-end suite from the v0.2.0 section below (same queries, same

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -11,30 +11,49 @@ of 5 timed runs after 1 warm-up. The resident model: `gpu_upload` pays the
 transfer once; every later reduction runs against device/host-resident memory
 with `transfer_ms=0.000` (assert with `gpu_last_stats()`).
 
-### Apple M4 Max (Metal), DuckDB CLI v1.5.5, TPC-H `lineitem`
+### Apple M4 Max (Metal), DuckDB CLI v1.5.5, TPC-H `lineitem`, SF1→SF100
 
-Built from `feat/ext-resident-hardening` (includes the parallel host f64 path).
+Built from `feat/ext-resident-hardening`. Six scale levels (6M → 600M rows,
+stepwise dbgen for SF50/SF100), six columns, mean of 5 warm runs per cell
+after 1 warm-up; every level passed a correctness gate (resident == native
+for every measured column) before its timings counted. SF100 ran with
+`GPUDB_UPLOAD_POOL_MAX_MB=32768` (the 4.8 GB per-column upload exceeds the
+default 4 GB pool cap — the guardrail and its documented escape hatch both
+work end-to-end).
 
-| Query (whole column) | Scale | native | resident e2e | internal wall / kernel | ratio |
-|---|---|---:|---:|---|:---:|
-| `sum(l_quantity::BIGINT)` | SF25 (150.0M) | 23 ms | **3 ms** | 2.88 ms / 2.69 ms (Metal) | **7.7×** |
-| `sum(l_extendedprice::DOUBLE)` | SF25 | 28 ms | **8 ms** | 9.1 ms (host, parallel) | **3.5×** |
-| `sum(l_quantity::BIGINT)` | SF10 (60.0M) | 9 ms | **2 ms** | 1.48 ms / 1.31 ms (Metal) | **4.5×** |
-| `sum(l_extendedprice::DOUBLE)` | SF10 | 11 ms | **3 ms** | 3.46 ms (host, parallel) | **3.4×** |
-| `sum(l_quantity::BIGINT)` | SF1 (6.0M) | 1 ms | 1 ms | 0.34 ms / 0.20 ms (Metal) | parity e2e* |
-| `sum(l_extendedprice::DOUBLE)` | SF1 | 1 ms | 1 ms | 0.39 ms (host, parallel) | parity e2e* |
+`sum` — native / resident e2e / ratio, per level (ms):
 
-\* at SF1 both sides finish ≈1 ms — per-statement CLI overhead dominates; the
-internal wall shows the reduction itself is ~3–5× faster.
+| Column | SF1 · 6M | SF5 · 30M | SF10 · 60M | SF25 · 150M | SF50 · 300M | SF100 · 600M |
+|---|---|---|---|---|---|---|
+| `l_quantity::BIGINT`¹ | 1.2 / 0.6 / **2.0×** | 5.0 / 1.0 / **5.0×** | 9.6 / 1.4 / **6.9×** | 23.2 / 3.4 / **6.8×** | 45.8 / 5.4 / **8.5×** | 99.0 / 10.0 / **9.9×** |
+| `l_orderkey` (BIGINT) | 0.6 / 0.6 / 1.0× | 2.0 / 1.0 / **2.0×** | 3.8 / 1.6 / **2.4×** | 9.4 / 2.6 / **3.6×** | 18.6 / 5.0 / **3.7×** | — |
+| `l_partkey` (BIGINT) | 0.4 / 0.4 / 1.0× | 1.8 / 1.0 / **1.8×** | 3.4 / 1.6 / **2.1×** | 8.8 / 2.6 / **3.4×** | 16.6 / 5.0 / **3.3×** | — |
+| `l_extendedprice::DOUBLE`¹ | 1.4 / 0.6 / **2.3×** | 5.6 / 1.8 / **3.1×** | 12.6 / 3.4 / **3.7×** | 28.4 / 8.8 / **3.2×** | 54.8 / 15.6 / **3.5×** | 116.8 / 28.2 / **4.1×** |
+| `l_discount::DOUBLE`¹ | 1.2 / 0.4 / **3.0×** | 5.2 / 1.8 / **2.9×** | 10.2 / 3.4 / **3.0×** | 26.0 / 7.6 / **3.4×** | 50.4 / 15.4 / **3.3×** | — |
+| `l_tax::DOUBLE`¹ | 1.4 / 0.4 / **3.5×** | 5.2 / 1.6 / **3.2×** | 10.2 / 3.6 / **2.8×** | 26.4 / 7.6 / **3.5×** | 50.4 / 15.2 / **3.3×** | — |
 
-The gap WIDENS with scale — native's scan grows linearly while the Metal
-kernel tracks VRAM bandwidth: SF25's 150M-row sum runs the kernel at
-~446 GB/s (2.69 ms for 1.2 GB), approaching the M4 Max's ~546 GB/s ceiling.
-Ratio progression: ~1× (SF1, overhead-bound) → 4.5× (SF10) → 7.7× (SF25).
+¹ these TPC-H columns are stored DECIMAL; the native query pays the
+DECIMAL→BIGINT/DOUBLE cast on every scan, while `gpu_upload` stores the cast
+result once — avoiding the recast is part of the resident model's win, and
+it is why `l_quantity` (cast per query) shows a higher ratio than the
+already-BIGINT `l_orderkey`/`l_partkey` (pure reduction: 3.3–3.7×). Both
+rows are the truth; pick the one that matches your schema.
 
-One-time `gpu_upload` cost: SF1 70 ms · SF10 725 ms · SF25 i64 1.99 s /
-f64 2.09 s → break-even vs native ≈ **110 repeated sums at SF10, ~100 at
-SF25**, then every query is ~7–20 ms cheaper forever. Honest losing rows: unfiltered `min`/`max` on
+**Losing row, stated plainly:** whole-column `min`/`max` — native answers
+from zonemap statistics in 0.2–2.2 ms at every scale without scanning (our
+attempted scan-forcing via `+ 0` was constant-folded away, so there is no
+honest scan-race to report). Resident min+max runs a real reduction
+(2 × ~5 ms at SF50). If DuckDB has statistics for your column, use native
+min/max.
+
+The i64 kernel tracks the memory ceiling as scale grows: 370 GB/s (SF10) →
+446 (SF25) → 496 (SF50) → **503 GB/s at SF100** (600M rows, kernel 9.53 ms)
+vs the M4 Max's ~546 GB/s spec. Ratio curve: 2× → 5× → 6.9× → 6.8× → 8.5×
+→ **9.9×**.
+
+One-time `gpu_upload` (i64, ms): SF1 87 · SF5 417 · SF10 831 · SF25 2,140 ·
+SF50 4,358 · SF100 9,469 → break-even ≈ 90–110 repeated sums at every level;
+after that each query is 8–107 ms cheaper forever. Honest losing rows: unfiltered `min`/`max` on
 persistent tables (native answers from zonemap statistics without scanning —
 resident min/max still run a real 1–2 ms reduction) and any one-shot query
 (that is what the streaming parity path is for).

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -64,29 +64,49 @@ parallel reduction in this branch flipped it to 3 ms. `gpu_last_stats()` now
 reports `reason=Resident_OnCpu` for this case (was misleadingly
 `Hot_GpuAlwaysWins`).
 
-### NVIDIA RTX 4090 Laptop (sm_89, 16 GB, CUDA 13), DuckDB CLI v1.5.2
+### NVIDIA RTX 4090 Laptop (sm_89, 16 GB, CUDA 13.0.88, driver 580.178.04), DuckDB CLI v1.5.5, TPC-H `lineitem`, SF1→SF100
 
-Reported by the Linux instance from `fix/core-cuda-ci-hardening` (extension
-code identical to `main` @ c7e0db5); same methodology, 5-run medians.
+Reported by the Linux instance; extension built from `feat/ext-resident-hardening`
+(PR #59), medians of 5 after warm-up, `-readonly`, threads 16. Correctness
+gates: **0 mismatches at every SF**. `gpu_last_stats` at every level and both
+dtypes: `backend=CUDA reason=Hot_GpuAlwaysWins transfer_ms=0.000`.
 
-| Query (whole column) | Rows | native | resident e2e | internal wall / kernel | ratio |
-|---|---|---:|---:|---|:---:|
-| `sum(BIGINT)` | 100M | 40 ms | **2 ms** | 1.48 ms / 1.45 ms | **~20×** |
-| TPC-H SF1 `sum(l_quantity)` | 6M | 10 ms | **~1 ms** | 0.087 ms / 0.042 ms | **~10×** |
-| `sum(DOUBLE)` | 10M | 10 ms | **~1 ms** | 0.20 ms / 0.17 ms | **~10×** (f64 on-GPU, unlike Metal) |
-| `min`+`max(BIGINT)` | 10M | 10–22 ms | **~1 ms** | — | **~10–20×** |
-| `sum(BIGINT)` | 10M | 8 ms | ~6 ms | 0.20 ms / 0.16 ms | parity e2e* |
+`sum` — native / resident e2e / ratio, per level (ms; `<1` printed as 1):
 
-\* same SF1-class caveat: ~5 ms per-statement CLI overhead hides a 40× kernel win.
+| Column | SF1 · 6M | SF5 · 30M | SF10 · 60M | SF25 · 150M | SF50 · 300M | SF100 · 600M |
+|---|---|---|---|---|---|---|
+| `l_quantity::BIGINT`¹ | 4 / <1 / **4×** | 10 / 1 / **10×** | 20 / 1 / **20×** | 48 / 2 / **24×** | 99 / 4 / **25×** | 192 / 9 / **21×** |
+| `l_orderkey` (BIGINT) | 1 / <1 / ~1× | 3 / <1 / **~3×** | 9 / 1 / **9×** | 13 / 2 / **6.5×** | 25 / 4 / **6.3×** | 50 / 9 / **5.6×** |
+| `l_partkey` (BIGINT) | 1 / <1 / ~1× | 3 / 1 / **3×** | 10 / 1 / **10×** | 14 / 2 / **7×** | 27 / 4 / **6.8×** | 56 / 9 / **6.2×** |
+| `l_extendedprice::DOUBLE`¹ | 6 / <1 / **6×** | 10 / 1 / **10×** | 21 / 1 / **21×** | 49 / 2 / **24×** | 98 / 4 / **24×** | 196 / 9 / **22×** |
+| `l_discount::DOUBLE`¹ | 5 / <1 / **5×** | 10 / 1 / **10×** | 21 / 1 / **21×** | 45 / 2 / **22×** | 89 / 4 / **22×** | 176 / 9 / **20×** |
+| `l_tax::DOUBLE`¹ | 3 / <1 / **3×** | 9 / 1 / **9×** | 19 / 1 / **19×** | 44 / 2 / **22×** | 88 / 4 / **22×** | 177 / 9 / **20×** |
 
-Upload cost: 6M 196 ms · 10M i64 618 ms · 10M f64 390 ms · 100M 3.39 s →
-break-even ≈ 22 queries (6M) to ≈ 90 queries (100M).
+¹ same DECIMAL-cast structure as the Metal table: native re-casts stored
+DECIMAL per scan, the resident column stores the cast once — cast-heavy
+columns hit 20–25×, already-BIGINT columns are the pure reduction race at
+5.6–10×. Kernel-level SF100 ratios (net of ~0.5–1 ms CLI per-statement
+overhead): 22.4× cast, 5.8× raw. Unlike Metal, DOUBLE runs **on the GPU**
+here — f64 ratios match the i64 cast rows.
 
-Library-level (`gpudb-bench`, no SQL overhead): 100M HOT CPU (OpenMP, 20T)
-30–42 ms vs CUDA 1.44 ms at 522 GiB/s ≈ spec VRAM bandwidth — **21–29×**.
-COLD still loses on CUDA exactly as documented since v0.2.0 (100M: 81.5 ms,
-of which 80 ms is PCIe) — the hybrid planner correctly dispatches cold
-one-shot reductions to the CPU.
+Kernel times SF1→SF100: 0.045 / 0.460 / 0.882 / 2.155 / 4.278 / **8.528 ms**
+— SF100 = **563 GB/s ≈ the 4090 Laptop's VRAM ceiling**. Same
+bandwidth-convergence story as Metal, higher ceiling.
+
+**Losing row, stated plainly:** whole-column `min`/`max` — native's zonemap
+statistics answer in 0–10 ms at every SF (the `+ 0` scan-forcing attempt was
+constant-folded on v1.5.5 too; 10 ms at SF100 is impossible DRAM bandwidth
+for a real 4.8 GB scan, so that IS the stats path). Resident min+max (two
+kernel launches) loses this row at every SF. Native wins; documented.
+
+One-time `gpu_upload` (ms, per column): SF1 ~200–425 → SF100 ~25,000–29,800.
+Break-even at SF100 ≈ 150 repeated sums for cast-heavy columns, ≈ 600 for
+raw-BIGINT. SF100 note: the 4.8 GB per-column host buffer exceeds the default
+4 GB pool cap — the sweep reproduced the clean cap error, then ran with the
+documented `GPUDB_UPLOAD_POOL_MAX_MB=16384` override (guardrail + escape
+hatch verified on both platforms). SF100 resident cells ran as per-column CLI
+processes (`SET memory_limit='4GB'`) on the 31 GB box; native SF100 numbers
+came from the main run at loadavg 2–3.
 
 ## 2026-07-19 (v0.3.0) — streaming aggregate rewrite: end-to-end parity with native
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known issues
 
-Status as of 2026-07-19, `v0.3.0`. **All known functional bugs resolved.**
+Status as of 2026-08-15, `v0.4.0`. **All known functional bugs resolved.**
 
 If you do hit something here, fall back to native DuckDB `sum()` / `min()` / `max()` / window functions for that query.
 
@@ -25,6 +25,18 @@ matching native DuckDB, and `IS NULL` on such a result is now `true`.
 | The SQL aggregate path (`gpu_sum`/`gpu_min`/`gpu_max` called from SQL) does not dispatch to the GPU | Deliberate v0.3.0 design, not a fallback. DuckDB feeds aggregates pre-grouped 2048-row chunks; on unified memory, copying those out to feed a GPU reduction is pure overhead (measured 3×–110× end-to-end loss in v0.2.0 — see BENCHMARK.md). v0.3.0 streams running accumulators instead and reaches parity with native. GPU reductions remain at operator level (`gpudb-bench` etc.); GPU value on the SQL path moves to the join track. |
 | Apple GPUs have no IEEE-754 double precision in MSL | Still true and still relevant to operator-level f64 work on Metal (runs on host there). No longer affects the SQL aggregate path (see row above). |
 | `GPUDB_FORCE_BACKEND` no longer affects SQL aggregates | The env var routed the deleted buffered/batched path; it is a silent no-op on the aggregate path as of v0.3.0. Operator-level tools still honor backend selection. |
+
+### Design notes — resident-column surface (v0.4.0)
+
+| Behavior | Reason |
+|---|---|
+| `gpu_sum_resident` (and the streaming `gpu_sum`) wrap on int64 overflow where native `sum(BIGINT)` promotes to `HUGEINT` | The GPU kernels and the C ABI accumulate in 64-bit; wrap is two's-complement (uint64 accumulate — defined behavior, identical on CPU/CUDA/Metal). Use native `sum()` if your column can exceed int64. |
+| One `gpu_upload` call = one column name; a name column with mixed values errors | Values from different names silently merging into one column is data corruption; use a constant name or `GROUP BY` the name column. |
+| `gpu_upload` names may not be NULL; read-side NULL names yield SQL `NULL` rows | Upload with NULL name used to silently register the column under `''`. |
+| Total memory buffered by in-flight `gpu_upload` states is capped (default 4 GB, `GPUDB_UPLOAD_POOL_MAX_MB`) | `gpu_upload` inside a running window frame buffers O(n²) (combine per output row) and would otherwise OOM the host from a KB-scale input. The cap turns that into a clean error. |
+| An unreferenced `gpu_upload` subquery column is pruned and the upload never runs | DuckDB's unused-column elimination; always reference the upload count in the outer query (see `src/extension/gpu_resident.cpp` header). |
+| Resident f64 columns run on the host on Apple Silicon (`reason=Resident_OnCpu`) | No IEEE-754 doubles in MSL. The host path is parallel (chunked reduction) as of v0.4.0 — measured faster than a native DuckDB scan on M4 Max — and f64 sums are deterministic per upload, not per dataset (parallel upload order affects rounding, same as native). |
+| Whole-column `gpu_min_resident`/`gpu_max_resident` are slower than native `min()`/`max()` on unfiltered persistent tables | Native answers those from zonemap statistics without scanning — a metadata lookup no engine can beat. The resident path wins where a real reduction happens (sums, or data DuckDB has no stats for). |
 
 ### Type support (v0.3.0)
 

--- a/src/backends/cpu/cpu_aggregator.cpp
+++ b/src/backends/cpu/cpu_aggregator.cpp
@@ -2,11 +2,13 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <numeric>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #if GPUDB_HAVE_OPENMP
@@ -15,6 +17,35 @@
 
 namespace gpudb {
 namespace {
+
+// Portable parallel chunking for builds without OpenMP (Apple clang ships no
+// libomp, so the macOS loadable extension otherwise reduces single-threaded).
+// Splits [0,n) into one contiguous chunk per worker and combines the partials
+// in chunk order — deterministic for a given (n, worker count), which matters
+// for f64 sums where the combine order changes the rounding.
+template <class Partial, class ChunkFn, class CombineFn>
+Partial parallel_chunks(std::size_t n, ChunkFn chunk, CombineFn combine) {
+    constexpr std::size_t kMinPerWorker = std::size_t(1) << 19; // 512k elems
+    const unsigned hw = std::thread::hardware_concurrency();
+    std::size_t workers = std::min<std::size_t>(hw ? hw : 1, n / kMinPerWorker);
+    if (workers <= 1) return chunk(std::size_t(0), n);
+
+    std::vector<Partial> parts(workers);
+    std::vector<std::thread> threads;
+    threads.reserve(workers);
+    const std::size_t per = n / workers;
+    for (std::size_t w = 0; w < workers; ++w) {
+        const std::size_t begin = w * per;
+        const std::size_t end   = (w + 1 == workers) ? n : begin + per;
+        threads.emplace_back([&parts, &chunk, w, begin, end] {
+            parts[w] = chunk(begin, end);
+        });
+    }
+    for (auto& t : threads) t.join();
+    Partial acc = parts[0];
+    for (std::size_t w = 1; w < workers; ++w) acc = combine(acc, parts[w]);
+    return acc;
+}
 
 // CPU resident column = a copy of the host data the aggregator owns.
 // (Could just hold a const pointer, but a copy matches GPU semantics so
@@ -115,12 +146,25 @@ private:
         std::int64_t v = (n == 0) ? 0 : init;
         switch (kind) {
             case ReduceKind::Sum: {
+                // Accumulate in uint64: overflow wraps (two's complement),
+                // matching the documented gpu_sum semantics, instead of the
+                // signed-overflow UB the old code had.
+                std::uint64_t uv = 0;
 #if GPUDB_HAVE_OPENMP
-                #pragma omp parallel for reduction(+:v) schedule(static)
-                for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(n); ++i) v += data[i];
+                #pragma omp parallel for reduction(+:uv) schedule(static)
+                for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(n); ++i)
+                    uv += static_cast<std::uint64_t>(data[i]);
 #else
-                for (std::size_t i = 0; i < n; ++i) v += data[i];
+                uv = parallel_chunks<std::uint64_t>(n,
+                    [data](std::size_t b, std::size_t e) {
+                        std::uint64_t acc = 0;
+                        for (std::size_t i = b; i < e; ++i)
+                            acc += static_cast<std::uint64_t>(data[i]);
+                        return acc;
+                    },
+                    [](std::uint64_t a, std::uint64_t b) { return a + b; });
 #endif
+                v = static_cast<std::int64_t>(uv);
                 break;
             }
             case ReduceKind::Min: {
@@ -129,7 +173,13 @@ private:
                 for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(n); ++i)
                     if (data[i] < v) v = data[i];
 #else
-                for (std::size_t i = 0; i < n; ++i) if (data[i] < v) v = data[i];
+                if (n > 0) v = parallel_chunks<std::int64_t>(n,
+                    [data](std::size_t b, std::size_t e) {
+                        std::int64_t m = std::numeric_limits<std::int64_t>::max();
+                        for (std::size_t i = b; i < e; ++i) if (data[i] < m) m = data[i];
+                        return m;
+                    },
+                    [](std::int64_t a, std::int64_t b) { return a < b ? a : b; });
 #endif
                 break;
             }
@@ -139,7 +189,13 @@ private:
                 for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(n); ++i)
                     if (data[i] > v) v = data[i];
 #else
-                for (std::size_t i = 0; i < n; ++i) if (data[i] > v) v = data[i];
+                if (n > 0) v = parallel_chunks<std::int64_t>(n,
+                    [data](std::size_t b, std::size_t e) {
+                        std::int64_t m = std::numeric_limits<std::int64_t>::min();
+                        for (std::size_t i = b; i < e; ++i) if (data[i] > m) m = data[i];
+                        return m;
+                    },
+                    [](std::int64_t a, std::int64_t b) { return a > b ? a : b; });
 #endif
                 break;
             }
@@ -166,7 +222,9 @@ private:
             return r;
         }
 
-        std::int64_t sum_v = 0;
+        // uint64 accumulate: overflow wraps (documented gpu_sum semantics)
+        // instead of signed-overflow UB.
+        std::uint64_t sum_v = 0;
         std::int64_t min_v = std::numeric_limits<std::int64_t>::max();
         std::int64_t max_v = std::numeric_limits<std::int64_t>::min();
 #if GPUDB_HAVE_OPENMP
@@ -174,19 +232,19 @@ private:
                                  reduction(max:max_v) schedule(static)
         for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(n); ++i) {
             const std::int64_t x = data[i];
-            sum_v += x;
+            sum_v += static_cast<std::uint64_t>(x);
             if (x < min_v) min_v = x;
             if (x > max_v) max_v = x;
         }
 #else
         for (std::size_t i = 0; i < n; ++i) {
             const std::int64_t x = data[i];
-            sum_v += x;
+            sum_v += static_cast<std::uint64_t>(x);
             if (x < min_v) min_v = x;
             if (x > max_v) max_v = x;
         }
 #endif
-        r.sum = sum_v;
+        r.sum = static_cast<std::int64_t>(sum_v);
         r.min = min_v;
         r.max = max_v;
         r.wall_ms = elapsed_ms(t0);
@@ -200,7 +258,13 @@ private:
         #pragma omp parallel for reduction(+:acc) schedule(static)
         for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(n); ++i) acc += data[i];
 #else
-        for (std::size_t i = 0; i < n; ++i) acc += data[i];
+        acc = parallel_chunks<double>(n,
+            [data](std::size_t b, std::size_t e) {
+                double a = 0.0;
+                for (std::size_t i = b; i < e; ++i) a += data[i];
+                return a;
+            },
+            [](double a, double b) { return a + b; });
 #endif
         AggResult r{};
         r.value_f64 = acc; r.rows = n;

--- a/src/backends/hybrid_planner.cpp
+++ b/src/backends/hybrid_planner.cpp
@@ -346,8 +346,8 @@ private:
                                   n, 0, /*resident*/true, /*borderline*/false);
             return run(*gpu_, h.inner());
         }
-        // Resident on CPU (rare; only happens if upload fell back) → CPU.
-        last_ = make_decision(Backend::CPU, DispatchReason::Hot_GpuAlwaysWins,
+        // Resident on CPU (f64 on Metal, or a GPU upload that fell back) → CPU.
+        last_ = make_decision(Backend::CPU, DispatchReason::Resident_OnCpu,
                               n, 0, /*resident*/true, /*borderline*/false);
         return run(*cpu_, h.inner());
     }
@@ -497,6 +497,7 @@ const char* to_string(DispatchReason r) noexcept {
         case DispatchReason::Hot_GpuAlwaysWins:        return "Hot_GpuAlwaysWins";
         case DispatchReason::GpuUnavailable:           return "GpuUnavailable";
         case DispatchReason::F64_NoGpuDoubles:         return "F64_NoGpuDoubles";
+        case DispatchReason::Resident_OnCpu:           return "Resident_OnCpu";
         case DispatchReason::GroupBy_LowCard_CpuWins:  return "GroupBy_LowCard_CpuWins";
         case DispatchReason::GroupBy_HighCard_GpuWins: return "GroupBy_HighCard_GpuWins";
         case DispatchReason::GroupBy_Borderline_GpuTry:return "GroupBy_Borderline_GpuTry";

--- a/src/extension/gpu_resident.cpp
+++ b/src/extension/gpu_resident.cpp
@@ -30,9 +30,21 @@
 //
 // Usage shape (single statement — the FROM subquery aggregates first, so the
 // upload completes before the projection reads it):
-//   SELECT gpu_sum_resident('l_qty') AS s
-//   FROM (SELECT gpu_upload('l_qty', l_quantity::BIGINT) FROM lineitem) u;
+//   SELECT u.n, gpu_sum_resident('l_qty') AS s
+//   FROM (SELECT gpu_upload('l_qty', l_quantity::BIGINT) AS n FROM lineitem) u;
 // or interactively: upload once, then query the name many times.
+// WARNING: the outer query MUST reference the subquery's upload count (u.n
+// above) — an unreferenced gpu_upload column is pruned by DuckDB's optimizer
+// and the upload silently never runs.
+//
+// Guardrails (each was a shipped footgun caught by adversarial review):
+//   - one gpu_upload state = one name; mixed names in one call error out
+//   - NULL names error at upload (read side emits SQL NULL per NULL row)
+//   - total buffered bytes capped (default 4 GB, GPUDB_UPLOAD_POOL_MAX_MB):
+//     gpu_upload in a running window frame buffers O(n²) and must hit a wall
+//     before it OOMs the host
+//   - i64 sums wrap on overflow (uint64 accumulate — defined behavior),
+//     unlike native sum(BIGINT) which promotes to HUGEINT; see KNOWN_ISSUES
 //
 // Dispatch goes through HybridAggregator: on a CUDA box the resident
 // reductions run on the GPU (DispatchReason::Hot_GpuAlwaysWins); on a
@@ -56,6 +68,7 @@ DUCKDB_EXTENSION_EXTERN
 
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <mutex>
@@ -75,10 +88,13 @@ namespace {
 
 struct UploadBuf {
     std::string               name;    // registry key, from the VARCHAR arg
+    bool                      name_set = false; // '' is a legal explicit name
     gpudb::Dtype              dtype = gpudb::Dtype::I64;
     std::vector<std::int64_t> i64;
     std::vector<double>       f64;
     std::size_t size() const { return dtype == gpudb::Dtype::I64 ? i64.size() : f64.size(); }
+    std::size_t bytes() const { return i64.size() * sizeof(std::int64_t)
+                                     + f64.size() * sizeof(double); }
 };
 
 struct Globals {
@@ -87,9 +103,33 @@ struct Globals {
     std::unordered_map<std::string,
         std::unique_ptr<gpudb::ResidentColumn>> registry;         // name -> column
     std::unordered_map<std::uint64_t, UploadBuf> pool;            // buf_id -> buffer
+    std::size_t   pool_bytes = 0;   // sum of bytes() over pool, kept exact
     std::uint64_t next_id = 1;
     std::string   last_stats = "no resident reduction has run yet";
 };
+
+// Cap on total host memory buffered by in-flight gpu_upload states. Without
+// it, gpu_upload inside a running window frame (combine() per output row,
+// every state's buffer live until query end) amplifies a KB-scale input into
+// tens of GB and OOMs the host — measured n²/2 growth. Default 4 GB,
+// override via GPUDB_UPLOAD_POOL_MAX_MB.
+std::size_t pool_cap_bytes() {
+    static const std::size_t cap = [] {
+        unsigned long long mb = 4096;
+        if (const char* s = std::getenv("GPUDB_UPLOAD_POOL_MAX_MB")) {
+            char* end = nullptr;
+            const unsigned long long v = std::strtoull(s, &end, 10);
+            if (end && *end == '\0' && v > 0) mb = v;
+        }
+        return static_cast<std::size_t>(mb) << 20;
+    }();
+    return cap;
+}
+
+constexpr const char* kPoolCapHint =
+    " (gpu_upload buffers exceed the pool cap; raise GPUDB_UPLOAD_POOL_MAX_MB"
+    " if intentional — note gpu_upload inside a window frame buffers"
+    " quadratically and is almost never what you want)";
 
 Globals& g() {
     static Globals instance;
@@ -134,10 +174,17 @@ void upload_state_init(duckdb_function_info /*info*/, duckdb_aggregate_state sta
 
 void upload_state_destroy(duckdb_aggregate_state* states, idx_t count) {
     std::lock_guard<std::mutex> lock(g().mu);
+    auto& G = g();
     for (idx_t i = 0; i < count; ++i) {
         auto* s = reinterpret_cast<UploadState*>(states[i]);
         if (!s || s->magic != UploadState::kMagic) continue;
-        if (s->buf_id != 0) g().pool.erase(s->buf_id);  // double-erase is a no-op
+        if (s->buf_id != 0) {
+            auto it = G.pool.find(s->buf_id);   // double-erase is a no-op
+            if (it != G.pool.end()) {
+                G.pool_bytes -= it->second.bytes();
+                G.pool.erase(it);
+            }
+        }
         s->magic = 0;
     }
 }
@@ -166,7 +213,7 @@ inline std::string read_name(duckdb_string_t* names, idx_t row) {
 }
 
 template <class T, gpudb::Dtype DT>
-void upload_update_t(duckdb_function_info /*info*/, duckdb_data_chunk input,
+void upload_update_t(duckdb_function_info info, duckdb_data_chunk input,
                      duckdb_aggregate_state* states) {
     duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
     duckdb_vector val_vec  = duckdb_data_chunk_get_vector(input, 1);
@@ -194,28 +241,56 @@ void upload_update_t(duckdb_function_info /*info*/, duckdb_data_chunk input,
     }
 
     std::lock_guard<std::mutex> lock(g().mu);
-    auto append_row = [&](UploadState* s, idx_t i) {
-        if (val_validity && !duckdb_validity_row_is_valid(val_validity, i)) return;
-        UploadBuf& b = state_buf_locked(s, DT);
-        if (b.name.empty() &&
-            (!name_validity || duckdb_validity_row_is_valid(name_validity, i))) {
-            b.name = read_name(names, i);
+    auto& G = g();
+    // Returns false after setting a function error (aborts the chunk).
+    auto append_row = [&](UploadState* s, idx_t i) -> bool {
+        // NULL values are skipped (standard aggregate semantics).
+        if (val_validity && !duckdb_validity_row_is_valid(val_validity, i)) return true;
+        // A NULL name on a contributing row is a user error, not data: the
+        // old code silently registered the column under '' instead.
+        if (name_validity && !duckdb_validity_row_is_valid(name_validity, i)) {
+            duckdb_aggregate_function_set_error(info,
+                "gpu_upload: name may not be NULL");
+            return false;
         }
+        UploadBuf& b = state_buf_locked(s, DT);
+        const char*       nm_data = duckdb_string_t_data(&names[i]);
+        const std::size_t nm_len  = duckdb_string_t_length(names[i]);
+        if (!b.name_set) {
+            b.name.assign(nm_data, nm_len);
+            b.name_set = true;
+        } else if (b.name.size() != nm_len ||
+                   std::memcmp(b.name.data(), nm_data, nm_len) != 0) {
+            // One state buffer = one column. Mixed names used to silently
+            // merge different names' values into the first row's column.
+            duckdb_aggregate_function_set_error(info,
+                ("gpu_upload: one aggregate received two different names ('" +
+                 b.name + "' and '" + std::string(nm_data, nm_len) +
+                 "') — use a constant name, or GROUP BY the name column").c_str());
+            return false;
+        }
+        if (G.pool_bytes + sizeof(T) > pool_cap_bytes()) {
+            duckdb_aggregate_function_set_error(info,
+                (std::string("gpu_upload: out of buffer memory") + kPoolCapHint).c_str());
+            return false;
+        }
+        G.pool_bytes += (DT == gpudb::Dtype::I64) ? sizeof(std::int64_t) : sizeof(double);
         if (DT == gpudb::Dtype::I64) b.i64.push_back(static_cast<std::int64_t>(data[i]));
         else                         b.f64.push_back(static_cast<double>(data[i]));
+        return true;
     };
 
     if (n == 1 || !per_row) {
-        for (idx_t i = 0; i < n; ++i) append_row(s0, i);
+        for (idx_t i = 0; i < n; ++i) if (!append_row(s0, i)) return;
     } else {
         for (idx_t i = 0; i < n; ++i) {
             UploadState* s = probe_upload_state(states[i]);
-            if (s) append_row(s, i);
+            if (s && !append_row(s, i)) return;
         }
     }
 }
 
-void upload_combine(duckdb_function_info /*info*/, duckdb_aggregate_state* source,
+void upload_combine(duckdb_function_info info, duckdb_aggregate_state* source,
                     duckdb_aggregate_state* target, idx_t count) {
     // Contract #3: source is read-only (window donor states are combined into
     // many targets). We COPY the source buffer's contents into the target's.
@@ -229,7 +304,24 @@ void upload_combine(duckdb_function_info /*info*/, duckdb_aggregate_state* sourc
         if (it == G.pool.end() || it->second.size() == 0) continue;
         const UploadBuf& sb = it->second;
         UploadBuf& db = state_buf_locked(dst, sb.dtype);
-        if (db.name.empty()) db.name = sb.name;
+        if (!db.name_set && sb.name_set) {
+            db.name = sb.name;
+            db.name_set = true;
+        } else if (db.name_set && sb.name_set && db.name != sb.name) {
+            duckdb_aggregate_function_set_error(info,
+                ("gpu_upload: combine merged two different names ('" + db.name +
+                 "' and '" + sb.name + "')").c_str());
+            return;
+        }
+        const std::size_t delta = sb.bytes();
+        if (G.pool_bytes + delta > pool_cap_bytes()) {
+            // This is the window-frame quadratic-buffering path: each output
+            // row's state receives a copy of its whole frame prefix.
+            duckdb_aggregate_function_set_error(info,
+                (std::string("gpu_upload: out of buffer memory") + kPoolCapHint).c_str());
+            return;
+        }
+        G.pool_bytes += delta;
         db.i64.insert(db.i64.end(), sb.i64.begin(), sb.i64.end());
         db.f64.insert(db.f64.end(), sb.f64.begin(), sb.f64.end());
     }
@@ -296,14 +388,11 @@ duckdb_aggregate_function make_upload_fn(duckdb_type value_type,
 // ---------------------------------------------------------------------------
 
 // Look up a registry column by the VARCHAR cell in input vector 0, row `row`.
-// Returns nullptr after setting a function error. Callers hold g().mu.
+// Returns nullptr after setting a function error. Callers hold g().mu and
+// have already skipped NULL-name rows (those produce SQL NULL, mirroring
+// what DuckDB's default NULL handling does for constant NULL arguments).
 gpudb::ResidentColumn* lookup_locked(duckdb_function_info info,
-                                     duckdb_string_t* names, uint64_t* validity,
-                                     idx_t row) {
-    if (validity && !duckdb_validity_row_is_valid(validity, row)) {
-        duckdb_scalar_function_set_error(info, "resident column name may not be NULL");
-        return nullptr;
-    }
+                                     duckdb_string_t* names, idx_t row) {
     std::string name = read_name(names, row);
     auto it = g().registry.find(name);
     if (it == g().registry.end()) {
@@ -326,10 +415,16 @@ void resident_i64_exec(duckdb_function_info info, duckdb_data_chunk input,
     uint64_t* validity = duckdb_vector_get_validity(name_vec);
     const idx_t n = duckdb_data_chunk_get_size(input);
     auto* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(output));
+    duckdb_vector_ensure_validity_writable(output);
+    uint64_t* out_validity = duckdb_vector_get_validity(output);
 
     std::lock_guard<std::mutex> lock(g().mu);
     for (idx_t i = 0; i < n; ++i) {
-        gpudb::ResidentColumn* col = lookup_locked(info, names, validity, i);
+        if (validity && !duckdb_validity_row_is_valid(validity, i)) {
+            duckdb_validity_set_row_invalid(out_validity, i);
+            continue;
+        }
+        gpudb::ResidentColumn* col = lookup_locked(info, names, i);
         if (!col) return;
         if (col->dtype() != gpudb::Dtype::I64) {
             duckdb_scalar_function_set_error(info,
@@ -351,10 +446,16 @@ void sum_resident_f64_exec(duckdb_function_info info, duckdb_data_chunk input,
     uint64_t* validity = duckdb_vector_get_validity(name_vec);
     const idx_t n = duckdb_data_chunk_get_size(input);
     auto* out = reinterpret_cast<double*>(duckdb_vector_get_data(output));
+    duckdb_vector_ensure_validity_writable(output);
+    uint64_t* out_validity = duckdb_vector_get_validity(output);
 
     std::lock_guard<std::mutex> lock(g().mu);
     for (idx_t i = 0; i < n; ++i) {
-        gpudb::ResidentColumn* col = lookup_locked(info, names, validity, i);
+        if (validity && !duckdb_validity_row_is_valid(validity, i)) {
+            duckdb_validity_set_row_invalid(out_validity, i);
+            continue;
+        }
+        gpudb::ResidentColumn* col = lookup_locked(info, names, i);
         if (!col) return;
         if (col->dtype() != gpudb::Dtype::F64) {
             duckdb_scalar_function_set_error(info,
@@ -374,10 +475,16 @@ void resident_info_exec(duckdb_function_info info, duckdb_data_chunk input,
     auto* names = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(name_vec));
     uint64_t* validity = duckdb_vector_get_validity(name_vec);
     const idx_t n = duckdb_data_chunk_get_size(input);
+    duckdb_vector_ensure_validity_writable(output);
+    uint64_t* out_validity = duckdb_vector_get_validity(output);
 
     std::lock_guard<std::mutex> lock(g().mu);
     for (idx_t i = 0; i < n; ++i) {
-        gpudb::ResidentColumn* col = lookup_locked(info, names, validity, i);
+        if (validity && !duckdb_validity_row_is_valid(validity, i)) {
+            duckdb_validity_set_row_invalid(out_validity, i);
+            continue;
+        }
+        gpudb::ResidentColumn* col = lookup_locked(info, names, i);
         if (!col) return;
         char buf[256];
         std::snprintf(buf, sizeof(buf), "dtype=%s rows=%zu device=%s",
@@ -403,12 +510,15 @@ void drop_resident_exec(duckdb_function_info info, duckdb_data_chunk input,
     uint64_t* validity = duckdb_vector_get_validity(name_vec);
     const idx_t n = duckdb_data_chunk_get_size(input);
     auto* out = reinterpret_cast<bool*>(duckdb_vector_get_data(output));
+    duckdb_vector_ensure_validity_writable(output);
+    uint64_t* out_validity = duckdb_vector_get_validity(output);
+    (void)info;
 
     std::lock_guard<std::mutex> lock(g().mu);
     for (idx_t i = 0; i < n; ++i) {
         if (validity && !duckdb_validity_row_is_valid(validity, i)) {
-            duckdb_scalar_function_set_error(info, "resident column name may not be NULL");
-            return;
+            duckdb_validity_set_row_invalid(out_validity, i);
+            continue;
         }
         out[i] = g().registry.erase(read_name(names, i)) > 0;
     }

--- a/src/extension/gpu_resident.cpp
+++ b/src/extension/gpu_resident.cpp
@@ -503,6 +503,36 @@ void last_stats_exec(duckdb_function_info /*info*/, duckdb_data_chunk input,
     }
 }
 
+// gpu_build_info(): which backends are COMPILED into this binary and which
+// one dispatch selected at load. This is the activation tripwire for the
+// registry's CUDA rollout: description.yml lists the cuda toolchain now
+// (future-ready), but the registry's pinned extension-ci-tools branch does
+// not provide nvcc yet — when its pin moves, the registry binary silently
+// starts compiling CUDA in, and this function is how CI (and users) see it:
+//   compiled=cpu           → today's registry linux binary
+//   compiled=cpu,cuda      → the moment upstream flips; time to announce
+//   compiled=cpu,metal     → registry osx_arm64 binary
+void build_info_exec(duckdb_function_info /*info*/, duckdb_data_chunk input,
+                     duckdb_vector output) {
+    std::string info = "compiled=cpu";
+#if defined(GPUDB_HAVE_CUDA)
+    info += ",cuda";
+#endif
+#if defined(GPUDB_HAVE_METAL)
+    info += ",metal";
+#endif
+    info += " runtime=";
+    switch (gpudb::default_backend()) {
+        case gpudb::Backend::CUDA:  info += "cuda";  break;
+        case gpudb::Backend::METAL: info += "metal"; break;
+        default:                    info += "cpu";   break;
+    }
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    for (idx_t i = 0; i < n; ++i) {
+        duckdb_vector_assign_string_element(output, i, info.c_str());
+    }
+}
+
 void drop_resident_exec(duckdb_function_info info, duckdb_data_chunk input,
                         duckdb_vector output) {
     duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
@@ -586,6 +616,8 @@ void register_gpu_resident(duckdb_connection con) {
         drop_resident_exec, DUCKDB_TYPE_BOOLEAN, true);
     register_scalar(con, "gpu_last_stats",
         last_stats_exec, DUCKDB_TYPE_VARCHAR, false);
+    register_scalar(con, "gpu_build_info",
+        build_info_exec, DUCKDB_TYPE_VARCHAR, false);
 }
 
 } // namespace gpudb_ext

--- a/src/include/gpu_backend.hpp
+++ b/src/include/gpu_backend.hpp
@@ -250,6 +250,8 @@ enum class DispatchReason : std::uint8_t {
     Hot_GpuAlwaysWins     = 3,  // resident column → GPU
     GpuUnavailable        = 4,  // no GPU compiled in / no device
     F64_NoGpuDoubles      = 5,  // Metal lacks IEEE-754 doubles, prefer CPU
+    Resident_OnCpu        = 6,  // column resides in host memory (f64 on Metal,
+                                // or a GPU upload that fell back) → CPU runs it
     // GROUP BY reasons
     GroupBy_LowCard_CpuWins  = 10, // expected_groups < threshold and small n
     GroupBy_HighCard_GpuWins = 11, // expected_groups >= n / 10 → high cardinality regime

--- a/test/sql/gpu_resident_guardrails.test
+++ b/test/sql/gpu_resident_guardrails.test
@@ -1,0 +1,57 @@
+# gpu_resident_guardrails SQL test — the failure modes adversarial review
+# found in the v0.4.0 resident surface, pinned so they stay fixed:
+#   - mixed names in one gpu_upload error instead of silently merging
+#   - NULL upload names error instead of registering under ''
+#   - the buffer pool cap turns the window-frame quadratic blowup into a
+#     clean error instead of an OOM
+#   - NULL name rows on the read side produce SQL NULL rows, not query aborts
+#   - i64 overflow wraps (documented, deterministic, no UB)
+#   - the stats line never claims the GPU won when the CPU ran
+#
+# Same single-statement upload shape as gpu_resident.test: the outer query
+# must reference the upload count u or DuckDB prunes the aggregate.
+#
+# Run via: ./scripts/run_sql_tests.sh gpu_resident_guardrails
+
+-- 1. Mixed names in one upload: hard error, values never cross columns
+-- expected_fail: one aggregate received two different names
+SELECT u FROM (SELECT gpu_upload(nm, v) AS u
+               FROM (VALUES ('a', 1::BIGINT), ('b', 2::BIGINT)) t(nm, v)) up;
+
+-- 2. NULL name at upload: hard error (was silently registered under '')
+-- expected_fail: gpu_upload name may not be NULL
+SELECT u FROM (SELECT gpu_upload(NULL::VARCHAR, v) AS u
+               FROM (VALUES (5::BIGINT)) t(v)) up;
+
+-- 3. Window-frame quadratic buffering hits the pool cap as a clean error
+--    (1 MB cap; 5000 rows would otherwise buffer ~n^2/2 * 8B ≈ 100 MB)
+-- env: GPUDB_UPLOAD_POOL_MAX_MB=1
+-- expected_fail: out of buffer memory
+SELECT count(*) FROM (SELECT gpu_upload('w', v) OVER (ORDER BY v) AS r
+                      FROM (SELECT range AS v FROM range(5000)) t) q;
+
+-- 4. NULL name rows on the read side: SQL NULL for those rows, query succeeds
+SELECT s IS NULL AS null_row, u
+FROM (SELECT gpu_sum_resident(NULL::VARCHAR) AS s, u
+      FROM (SELECT gpu_upload('g4', range::BIGINT) AS u FROM range(10)) up) q;
+-- expect: true  10
+
+-- 5. i64 sum wraps at overflow (uint64 accumulate: deterministic, documented)
+SELECT gpu_sum_resident('g5') AS wrapped, u
+FROM (SELECT gpu_upload('g5', v) AS u
+      FROM (VALUES (9223372036854775807::BIGINT), (1::BIGINT)) t(v)) up;
+-- expect: -9223372036854775808  2
+
+-- 6. Re-upload under an existing name replaces the column (10 rows -> 3 rows)
+SELECT gpu_sum_resident('g6') AS s, gpu_resident_info('g6') LIKE 'dtype=I64 rows=3 %' AS rows_ok, u2
+FROM (SELECT gpu_upload('g6', range::BIGINT) AS u2
+      FROM (SELECT u1 FROM (SELECT gpu_upload('g6', range::BIGINT) AS u1
+                            FROM range(10)) a) b, range(3)) up;
+-- expect: 3  true  3
+
+-- 7. The stats line never pairs backend=CPU with reason=Hot_GpuAlwaysWins
+--    (f64 columns are CPU-resident on Metal; reason must say Resident_OnCpu)
+SELECT gpu_last_stats() NOT LIKE '%backend=CPU reason=Hot_GpuAlwaysWins%' AS truthful, s > 0 AS sum_ok, u
+FROM (SELECT gpu_sum_resident_f64('g7') AS s, u
+      FROM (SELECT gpu_upload('g7', (range + 1)::DOUBLE) AS u FROM range(2000000)) up) q;
+-- expect: true  true  2000000

--- a/test/sqllogic/gpudb.test
+++ b/test/sqllogic/gpudb.test
@@ -392,3 +392,10 @@ false
 statement error
 SELECT gpu_sum_resident('r1');
 ----
+
+# gpu_build_info: compiled-backend tripwire. CPU is always compiled; the CI
+# runner has no GPU so runtime resolves to cpu there (cuda/metal on GPU boxes).
+query T
+SELECT gpu_build_info() LIKE 'compiled=cpu%runtime=%';
+----
+true

--- a/test/sqllogic/gpudb.test
+++ b/test/sqllogic/gpudb.test
@@ -254,3 +254,141 @@ GROUP BY k ORDER BY k;
 ----
 1	nan
 2	5.0
+
+# ---------------------------------------------------------------------------
+# Resident-column surface (v0.4.0): gpu_upload / gpu_*_resident /
+# gpu_resident_info / gpu_drop_resident / gpu_last_stats.
+# The sqllogictest connection persists across queries, so a column uploaded in
+# one statement is queryable in the next. All assertions are deterministic and
+# backend-independent (CPU fallback in CI, CUDA/Metal on GPU boxes).
+# ---------------------------------------------------------------------------
+
+# Upload 0..999 under a name; the aggregate returns the uploaded row count.
+query I
+SELECT gpu_upload('r1', range::BIGINT) FROM range(1000);
+----
+1000
+
+# Resident reductions, no re-scan: sum/min/max of 0..999.
+query I
+SELECT gpu_sum_resident('r1');
+----
+499500
+
+query I
+SELECT gpu_min_resident('r1');
+----
+0
+
+query I
+SELECT gpu_max_resident('r1');
+----
+999
+
+# Resident result matches the native aggregate over the same data.
+query T
+SELECT gpu_sum_resident('r1') = (SELECT sum(range::BIGINT) FROM range(1000));
+----
+true
+
+# gpu_last_stats records the reduction (backend varies; shape does not).
+query T
+SELECT gpu_last_stats() LIKE 'op=resident_i64 backend=%rows=1000%';
+----
+true
+
+# DOUBLE column: resident f64 sum. 0..99 halved sums to 2475.
+query I
+SELECT gpu_upload('r2', (range / 2.0)::DOUBLE) FROM range(100);
+----
+100
+
+query R
+SELECT gpu_sum_resident_f64('r2');
+----
+2475.0
+
+# Dtype mismatch is a clean error, not a wrong answer.
+statement error
+SELECT gpu_sum_resident('r2');
+----
+
+statement error
+SELECT gpu_sum_resident_f64('r1');
+----
+
+# NULL values are skipped at upload (2 of 4 rows survive).
+query I
+SELECT gpu_upload('r3', CASE WHEN range % 2 = 0 THEN range ELSE NULL END::BIGINT)
+FROM range(4);
+----
+2
+
+query I
+SELECT gpu_sum_resident('r3');
+----
+2
+
+# A NULL name at upload is an error (never silently registered under '').
+statement error
+SELECT gpu_upload(NULL::VARCHAR, v) FROM (VALUES (5::BIGINT)) t(v);
+----
+
+# Mixed names within one upload are an error (values never cross columns).
+statement error
+SELECT gpu_upload(nm, v) FROM (VALUES ('a', 1::BIGINT), ('b', 2::BIGINT)) t(nm, v);
+----
+
+# A NULL name on the read side yields SQL NULL for that row, not a query error.
+query I
+SELECT gpu_sum_resident(NULL::VARCHAR);
+----
+NULL
+
+# Unknown names are a clean error.
+statement error
+SELECT gpu_sum_resident('never_uploaded');
+----
+
+# i64 sum WRAPS on overflow (documented; native sum(BIGINT) promotes instead).
+query I
+SELECT gpu_upload('r4', v) FROM (VALUES (9223372036854775807::BIGINT), (1::BIGINT)) t(v);
+----
+2
+
+query I
+SELECT gpu_sum_resident('r4');
+----
+-9223372036854775808
+
+# Re-upload under an existing name replaces the column.
+query I
+SELECT gpu_upload('r1', range::BIGINT) FROM range(10);
+----
+10
+
+query I
+SELECT gpu_sum_resident('r1');
+----
+45
+
+# gpu_resident_info reports dtype and rows.
+query T
+SELECT gpu_resident_info('r1') LIKE 'dtype=I64 rows=10 %';
+----
+true
+
+# Drop frees the column; a second drop reports it is gone.
+query T
+SELECT gpu_drop_resident('r1');
+----
+true
+
+query T
+SELECT gpu_drop_resident('r1');
+----
+false
+
+statement error
+SELECT gpu_sum_resident('r1');
+----


### PR DESCRIPTION
## What

Extension-side hardening of the v0.4.0 resident-column surface — closes every extension finding from the pre-release adversarial review (three independent review passes; the build-system findings are #58).

### Fixes
- **Window-frame OOM (blocker):** `gpu_upload(...) OVER (...)` buffers O(n²) via per-output-row `combine()` — measured **13.8 GB RSS from 50k input rows**. In-flight upload buffers are now capped (default 4 GB, `GPUDB_UPLOAD_POOL_MAX_MB`); exceeding the cap is a clean error naming the env var and the window pitfall.
- **Mixed-name merge:** `gpu_upload(name_column, v)` silently merged every value into the first row's column (data attributed to the wrong name). Now a hard error; per-row name check is an allocation-free memcmp.
- **NULL names:** upload with a NULL name silently registered the column under `''`; now errors. Read side: a NULL name *row* yields SQL NULL for that row instead of aborting the query (consistent with constant-NULL behavior).
- **Signed-overflow UB:** i64 sums accumulate in `uint64` (documented wrap semantics, defined behavior) — OpenMP, scalar, and fused `agg_all` paths.
- **Truthful diagnostics:** `gpu_last_stats` claimed `reason=Hot_GpuAlwaysWins` for CPU-resident reductions; new additive `DispatchReason::Resident_OnCpu` (shared `gpu_backend.hpp`, enum value 6 — Linux instance: your reference branch used a different name for this slot, this one is canonical).

### Performance
Builds without OpenMP (Apple clang = every macOS build) reduced single-threaded. New chunked `std::thread` fallback with deterministic combine order. **Resident f64 sum on M4 Max flips from losing to native (29 ms vs 11 ms, TPC-H SF10) to winning: 3 ms vs 11 ms.**

### Benchmarks (BENCHMARK.md v0.4.0 entry, 5-run medians)
| Platform | `sum(BIGINT)` | `sum(DOUBLE)` |
|---|---|---|
| M4 Max / Metal, SF10 60M | native 9 ms → **2 ms (4.5×)** | native 11 ms → **3 ms (3.4×)** |
| RTX 4090 Laptop / CUDA, 100M | native 40 ms → **2 ms (~20×)** | 10M: native 10 ms → **~1 ms (~10×)** |

### Tests
- `test/sql/gpu_resident_guardrails.test`: 7 cases pinning every fix (incl. the window-cap path under a 1 MB cap).
- `test/sqllogic/gpudb.test`: full resident-surface coverage — the community-CI runner previously exercised **none** of the new functions.
- KNOWN_ISSUES.md: v0.4.0 design-notes table (wrap semantics, name rules, pool cap, pruning footgun, zonemap caveat).

Verified on M4 Max: 96/96 unit, SQL suite green (69 + 7 new), sqllogic sequence hand-verified on DuckDB v1.5.5.
