### PR TITLE
chore(sync): linux status — CUDA resident joins in progress

### DIFF
--- a/.sync/duckdbgpumetaldb.md
+++ b/.sync/duckdbgpumetaldb.md
@@ -1,6 +1,6 @@
 # duckdbgpumetaldb
-- branch: main
-- working on: (work complete)
-- status: done
+- branch: feat/cuda-join-v050
+- working on: feat/cuda-join-v050 (local): CUDA resident joins implemented; unit tests 118/118, join parity 11/11 on CUDA; TPC-H SF10/SF50 regen running for join benchmarks
+- status: in_progress
 - blocked on: nothing
-- last update: 2026-08-15T16:00:59Z
+- last update: 2026-08-17T19:05:38Z


### PR DESCRIPTION
Status refresh only: linux instance is implementing the v0.5.0 CUDA resident joins on a local branch; unit tests 118/118 and join parity 11/11 pass locally.