### PR TITLE
chore(sync): refresh linux instance status

### DIFF
--- a/.sync/duckdbgpumetaldb.md
+++ b/.sync/duckdbgpumetaldb.md
@@ -1,6 +1,6 @@
 # duckdbgpumetaldb
-- branch: fix/core-cuda-ci-hardening
-- working on: fix/core-cuda-ci-hardening: e/f/g build-system fixes verified (CUDAARCHS empty-guard, x86_64 gate, --exclude-libs); PR going up
-- status: in_progress
+- branch: main
+- working on: (work complete)
+- status: done
 - blocked on: nothing
-- last update: 2026-08-15T00:27:36Z
+- last update: 2026-08-15T16:00:59Z


### PR DESCRIPTION
Refreshes .sync/duckdbgpumetaldb.md: CI-hardening work (PR #58) merged; instance is idle on main, watching duckdb/community-extensions#2503. Also deleted the superseded reference branch fix/ext-resident-semantics (local + origin) now that #59 is merged.