### PR TITLE
chore(sync): remove nine stale May-era worktree status files

### DIFF
--- a/.sync/feat-ci-and-cpu-parallel.md
+++ b/.sync/feat-ci-and-cpu-parallel.md
@@ -1,6 +1,0 @@
-# feat-ci-and-cpu-parallel
-- branch: feat/ci-and-cpu-parallel
-- working on: CI workflow + parallel CPU GROUP BY (non-conflicting with feat/cuda-hashjoin)
-- status: in_progress
-- blocked on: nothing
-- last update: 2026-05-09T18:54:36Z

--- a/.sync/feat-core-hybrid-planner.md
+++ b/.sync/feat-core-hybrid-planner.md
@@ -1,6 +1,0 @@
-# feat-core-hybrid-planner
-- branch: feat/core-hybrid-planner
-- working on: implementing GOAL.md item 7 — hybrid CPU/GPU planner v1 (HybridAggregator + HybridGroupByAggregator + bench)
-- status: in_progress
-- blocked on: nothing
-- last update: 2026-05-09T21:55:29Z

--- a/.sync/feat-ext-duckdb-stub.md
+++ b/.sync/feat-ext-duckdb-stub.md
@@ -1,6 +1,0 @@
-# feat-ext-duckdb-stub
-- branch: feat/ext-duckdb-stub
-- working on: (work complete)
-- status: done
-- blocked on: nothing
-- last update: 2026-05-09T19:19:37Z

--- a/.sync/feat-ext-macos-validate.md
+++ b/.sync/feat-ext-macos-validate.md
@@ -1,6 +1,0 @@
-# feat-ext-macos-validate
-- branch: feat/ext-macos-validate
-- working on: starting feat/ext-macos-validate: build + test DuckDB extension on Apple Silicon
-- status: in_progress
-- blocked on: nothing
-- last update: 2026-05-09T21:43:31Z

--- a/.sync/feat-metal-hashjoin-scaffold.md
+++ b/.sync/feat-metal-hashjoin-scaffold.md
@@ -1,6 +1,0 @@
-# feat-metal-hashjoin-scaffold
-- branch: feat/metal-hashjoin-scaffold
-- working on: starting feat/metal-hashjoin-scaffold: HashJoinProbe abstract interface + CPU reference + Metal sort-merge stub
-- status: in_progress
-- blocked on: nothing
-- last update: 2026-05-09T21:45:11Z

--- a/.sync/feat-metal-multiagg.md
+++ b/.sync/feat-metal-multiagg.md
@@ -1,6 +1,0 @@
-# feat-metal-multiagg
-- branch: feat/metal-multiagg
-- working on: starting feat/metal-multiagg: agg_all_i64 (sum+min+max+count single-pass)
-- status: in_progress
-- blocked on: nothing
-- last update: 2026-05-09T21:43:10Z

--- a/.sync/fix-window-bugs-followup.md
+++ b/.sync/fix-window-bugs-followup.md
@@ -1,6 +1,0 @@
-# fix-window-bugs-followup
-- branch: fix/window-bugs-followup
-- working on: (work complete)
-- status: done
-- blocked on: nothing
-- last update: 2026-05-10T00:33:00Z

--- a/.sync/fix-window-partition-bug.md
+++ b/.sync/fix-window-partition-bug.md
@@ -1,6 +1,0 @@
-# fix-window-partition-bug
-- branch: fix/window-partition-bug
-- working on: (work complete)
-- status: done
-- blocked on: nothing
-- last update: 2026-05-09T22:26:22Z

--- a/.sync/test-sql-suite-expand.md
+++ b/.sync/test-sql-suite-expand.md
@@ -1,6 +1,0 @@
-# test-sql-suite-expand
-- branch: test/sql-suite-expand
-- working on: (work complete)
-- status: done
-- blocked on: nothing
-- last update: 2026-05-09T22:30:17Z


### PR DESCRIPTION
All from worktrees retired in May; most read '(work complete)'. The two
live instance files and the convention README stay.
