### PR TITLE
feat: v0.5.0 — GPU joins from SQL on Apple Metal and NVIDIA CUDA

### DIFF
--- a/.sync/duckdbgpumetaldbram.md
+++ b/.sync/duckdbgpumetaldbram.md
@@ -1,6 +1,6 @@
 # duckdbgpumetaldbram
-- branch: main
-- working on: (work complete) — v0.4.0 released: #58/#59/#60-#64 merged, tag pushed, GitHub release up (osx_arm64), registry PR duckdb/community-extensions#2503 open, nightly registry-smoke CI added
-- status: done
-- blocked on: nothing (linux release binary + registry review pending on their sides)
-- last update: 2026-08-15T04:30:00Z
+- branch: feat/metal-join-v050
+- working on: v0.5.0 PR assembly: BENCHMARK.md joins section, KNOWN_ISSUES, committed SQL join tests, review pass, then PR
+- status: in_progress
+- blocked on: nothing
+- last update: 2026-08-22T15:27:32Z

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -890,31 +890,44 @@ These are wired into `src/operators/planner.cpp` (this commit / next).
 | Gap | Owner | Effort |
 |---|---|---|
 | Mac CPU OpenMP baseline | macOS instance | 1 hr |
-| TPC-H lineitem on Metal | macOS instance | 1 hr (in flight) |
-| Metal radix sort for >10M rows | macOS instance (in flight on `feat/metal-groupby-radix-gpu`) | multi-session |
-| CUDA hash join probe | Linux instance | multi-session |
-| Window functions on CUDA | Linux instance | this PR (in flight) |
-| Hybrid planner wiring in extension | Linux instance | this PR (in flight) |
+| TPC-H lineitem on Metal | macOS instance | 1 hr |
+| Window functions on CUDA | Linux instance | multi-session |
 
 ---
 
-## 2026-05-09 (night) — Metal hash-join SCAFFOLD landed
+## 2026-07-07 — Metal hash join: adaptive global + partitioned TG hash
 
-`HashJoinProbe` abstract interface + CPU reference (`std::unordered_map`) +
-Metal STUB are in. The Metal stub currently delegates to CPU work under the
-hood (Backend::METAL with CPU-shaped reduction), the same pattern the
-original Metal groupby used before being replaced with a real GPU kernel.
+Metal inner equi-join on int64 keys. Small builds (≤500k rows) use a fused
+global slot-lock hash table (one command buffer). Larger builds use full radix
+hash join: partition both sides, per-partition threadgroup hash build+probe
+(same pattern as Metal GROUP BY slot-lock). Sort-merge remains when
+`2 × n_build` exceeds the 256M-slot cap. Override: `GPUDB_METAL_HASHJOIN_PATH`.
 
-**Numbers will therefore match the CPU baseline** — that's expected. The
-real Metal sort-merge implementation will replace the stub when the CUDA
-hash-join (in flight on `feat/cuda-hashjoin`) lands on main and the
-abstract contract is locked in.
+### Apple M4, 1M build × 10M probe (96.9% selectivity)
 
-Why sort-merge for Metal (not a direct CUDA port): Apple Silicon GPUs have
-no 64-bit `atomic_compare_exchange`, so the CUDA open-addressing hash table
-can't be mirrored. Sort + binary-search merge reuses the radix-sort kernels
-already in `groupby.metal`. See `src/backends/metal/metal_hashjoin.mm`
-header for the planned algorithm.
+```
+gpudb-hashjoin-bench  build=1,000,000  probe=10,000,000  runs=5  skew=0.0
+
+[CPU]   median wall=191 ms    0.43 GiB/s
+[Metal] median wall= 38 ms    2.17 GiB/s   kernel 22 ms (4.9× wall, partitioned TG hash)
+```
+
+100k × 500k: Metal 2.1 ms wall vs CPU 3.5 ms (auto-selects global path).
+Build scatter is cached when the same build table is probed repeatedly.
+
+---
+
+## 2026-07-07 (earlier) — Metal hash join: global slot-lock only
+
+First landing used a single global slot-lock table (4.4× wall @ 1M×10M).
+Superseded by the adaptive + partitioned TG hash path above for large builds.
+
+---
+
+## 2026-05-09 (night) — Metal hash-join SCAFFOLD landed (superseded)
+
+~~`HashJoinProbe` abstract interface + CPU reference + Metal STUB.~~
+Superseded by the Metal hash join paths above.
 
 ### Apple M4 Max, scaffold sanity run (Metal == CPU until kernel lands)
 
@@ -975,8 +988,8 @@ that compete with CUDA on real workloads. Achieved.
 3. ✅ Resident-column workloads with many queries per upload —
    already implicit in HOT vs COLD (200M COLD 69.5 ms vs HOT 4.46 ms = 15.6×
    amortization, in addition to the GPU vs CPU win).
-4. ⏳ Sort-based hash join (when CUDA hash-join lands on main) —
-   another high-cardinality regime where Metal should win 3-5× over CPU.
+4. ✅ Hash join — adaptive global + partitioned TG hash on Metal (4.9× wall @ 1M×10M);
+   CUDA slot-lock path ships separately.
 
 ---
 

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -2,6 +2,136 @@
 
 Append-only. Reproducible runs only — include hardware, CUDA toolkit, build flags.
 
+## 2026-08-22 (v0.5.0) — fused resident joins: the GPU beats DuckDB's native hash join end-to-end, on both backends
+
+First benchmark of the fused resident join surface
+(`gpu_upload_pair` + `gpu_[left_|semi_|anti_]join_{sum,count}_resident[_f64]`
+and the row-returning `gpu_join_rows_resident`). The join model: keys and
+payload are uploaded once with `gpu_upload_pair`; the build side is radix-
+sorted on the device on first use and cached (with its permutation); every
+later join probes that sorted build with a binary search and reduces the
+payload in the same pass — no materialised join output, `transfer_ms=0.000`.
+
+**Correctness gates before any timing counted** (identical on both backends):
+`BIGINT` sums bit-equal to native (`IS NOT DISTINCT FROM`), `matched` equal to
+native `COUNT(*)`, `DOUBLE` sums within a 1e-9 relative contract (measured
+≤ 1e-11 on CUDA, ≤ 1e-14 on Metal). `scripts/join_parity_check.sh` (11
+adversarial scenarios × 12 checks, native and gpudb in the same statement)
+passes 11/11 on both machines. Data: TPC-H dbgen; SF10 = 59,986,052 lineitem ⋈
+15,000,000 orders; SF50 = 300,005,811 ⋈ 75,000,000.
+
+The six measurements (money columns uploaded as cents `BIGINT` for the i64
+rows, as `DOUBLE` for the f64 rows):
+
+- **(a) inner i64** — `sum(l_extendedprice)` over `lineitem ⋈ orders ON l_orderkey = o_orderkey` (lineitem probe, orders build).
+- **(b) inner f64** — the same join with a `DOUBLE` payload.
+- **(c) multiplicity** — `sum(o_totalprice)` over `orders ⋈ lineitem` (orders probe, lineitem build: each probe row matches ~4 build rows — the full-multiplicity path, honestly measured).
+- **(d) Q3-style filtered join** — f64 revenue expression over `lineitem ⋈ (orders WHERE o_orderdate filter)` (build = 7.3M filtered orders at SF10, 49% selectivity).
+- **(e) EXISTS semi-join** — `sum(o_totalprice)` for orders that have a late lineitem (`gpu_semi_join_sum_resident_f64`, build = 37.9M at SF10).
+- **(f) row-returning** — `count(*)` over `gpu_join_rows_resident(probe, build, 'inner')`, 60M output pairs, end-to-end — the honest materialisation row.
+
+### Apple M4 Max (Metal) — native and embedded engine both DuckDB v1.5.2
+
+Branch `feat/metal-join-v050`, clean rebuild; native = DuckDB CLI v1.5.2
+`-readonly`, 16 threads, `.timer on`, warm, median of 5 after a warm-up.
+gpudb = `gpu_last_stats()` `wall_ms` of the warm call (uploads paid earlier);
+`backend=Metal reason=Hot_GpuAlwaysWins transfer_ms=0.000` on every
+aggregate row. SF50 ran with `GPUDB_UPLOAD_POOL_MAX_MB=12288`.
+
+| measurement | SF | native (ms) | gpudb warm (ms) | speedup | result check |
+|---|---|---:|---:|---:|---|
+| (a) inner i64 | 10 | 85 | 6.0 | **14.1×** | bit-exact 229381315677336, matched 59,986,052 |
+| (a) inner i64 | 50 | 429 | 36.8 | **11.7×** | bit-exact 1147107475076666, matched 300,005,811 |
+| (b) inner f64 | 10 | 76 | 11.9 | **6.4×** | rel-diff 3e-14 |
+| (b) inner f64 | 50 | 363 | 60.5–71.6 | **5.1–6.0×** | rel-diff 1.5e-14 |
+| (c) multiplicity | 10 | 84 | 10.4 | **8.1×** | bit-exact 1132953380841601 |
+| (d) Q3-style filtered f64 | 10 | 68 | 13.7 | **5.0×** | rel-diff 6e-15, matched 29,150,762 |
+| (e) EXISTS semi f64 | 10 | 182 | 8.2 | **22.2×** | rel-diff 4e-16, matched 13,753,474 |
+| (f) rows, 60M pairs, end-to-end | 10 | 76 | 65.4 | 1.16× | 59,986,052 pairs == native |
+
+One-time costs, stated plainly: the upload + first-join sort statement is
+≈ 0.9–1.3 s at SF10 and ≈ 7.5 s at SF50 — break-even after ~15–20 repeated
+joins at SF10, ~20 at SF50; every join after that is 70–400 ms cheaper.
+
+f64 on Metal: no doubles in MSL, so the `DOUBLE` payload reduction is split —
+the GPU kernel writes each probe row's multiplicity (the random-access part),
+the host does one sequential multiply-add stream over the payload. A pure
+host binary-search loop was 458 ms (lost to native 76 ms); the split is
+11.9 ms. Pattern: "GPU searches, host streams".
+
+### NVIDIA RTX 4090 Laptop (sm_89, 16 GB, driver 580.178.04, CUDA 13.0) — native DuckDB CLI v1.5.5 (v1.5.2 agrees within ~10%)
+
+Branch `feat/cuda-join-v050`, clean rebuild. Native: DuckDB CLI v1.5.5
+(d8cdaa33fd) `-readonly`, 20 threads, `.timer on`, query 5× in one process,
+run 1 discarded, settled value; every native also re-run on a v1.5.2 CLI
+(listed second). Embedded libduckdb in `gpudb-sql`: v1.5.2. gpudb:
+`gpu_last_stats()` `wall_ms` after the last of 3 calls (cold/warm/warm), the
+statement run twice per pass, 4 independent passes — ranges are min–max over
+the 8 samples, not averaged. All aggregate rows `backend=CUDA
+reason=Hot_GpuAlwaysWins transfer_ms=0`. SF50 used
+`GPUDB_UPLOAD_POOL_MAX_MB=10240` (i64) / `12288` (f64).
+
+| measurement | SF | native v1.5.5 / v1.5.2 (ms) | gpudb warm (ms) | speedup |
+|---|---|---:|---:|---:|
+| (a) inner i64 | 10 | 239 / 229 | 4.9–6.0 | **~40×** |
+| (a) inner i64 | 50 | 998 / 1011 | 26.9–36.7 | **27–37×** |
+| (b) inner f64 (fully on-device) | 10 | 242 / 210 | 4.9–6.0 | **~44×** |
+| (b) inner f64 | 50 | 1090 / 1074 | 34.2–37.9 | **~30×** |
+| (c) multiplicity | 10 | 246 / 255 | 1.73–1.76 | **~140×** |
+| (c) multiplicity | 50 | 1037 / 1087 | 8.25–9.0 | **~124×** |
+| (d) Q3-style filtered f64 | 10 | 141 / 193 | 4.83–5.69 | **25–29×** |
+| (d) Q3-style filtered f64 | 50 | 704 / 728 | 26.6–35.7 | **20–26×** |
+| (e) EXISTS semi f64 | 10 | 640 / 623 | 1.70 (every sample) | **~376×** |
+| (e) EXISTS semi f64 | 50 | 2775 / 2932 | 7.5–8.98 | **~330×** |
+| (f) rows, 60M pairs, end-to-end | 10 | 232 / 272 | 453–481 | 0.5× — **native wins** |
+
+Correctness, identical in all 4 passes and equal to the Metal values: (a)
+SF10 229381315677336 / SF50 1147107475076666, matched 59,986,052 /
+300,005,811; (c) 1132953380841601 / 5666767889974700; (d) matched
+29,150,762 / 145,747,936; (e) matched 13,753,474 / 68,769,689; f64 within
+~1e-11 relative; (f) pairs == native `COUNT(*)`.
+
+**Losing row, stated plainly — (f) on a discrete GPU.** `gpu_last_stats()`
+for the 60M-pair materialisation: wall 356.6 ms = kernel 14.8 + transfer
+341.8 ms — ≈ 960 MB of index pairs crossing PCIe device→host (pageable).
+Native DuckDB's hash join wins end-to-end by 2×. Pinned staging could
+roughly halve the copy but not close the gap. The fused aggregate variants
+have no device→host output and are the intended path on PCIe hardware; the
+rows function is the composability primitive for unified-memory machines
+(where it wins modestly, see the Metal row). SF50 (f) not run: 300M pairs
+exceeds `GPUDB_JOIN_ROWS_MAX_M` (100M) by design.
+
+Why CUDA's ratios are higher than Metal's: the 4090's native baseline is
+2–3× slower than the M4 Max's (20-thread laptop CPU vs Apple's memory
+subsystem) while its sorted-build probe is disproportionately fast (L2
+catches the top levels of the binary search) — the (c)/(e) shapes benefit
+most. Both columns are the truth for their machine.
+
+Timing variance note (CUDA): SF50 (a)/(d) are bimodal 27 ↔ 36 ms — laptop
+GPU clock states; both modes are inside the ranges; correctness unaffected.
+
+### Reproduce
+
+```bash
+./scripts/get_duckdb_libs.sh && ./scripts/build.sh        # gpudb-sql
+SF=10 ./scripts/gen_tpch.sh                                # data/tpch_sf10/
+./scripts/join_parity_check.sh build-macos                 # or build-linux: 11 scenarios, 0 failed
+
+# (a) inner i64 — uploads and the join in one statement (reference every
+# upload's count column, or the upload subquery is pruned):
+./build-macos/bin/gpudb-sql --sql "
+SELECT gpu_join_sum_resident('l.k','l.v','o') AS cents, gpu_last_stats(), u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('l', l_orderkey, (l_extendedprice*100)::BIGINT) AS n1 FROM lineitem) u1,
+     (SELECT gpu_upload('o', o_orderkey) AS n2 FROM orders) u2;"
+# native bar, same engine version, warm:
+#   SELECT sum((l_extendedprice*100)::BIGINT) FROM lineitem l JOIN orders o ON l.l_orderkey = o.o_orderkey;
+# (e) semi: gpu_semi_join_sum_resident_f64('o.k','o.v','late') with
+#   build 'late' = l_orderkey WHERE l_receiptdate > l_commitdate.
+# (f) rows: gpudb-sql --multi, uploads as earlier statements, then
+#   SELECT count(*) FROM gpu_join_rows_resident('l','o','inner');
+# SF50: export GPUDB_UPLOAD_POOL_MAX_MB=12288
+```
+
 ## 2026-08-15 (v0.4.0) — resident-column SQL surface: the GPU wins from SQL
 
 First benchmark of the `gpu_upload` / `gpu_*_resident` SQL functions (merged in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(GPUDB_ENABLE_METAL  "Enable Metal backend (auto on macOS)" ON)
 option(GPUDB_BUILD_TESTS   "Build unit tests"                     ON)
 option(GPUDB_BUILD_BENCH   "Build CLI benchmark tool"             ON)
 option(GPUDB_BUILD_EXT     "Build DuckDB extension wrapper"       OFF)
+option(GPUDB_REQUIRE_CUDA  "Fail configure if the CUDA toolkit is not found (no silent CPU fallback)" OFF)
 # Static cudart => the produced binaries have NO dynamic dependency on
 # libcudart.so/libcuda.so, so a CUDA-enabled loadable extension still LOADs on
 # GPU-less/driver-less machines (cudart_static dlopens the driver at runtime;
@@ -78,6 +79,9 @@ if(GPUDB_ENABLE_CUDA)
         set(GPUDB_HAS_CUDA ON)
         message(STATUS "CUDA enabled (compiler: ${CMAKE_CUDA_COMPILER}, archs: ${CMAKE_CUDA_ARCHITECTURES}, toolkit: ${CUDAToolkit_VERSION}, static runtime: ${GPUDB_CUDA_STATIC_RUNTIME})")
     else()
+        if(GPUDB_REQUIRE_CUDA)
+            message(FATAL_ERROR "GPUDB_REQUIRE_CUDA=ON but no CUDA compiler was found. Put nvcc on PATH (e.g. export PATH=/usr/local/cuda/bin:$PATH) or set CUDACXX=/path/to/nvcc, or build without the flag to get the CPU-only fallback.")
+        endif()
         message(STATUS "CUDA toolkit not found — CUDA backend disabled")
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(gpudb
-    VERSION 0.4.0
+    VERSION 0.5.0
     DESCRIPTION "GPU-accelerated operators for DuckDB (CUDA + Metal)"
     LANGUAGES CXX
 )

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,8 +1,8 @@
 # Known issues
 
-Status as of 2026-08-15, `v0.4.0`. **All known functional bugs resolved.**
+Status as of 2026-08-22, `v0.5.0`. **All known functional bugs resolved.**
 
-If you do hit something here, fall back to native DuckDB `sum()` / `min()` / `max()` / window functions for that query.
+If you do hit something here, fall back to native DuckDB `sum()` / `min()` / `max()` / `JOIN` / window functions for that query — every shape the GPU path does not cover runs natively.
 
 ---
 
@@ -38,6 +38,24 @@ matching native DuckDB, and `IS NULL` on such a result is now `true`.
 | Resident f64 columns run on the host on Apple Silicon (`reason=Resident_OnCpu`) | No IEEE-754 doubles in MSL. The host path is parallel (chunked reduction) as of v0.4.0 — measured faster than a native DuckDB scan on M4 Max — and f64 sums are deterministic per upload, not per dataset (parallel upload order affects rounding, same as native). |
 | Whole-column `gpu_min_resident`/`gpu_max_resident` are slower than native `min()`/`max()` on unfiltered persistent tables | Native answers those from zonemap statistics without scanning — a metadata lookup no engine can beat. The resident path wins where a real reduction happens (sums, or data DuckDB has no stats for). |
 
+### Design notes — fused resident joins (v0.5.0)
+
+| Behavior | Reason |
+|---|---|
+| Join keys must be `BIGINT` resident columns; payloads may be `BIGINT` or `DOUBLE` | The v0.5 join ABI is single-column i64 equi-join. `DOUBLE`/`DECIMAL`/`VARCHAR` keys, composite keys, and non-equi joins are not on the GPU path — write them as native `JOIN`s. |
+| Keys and payloads must be uploaded together with `gpu_upload_pair(name, key, payload)` — registers `name.k` and `name.v` | Two separate `gpu_upload` calls over a parallel scan do not preserve row alignment between key and payload (DuckDB scans chunks in parallel); a misaligned pair silently sums the wrong rows. `gpu_upload_pair` interleaves both in one scan. |
+| `gpu_join_sum_resident` returns SQL `NULL` when no rows join; `gpu_join_count_resident` returns `0` | Matches native `sum()` / `count(*)` over an empty join. |
+| INNER and LEFT carry full build-side multiplicity (a probe row joined to 3 equal build keys contributes 3×); SEMI/ANTI contribute each probe row at most once | Native join semantics. `matched` in `gpu_last_stats()` counts the rows contributing for that kind (ANTI counts non-matching probe rows). |
+| RIGHT / FULL OUTER are compositions, not separate functions | Probe-payload sum equals INNER / LEFT respectively; the missing-side `COUNT(*)` term is `gpu_anti_join_count_resident` with the sides swapped. |
+| `DOUBLE` join sums are compared to native within a relative tolerance (1e-9 contract; measured ≤ 1e-11 on both backends), never bit-for-bit | Summation order differs per backend (CUDA: on-device atomics; Metal: GPU multiplicity + host stream). `BIGINT` sums are bit-exact on both. |
+| On Apple Silicon the `DOUBLE` payload reduction runs on the host after the GPU computes per-row multiplicity ("GPU searches, host streams") | No IEEE-754 doubles in MSL. Still 5–6× faster than native at SF50 because the random-access part is on the GPU and the host pass is a sequential stream. |
+| `gpu_join_rows_resident` (row-returning) wins modestly on unified memory (1.16× at 60M pairs on M4 Max) and **loses to native on discrete GPUs** (0.5× on RTX 4090: ~96% of wall is the ~960 MB device→host copy) | Materialising 60M index pairs across PCIe costs more than DuckDB's native hash join. Use the fused aggregate variants on discrete GPUs; the rows function is the composability primitive for unified-memory machines. Output capped at `GPUDB_JOIN_ROWS_MAX_M` (default 100M rows) with a clean error. |
+| The build side's sorted-key + permutation cache (16 bytes per build row) lives on the device outside the `GPUDB_UPLOAD_POOL_MAX_MB` accounting | Device OOM surfaces as a clean `runtime_error` on the first join call rather than at upload. |
+| TPC-H SF50-scale pair uploads need `GPUDB_UPLOAD_POOL_MAX_MB` raised (10–12 GB) | Default 4 GB pool refuses with the documented error; same guardrail as resident columns. |
+| `gpu_join_rows_resident` needs the uploads to run as earlier statements (`gpudb-sql --multi`, or separate statements on one connection) | A table function's bind/init cannot be sequenced after an upload in the same statement. The scalar join-aggregate functions have no such restriction. |
+| `probe_idx` / `build_idx` from `gpu_join_rows_resident` refer to **upload order**, which equals table order only when the upload scan was not parallel | Same ordering caveat as any parallel scan; use the indices to look up rows, not as row numbers of the source table. |
+| Multi-table join chains, `GROUP BY` over join results, and `ORDER BY` are not on the GPU path | Roadmap (v0.6). Unsupported shapes run natively — gpudb never breaks a query. |
+
 ### Type support (v0.3.0)
 
 | Aggregate | Supported input types | Notes |
@@ -53,6 +71,7 @@ matching native DuckDB, and `IS NULL` on such a result is now `true`.
 
 | Issue | Fixed in |
 |---|---|
+| CUDA v1 `HashJoinProbe` (operator-level, `gpudb-hashjoin-bench`) emitted every build row for duplicate build keys, diverging from the CPU reference and the header contract (first build row wins) | v0.5.0 — one slot per key, `atomicMin` on the smallest build index. Behaviour change only for callers relying on the old multimap output of the v1 probe; the v0.5 fused joins carry full multiplicity by design and are unaffected |
 | `gpu_min/gpu_max(DOUBLE)` leaked the fold identity (`+inf`/`-inf`) on all-NaN groups, and `gpu_max` dropped NaN where native returns NaN | v0.3.0 — caught by pre-release adversarial review, fixed before the overloads ever shipped: f64 min/max folds now use a NaN-aware total order matching native (NaN sorts greatest) |
 | `MIN/MAX/SUM(empty input)` returned `0` instead of SQL `NULL` | v0.2.0 (PR #44) — finalize marks the output row invalid via `duckdb_vector_ensure_validity_writable` + `duckdb_validity_set_row_invalid` when a state accumulated zero non-NULL values; `set_special_handling` registered so DuckDB does not short-circuit our NULL handling |
 | `MIN/MAX/SUM(all NULLs)` returned `0` instead of SQL `NULL` | v0.2.0 (PR #44) — same fix; a state with zero non-NULL values (all input rows NULL) yields SQL `NULL`, including per-group in GROUP BY |
@@ -73,5 +92,6 @@ cd duckdbgpumetaldbram
 ./scripts/get_duckdb_libs.sh
 ./scripts/build.sh
 ./scripts/local_check.sh        # builds + cpp tests + smoke benchmarks
-./scripts/run_sql_tests.sh      # 5 .test files, 60 queries, 0 fail / 0 xfail
+./scripts/run_sql_tests.sh      # 9 .test files, 0 fail (guardrail cases are asserted expected-fails)
+./scripts/join_parity_check.sh  # 11 adversarial join scenarios, native vs gpudb in the same statement
 ```

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -71,6 +71,7 @@ matching native DuckDB, and `IS NULL` on such a result is now `true`.
 
 | Issue | Fixed in |
 |---|---|
+| Metal v1 `HashJoinProbe` lost a small number of matches on GitHub's macOS runner (`Apple Paravirtual device`): 199,973 vs 199,998 on a 50k×200k join | v0.5.0 — the slot-lock tables spun on a locked slot for a bounded number of attempts (a GPU gives no cross-threadgroup forward-progress guarantee, so the spinner could give up and silently drop its row), read another thread's key through relaxed atomics, and chained init → build → probe in one compute encoder with no memory barrier. Now: wait-free insert (never spin, never read a foreign key during build), probe scans the whole run and keeps the smallest build index (exact first-row-wins on both paths), `memoryBarrierWithScope:MTLBarrierScopeBuffers` between dependent dispatches. Regression tests: duplicate-heavy 97-key build and a 700k-row 5-key build on the partitioned path |
 | CUDA v1 `HashJoinProbe` (operator-level, `gpudb-hashjoin-bench`) emitted every build row for duplicate build keys, diverging from the CPU reference and the header contract (first build row wins) | v0.5.0 — one slot per key, `atomicMin` on the smallest build index. Behaviour change only for callers relying on the old multimap output of the v1 probe; the v0.5 fused joins carry full multiplicity by design and are unaffected |
 | `gpu_min/gpu_max(DOUBLE)` leaked the fold identity (`+inf`/`-inf`) on all-NaN groups, and `gpu_max` dropped NaN where native returns NaN | v0.3.0 — caught by pre-release adversarial review, fixed before the overloads ever shipped: f64 min/max folds now use a NaN-aware total order matching native (NaN sorts greatest) |
 | `MIN/MAX/SUM(empty input)` returned `0` instead of SQL `NULL` | v0.2.0 (PR #44) — finalize marks the output row invalid via `duckdb_vector_ensure_validity_writable` + `duckdb_validity_set_row_invalid` when a state accumulated zero non-NULL values; `set_special_handling` registered so DuckDB does not short-circuit our NULL handling |
@@ -92,6 +93,6 @@ cd duckdbgpumetaldbram
 ./scripts/get_duckdb_libs.sh
 ./scripts/build.sh
 ./scripts/local_check.sh        # builds + cpp tests + smoke benchmarks
-./scripts/run_sql_tests.sh      # 9 .test files, 0 fail (guardrail cases are asserted expected-fails)
+./scripts/run_sql_tests.sh      # 9 .test files, 0 fail (4 GUARDRAIL cases assert that misuse is rejected)
 ./scripts/join_parity_check.sh  # 11 adversarial join scenarios, native vs gpudb in the same statement
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ SELECT gpu_last_stats();                                      -- proof: which pr
 --   wall_ms=9.702 kernel_ms=9.533 transfer_ms=0.000
 ```
 
-Apache-2.0 · v0.4.0 · Linux + macOS · DuckDB ≥ 1.2
+```sql
+-- v0.5.0: joins. Upload key+payload pairs once; the GPU joins and reduces
+-- in one pass against a cached sorted build side — no join output materialised.
+SELECT gpu_upload_pair('l', l_orderkey, (l_extendedprice*100)::BIGINT) FROM lineitem;  -- once
+SELECT gpu_upload('o', o_orderkey) FROM orders;                                          -- once
+SELECT gpu_join_sum_resident('l.k', 'l.v', 'o');   -- = sum(...) FROM lineitem JOIN orders
+--   SF50: 37 ms vs 429 ms native on M4 Max (11.7×), 27-37 ms vs 998 ms on RTX 4090 (~30×)
+-- inner / left / semi / anti × sum(BIGINT) / sum(DOUBLE) / count — all bit-exact
+-- or within 1e-9 of native, verified by scripts/join_parity_check.sh
+```
+
+Apache-2.0 · v0.5.0 · Linux + macOS · DuckDB ≥ 1.2
 
 ---
 
@@ -50,6 +61,10 @@ factors, six columns, both platforms) + reproduction: **[BENCHMARK.md](BENCHMARK
 
 | TPC-H | Workload | Hardware | Native | gpudb | |
 |---|---|---|---:|---:|:---|
+| **SF50** (300M ⋈ 75M) | `JOIN` + `SUM` BIGINT | RTX 4090 Laptop · CUDA | 998 ms | **27–37 ms** | **27–37× 🚀** |
+| **SF10** (60M ⋈ 15M) | `EXISTS` semi-join + `SUM` DOUBLE | RTX 4090 Laptop · CUDA | 640 ms | **1.7 ms** | **~376× 🚀** |
+| **SF50** (300M ⋈ 75M) | `JOIN` + `SUM` BIGINT | MacBook M4 Max · Metal | 429 ms | **37 ms** | **11.7× 🚀** |
+| **SF10** (60M ⋈ 15M) | `EXISTS` semi-join + `SUM` DOUBLE | MacBook M4 Max · Metal | 182 ms | **8.2 ms** | **22.2× 🚀** |
 | **SF50** (300M rows) | `SUM` BIGINT | RTX 4090 Laptop · CUDA | 99 ms | **4 ms** | **25× 🚀** |
 | **SF100** (600M rows) | `SUM` DOUBLE | RTX 4090 Laptop · CUDA | 196 ms | **9 ms** | **22× 🚀** |
 | **SF100** (600M rows) | `SUM` BIGINT | MacBook M4 Max · Metal | 99 ms | **10 ms** | **9.9× 🚀** |
@@ -233,38 +248,50 @@ Two SQL paths, by design (v0.4.0):
 - **Resident** `gpu_upload` + `gpu_*_resident` — the GPU path with substance:
   pay the transfer once, then reductions run on-device (CUDA and Metal) at
   memory-bandwidth speed with `transfer_ms=0.000`. This is where the
-  4–25× numbers above come from. The SQL join path is in development.
+  4–25× numbers above come from.
+- **Resident joins (v0.5.0)** `gpu_upload_pair` + `gpu_[left_|semi_|anti_]join_{sum,count}_resident[_f64]`
+  — fused join + reduction against a device-cached sorted build side; the
+  11–376× join rows above. Row-returning `gpu_join_rows_resident` exists as
+  the composability primitive (wins on unified memory, loses to native across
+  PCIe — [BENCHMARK.md](BENCHMARK.md) states both).
 
 ## Testing
 ```bash
-./build-linux/test/test_gpudb        # 96 unit checks across the backends present at build time
-./scripts/run_sql_tests.sh           # SQL-level suite: gpu_sum / min / max / GROUP BY / window
+./build-linux/test/test_gpudb        # unit checks across the backends present at build time (118 CUDA / 137 Metal)
+./scripts/run_sql_tests.sh           # SQL-level suite: gpu_sum / min / max / GROUP BY / window / resident / joins
+./scripts/join_parity_check.sh       # 11 adversarial join scenarios, native vs gpudb in the same statement
 ./scripts/local_check.sh             # everything CI would run, end to end
 ```
 
 The SQL test suite lives in `test/sql/*.test`. Each file is plain SQL with
 `-- expect:` lines after each query; the runner reports per-query
-PASS / FAIL / XFAIL (expected fail) / SKIP. As of v0.4.0: 76 queries green
-(69 pass + 7 guardrail cases whose expected errors are asserted), plus full
+PASS / FAIL / XFAIL (expected fail) / SKIP. As of v0.5.0: 91 queries green
+(87 pass + 4 guardrail cases whose expected errors are asserted), plus full
 resident-surface coverage in the community-CI sqllogic suite.
 
-**Reproducibility entry point:** [`scripts/local_check.sh`](scripts/local_check.sh) runs the full pipeline end-to-end (configure → build → 96 unit tests → smoke benchmarks → SQL suite). The hosted CI workflow lives at [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (Linux + macos-15) and runs on every push to `main`.
+**Reproducibility entry point:** [`scripts/local_check.sh`](scripts/local_check.sh) runs the full pipeline end-to-end (configure → build → unit tests → smoke benchmarks → SQL suite → join parity harness). The hosted CI workflow lives at [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (Linux + macos-15) and runs on every push to `main`.
 
 ## Roadmap
 
-### Latest — shipped in v0.4.0
+### Latest — shipped in v0.5.0
+- [x] **GPU joins from SQL, both backends** — `gpu_upload_pair` + fused `gpu_[left_|semi_|anti_]join_{sum,count}_resident[_f64]` (inner / left / semi / anti; right / full as documented compositions) and the row-returning `gpu_join_rows_resident`. Sorted-build + binary-search probe with the sorted side cached on the device. Verified against native DuckDB's hash join end-to-end on TPC-H SF10/SF50: **11.7× (Metal) / 27–37× (CUDA)** inner join-sum at SF50, **22× / ~376×** on the EXISTS semi-join; i64 bit-exact, f64 within 1e-11. Honest losing row kept: row materialisation across PCIe loses to native on discrete GPUs.
+- [x] **Adversarial parity harness** — `scripts/join_parity_check.sh`: 11 scenarios × 12 checks (dup-heavy, Knuth-hash, Zipf skew, int64 boundaries, negative keys, no-match, all-match, inverted sizes), native and gpudb computed in the same statement; passes on both machines.
+- [x] **Metal hash join + hybrid join planner + on-device segment reduce** — contributed by [@lmangani](https://github.com/lmangani) ([PR #43](https://github.com/singhpratech/duckdbgpumetaldbram/pull/43)); this release lands that commit as the base of the join stack.
+- [x] **Colab notebook runs real CUDA** — requests a T4 runtime automatically, builds with `GPUDB_REQUIRE_CUDA=1` (configure fails loudly instead of silently falling back to CPU), and the test cell asserts the CUDA backend actually ran.
+
+### Shipped in v0.4.0
 - [x] **Resident-column SQL surface** — `gpu_upload` / `gpu_sum_resident` / `gpu_min_resident` / `gpu_max_resident` / `gpu_sum_resident_f64` / `gpu_resident_info` / `gpu_last_stats` / `gpu_drop_resident` / `gpu_build_info`. The GPU genuinely executes SQL reductions on both CUDA and Metal — up to **25×** over native (see Numbers). Hardened by a three-reviewer adversarial pass pre-release: buffer-pool cap (window-frame O(n²) OOM → clean error), mixed-name/NULL-name guards, defined overflow wrap, truthful dispatch stats.
 - [x] **CUDA-ready community build** — the root Makefile auto-detects nvcc with a statically linked CUDA runtime (no libcuda/libcudart dynamic deps; loads clean on GPU-less machines) so the registry's Linux binary flips to CUDA automatically when the registry's build tooling ships its CUDA toolchain. Also fixed a CMake ordering bug that had every prior CUDA build shipping single-arch fatbins.
 - [x] **Full dual-platform benchmark record** — TPC-H SF1→SF100, six columns, correctness-gated, both backends, in [BENCHMARK.md](BENCHMARK.md).
 - [x] [Community Extensions PR #2503](https://github.com/duckdb/community-extensions/pull/2503) **merged** (2026-08-17) — the registry now serves **v0.4.0**, resident-column surface included.
 
 ### In flight
-- [ ] **Real Metal hash join + on-device segment reduce + `gpu_inner_join`** — contributed by [@lmangani](https://github.com/lmangani) in [PR #43](https://github.com/singhpratech/duckdbgpumetaldbram/pull/43) (verified 9.9× on a 1M×10M inner join on M4 Max); landing after a rebase/split pass.
 - [ ] **Community packaging phase 2** — `requires_toolchains: "python3;cuda"` registry update (the build side shipped in v0.4.0; the token activates when the registry adopts CUDA-capable ci-tools — `SELECT gpu_build_info();` shows what any given binary carries).
 
-### Next (v0.5.0 — directional, we'll see what the data says)
-- [ ] **GPU join as the SQL-path GPU story** — land and extend PR #43's join stack; benchmark against DuckDB's 16-thread hash join end-to-end.
-- [ ] Resident GROUP BY from SQL (`gpu_groupby_resident`) riding the same upload-once model
+### Next (v0.6.0 — directional, we'll see what the data says)
+- [ ] Resident GROUP BY from SQL returning (key, aggregate) rows, riding the same upload-once model and the cached radix sort
+- [ ] `ORDER BY` / top-k on resident columns
+- [ ] GROUP BY over join results; composite join keys
 - [ ] Resident f64 min/max (needs a v2 backend ABI entry)
 
 ### Beyond (v0.6.0+ — exploratory)

--- a/README.md
+++ b/README.md
@@ -265,8 +265,10 @@ Two SQL paths, by design (v0.4.0):
 
 The SQL test suite lives in `test/sql/*.test`. Each file is plain SQL with
 `-- expect:` lines after each query; the runner reports per-query
-PASS / FAIL / XFAIL (expected fail) / SKIP. As of v0.5.0: 91 queries green
-(87 pass + 4 guardrail cases whose expected errors are asserted), plus full
+PASS / FAIL / GUARDRAIL / SKIP. As of v0.5.0: 91 queries, 0 failures — 87
+result checks plus 4 GUARDRAIL cases (deliberate misuse such as a `DOUBLE` join
+key or a `NULL` upload name, which the extension must reject with a clear
+error; the suite fails if one of them unexpectedly succeeds) — plus full
 resident-surface coverage in the community-CI sqllogic suite.
 
 **Reproducibility entry point:** [`scripts/local_check.sh`](scripts/local_check.sh) runs the full pipeline end-to-end (configure → build → unit tests → smoke benchmarks → SQL suite → join parity harness). The hosted CI workflow lives at [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (Linux + macos-15) and runs on every push to `main`.

--- a/benchmark/hashjoin_bench_main.cpp
+++ b/benchmark/hashjoin_bench_main.cpp
@@ -16,10 +16,6 @@
 //   - Run on Backend::CPU once to get the reference JoinResult.
 //   - Run on every other available backend; canonicalize the matched-pair
 //     vectors via std::sort and compare. Mismatch is exit code 2.
-//
-// The Metal backend currently delegates to CPU work (scaffold), so its
-// numbers will match CPU. That is the expected state until the real Metal
-// sort-merge kernel lands. See BENCHMARK.md.
 
 #include "gpu_backend.hpp"
 
@@ -198,6 +194,41 @@ int main(int argc, char** argv) {
     }
 
     for (auto b : backends) run_backend(b, build, probe, a.runs, &reference, a.verify);
+
+    // Hybrid planner dispatch (CPU vs GPU threshold).
+    {
+        const std::size_t bytes = (build.size() + probe.size()) * sizeof(std::int64_t);
+        std::printf("\n[Hybrid]\n");
+        try {
+            auto hj = gpudb::make_hybrid_hashjoin_probe();
+            std::printf("  device: %s\n", hj->device_name().c_str());
+            auto first = hj->inner_join_i64(build.data(), build.size(),
+                                            probe.data(), probe.size());
+            std::printf("  matched: %zu / %zu probe rows (%.1f%%)\n",
+                        first.matched, probe.size(),
+                        probe.empty() ? 0.0
+                                      : 100.0 * static_cast<double>(first.matched) / probe.size());
+            std::printf("  dispatch: %s (%s)\n",
+                        gpudb::to_string(hj->last_decision().chosen),
+                        gpudb::to_string(hj->last_decision().reason));
+            if (!join_equals(first, reference)) {
+                std::fprintf(stderr, "  CORRECTNESS FAIL: hybrid differs from CPU reference\n");
+                std::exit(2);
+            }
+            std::vector<double> wall, kernel;
+            for (int i = 0; i < a.runs; ++i) {
+                auto r = hj->inner_join_i64(build.data(), build.size(),
+                                            probe.data(), probe.size());
+                wall.push_back(r.wall_ms);
+                kernel.push_back(r.kernel_ms);
+            }
+            const double w = median(wall), k = median(kernel);
+            std::printf("  median wall=%8.3f ms  kernel=%8.3f ms  throughput=%6.2f GiB/s\n",
+                        w, k, gibps(bytes, w));
+        } catch (const std::exception& e) {
+            std::printf("  unavailable: %s\n", e.what());
+        }
+    }
 
     std::printf("\ndone.\n");
     return 0;

--- a/benchmark/sql_demo_main.cpp
+++ b/benchmark/sql_demo_main.cpp
@@ -22,9 +22,12 @@ namespace {
 
 void usage(const char* a0) {
     std::fprintf(stderr,
-        "usage: %s [--db FILE] [--sql QUERY]\n"
+        "usage: %s [--db FILE] [--sql QUERY] [--multi]\n"
         "  --db FILE    use FILE as the DuckDB database (default: in-memory)\n"
-        "  --sql QUERY  run this single SQL statement (default: read stdin)\n", a0);
+        "  --sql QUERY  run this single SQL statement (default: read stdin)\n"
+        "  --multi      split input on ';' and run statements sequentially in\n"
+        "               ONE connection (resident columns persist between\n"
+        "               statements); prints each result + per-statement time\n", a0);
 }
 
 void die(const char* what) {
@@ -57,12 +60,15 @@ int main(int argc, char** argv) {
     std::string db_path = ":memory:";
     std::string sql;
 
+    bool multi = false;
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
         if (a == "--db" && i + 1 < argc) {
             db_path = argv[++i];
         } else if (a == "--sql" && i + 1 < argc) {
             sql = argv[++i];
+        } else if (a == "--multi") {
+            multi = true;
         } else if (a == "-h" || a == "--help") {
             usage(argv[0]); return 0;
         } else {
@@ -87,6 +93,42 @@ int main(int argc, char** argv) {
     } catch (const std::exception& e) {
         std::fprintf(stderr, "registration failed: %s\n", e.what());
         duckdb_disconnect(&con); duckdb_close(&db); return 2;
+    }
+
+    if (multi) {
+        // Naive ';' split — good enough for test scripts (no ';' inside
+        // string literals). Statements run on the SAME connection so
+        // resident columns persist between them.
+        std::size_t pos = 0;
+        int stmt_no = 0;
+        int rc = 0;
+        while (pos < sql.size()) {
+            std::size_t semi = sql.find(';', pos);
+            std::string stmt = sql.substr(pos, semi == std::string::npos
+                                                   ? std::string::npos : semi - pos);
+            pos = (semi == std::string::npos) ? sql.size() : semi + 1;
+            // Skip empty/whitespace-only fragments.
+            const std::size_t nonws = stmt.find_first_not_of(" \t\r\n");
+            if (nonws == std::string::npos) continue;
+            ++stmt_no;
+            const auto s0 = std::chrono::steady_clock::now();
+            duckdb_result sr;
+            if (duckdb_query(con, stmt.c_str(), &sr) == DuckDBError) {
+                std::fprintf(stderr, "statement %d failed: %s\n",
+                             stmt_no, duckdb_result_error(&sr));
+                duckdb_destroy_result(&sr);
+                rc = 3;
+                break;
+            }
+            const auto s1 = std::chrono::steady_clock::now();
+            print_result(sr);
+            duckdb_destroy_result(&sr);
+            std::fprintf(stderr, "[gpudb-sql] stmt %d elapsed %.3f ms\n", stmt_no,
+                std::chrono::duration<double, std::milli>(s1 - s0).count());
+        }
+        duckdb_disconnect(&con);
+        duckdb_close(&db);
+        return rc;
     }
 
     const auto t0 = std::chrono::steady_clock::now();

--- a/docs/BENCHMARK_PLAN.md
+++ b/docs/BENCHMARK_PLAN.md
@@ -56,13 +56,11 @@ real query (TPC-H or ClickBench).
 
 **Status:** shipped on Metal with **GPU-resident radix sort + on-device scan + min-max pre-scan**. Peak 4.89× over CPU at 500M × 1M groups. Ties CUDA on TPC-H wall.
 
-### 2.4 Hash join (the next big op)
+### 2.4 Hash join
 - `inner_join(build_keys, probe_keys)` → matched (probe_idx, build_idx) pairs
 - Future: outer joins, anti/semi-joins
 
-**Status:**
-- CUDA: in flight on `feat/cuda-hashjoin` (Linux Claude)
-- Metal: scaffold in flight on `feat/metal-hashjoin-scaffold` (CPU+stub today; sort-merge real impl when CUDA lands)
+**Status:** shipped on CUDA and Metal. Metal uses adaptive global slot-lock (small build) plus partitioned TG hash radix join (4.9× wall vs CPU @ 1M×10M M4). SQL: `gpu_inner_join`.
 
 ### 2.5 Window functions (the GOAL.md item 8 differentiator)
 - `RANK()`, `ROW_NUMBER()` over partition
@@ -157,6 +155,6 @@ Where we lose, we **say so in BENCHMARK.md** and explain why. Honesty buys credi
 | SUM f64 | ✅ | ✅ | host fallback | Q1 (SUM(l_extendedprice)) | same |
 | `agg_all_i64` (multi-agg) | 🔜 | — | 🔜 (`feat/metal-multiagg`) | derived from Q1 | (incoming) |
 | GROUP BY hash | ✅ | ✅ | ✅ (radix sort) | Q1 GROUP BY l_returnflag | "Metal GROUP BY" / matrix |
-| Hash join probe | ✅ | ⏳ (`feat/cuda-hashjoin`) | scaffold (`feat/metal-hashjoin-scaffold`) | Q3, Q5, Q12 | (incoming) |
+| Hash join probe | ✅ | ✅ | ✅ adaptive + partitioned TG hash | Q3, Q5, Q12 | Metal hash join (2026-07-07) |
 | Window functions | — | — | — | Q8 (window) — future | — |
 | DuckDB extension wrapper | — | — | scaffold + `gpu_sum`, `gpu_min`, `gpu_max` (Linux-built; macOS validation: `feat/ext-macos-validate`) | All TPC-H | (when end-to-end) |

--- a/docs/MACOS_EXTENSION_BUILD.md
+++ b/docs/MACOS_EXTENSION_BUILD.md
@@ -82,7 +82,7 @@ needed by 'src/extension/libgpudb_duckdb.dylib'.  Stop.
 This breaks both `libgpudb_duckdb` (the loadable) and `gpudb-sql` (which
 transitively links `gpudb_ext`).
 
-**Suggested fix (one line, applied on this branch):**
+**Fix (landed in main):**
 
 ```cmake
 target_link_libraries(gpudb_ext PUBLIC
@@ -94,7 +94,7 @@ target_link_libraries(gpudb_ext PUBLIC
 `CMAKE_SHARED_LIBRARY_SUFFIX` resolves to `.so` on Linux and `.dylib` on
 macOS, matching what `scripts/get_duckdb_libs.sh` already extracts on each
 platform (the script handles both suffixes correctly — only the CMake
-side was Linux-specific). Same fix is needed on `feat/ext-duckdb-stub`.
+side was Linux-specific). Same fix is needed anywhere extension CMake still hard-codes `.so`.
 
 After this change:
 
@@ -257,10 +257,8 @@ cmake --build build-macos -j
 
 ## Suggested follow-ups for the Linux Claude
 
-1. Apply the `CMAKE_SHARED_LIBRARY_SUFFIX` fix to
-   `src/extension/CMakeLists.txt` on `feat/ext-duckdb-stub` so it stays
-   in sync with main once both branches converge. (Already applied to
-   main via this PR.)
+1. The `CMAKE_SHARED_LIBRARY_SUFFIX` fix in `src/extension/CMakeLists.txt`
+   is landed — keep it when merging other extension work.
 2. When integrating the official DuckDB extension-template (the path
    `scripts/append_extension_footer.py` recommends), build `.duckdb_extension`
    artifacts for both `linux_amd64` and `osx_arm64` so the

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -63,7 +63,7 @@ target_link_libraries(gpudb_ext PUBLIC
 )
 ```
 
-This is being addressed by `feat/ext-macos-validate` (in flight). Owner: Linux Claude per CLAUDE.md ownership of `src/extension/`.
+This is documented in [MACOS_EXTENSION_BUILD.md](docs/MACOS_EXTENSION_BUILD.md). Resolved for current builds.
 
 ### 2. CI workflow is disabled
 
@@ -107,14 +107,17 @@ Our local builds cover Linux x86_64 and macOS arm64. Need CI matrix to cover the
 
 ---
 
-## 📋 Open PRs that affect release readiness
+## 📋 Recently landed (v0.1.4)
 
-| PR | Branch | What it adds | Merge order |
-|---|---|---|---|
-| #5 | `feat/metal-groupby-radix-gpu` | Metal GROUP BY radix sort + GPU scan + min-max (peak 4.89×) | merge first |
-| (in flight) | `feat/metal-multiagg` | `agg_all_i64` operator (sum+min+max+count one pass) | parallel agent — under review |
-| (in flight) | `feat/ext-macos-validate` | macOS extension build validation + fixes | **MUST land for macOS in submission** |
-| (in flight) | `feat/metal-hashjoin-scaffold` | Hash-join interface + CPU + Metal stub | optional for v1 |
+| Feature | What it adds |
+|---|---|
+| Metal hash join | Adaptive global slot-lock + partitioned TG hash; `gpu_inner_join` SQL |
+| Hybrid hash join | `HybridHashJoinProbe` size-based CPU/GPU dispatch |
+| GPU segment-reduce | On-device segment boundaries after Metal radix GROUP BY sort |
+| Extension hybrid | `gpu_sum` / `gpu_min` / `gpu_max` and GROUP BY use hybrid planner |
+
+Older release-track items (community extension submission, multi-agg fusion, etc.)
+are tracked in GitHub issues and prior release notes.
 
 ---
 

--- a/examples/gpudb_quickstart.ipynb
+++ b/examples/gpudb_quickstart.ipynb
@@ -144,9 +144,10 @@
    "outputs": [],
    "source": [
     "# GPUDB_REQUIRE_CUDA=1 makes configure FAIL if CMake cannot find nvcc —\n",
-    "# no silent CPU-only build. Look for 'CUDA enabled (compiler: ...)' below.\n",
+    "# no silent CPU-only build. CUDAARCHS=75 compiles only the T4's sm_75 (much\n",
+    "# faster on Colab's 2-core VM). Look for 'CUDA enabled (compiler: ...)' below.\n",
     "!git clone --depth 1 https://github.com/singhpratech/duckdbgpumetaldbram.git\n",
-    "!cd duckdbgpumetaldbram && PATH=/usr/local/cuda/bin:$PATH GPUDB_REQUIRE_CUDA=1 ./scripts/build.sh 2>&1 | tee build.log | grep -E 'CUDA enabled|CUDA toolkit not found|error|Error|==>' \n",
+    "!cd duckdbgpumetaldbram && CUDAARCHS=75 GPUDB_REQUIRE_CUDA=1 ./scripts/build.sh 2>&1 | tee build.log | grep -E 'CUDA enabled|CUDA toolkit not found|error|Error|==>' \n",
     "!grep -q 'CUDA enabled' duckdbgpumetaldbram/build.log && echo 'OK: CUDA backend compiled in' || (echo 'FAIL: CUDA backend NOT compiled — see build.log'; exit 1)\n"
    ]
   },

--- a/examples/gpudb_quickstart.ipynb
+++ b/examples/gpudb_quickstart.ipynb
@@ -112,7 +112,7 @@
    "source": [
     "## Part 2 (optional) — real CUDA on Colab's free T4\n",
     "\n",
-    "**Runtime → Change runtime type → T4 GPU**, then run the cells below. This\n",
+    "This notebook requests a **T4 GPU runtime automatically** when opened from GitHub (notebook metadata). If Colab could not attach a GPU (free-tier capacity, or you changed the runtime), the first cell below stops with a clear message — use **Runtime → Change runtime type → T4 GPU** and re-run. This\n",
     "builds the gpudb engine from source (the core build needs only cmake + nvcc,\n",
     "both preinstalled on Colab GPU runtimes — no submodules, no DuckDB build) and\n",
     "runs the operator-level benchmarks on the GPU. Takes a few minutes on Colab's\n",
@@ -203,7 +203,8 @@
  "metadata": {
   "colab": {
    "name": "gpudb_quickstart.ipynb",
-   "provenance": []
+   "provenance": [],
+   "gpuType": "T4"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -212,7 +213,8 @@
   },
   "language_info": {
    "name": "python"
-  }
+  },
+  "accelerator": "GPU"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/examples/gpudb_quickstart.ipynb
+++ b/examples/gpudb_quickstart.ipynb
@@ -125,8 +125,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!nvidia-smi\n",
-    "!nvcc --version | tail -2"
+    "# Hard stop unless this runtime actually has an NVIDIA GPU + nvcc.\n",
+    "# (Runtime -> Change runtime type -> T4 GPU). Without this check the build\n",
+    "# would silently fall back to the CPU backend and the cells below would\n",
+    "# report CPU numbers under a CUDA heading.\n",
+    "import os, shutil, subprocess\n",
+    "os.environ['PATH'] = '/usr/local/cuda/bin:' + os.environ['PATH']\n",
+    "assert shutil.which('nvidia-smi'), 'No nvidia-smi: this is a CPU runtime. Switch to a T4 GPU runtime and re-run.'\n",
+    "assert shutil.which('nvcc'), 'No nvcc: CUDA toolkit missing on this runtime.'\n",
+    "print(subprocess.run(['nvidia-smi', '--query-gpu=name,driver_version,memory.total', '--format=csv,noheader'], capture_output=True, text=True).stdout.strip())\n",
+    "print(subprocess.run(['nvcc', '--version'], capture_output=True, text=True).stdout.strip().splitlines()[-1])\n"
    ]
   },
   {
@@ -135,8 +143,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# GPUDB_REQUIRE_CUDA=1 makes configure FAIL if CMake cannot find nvcc —\n",
+    "# no silent CPU-only build. Look for 'CUDA enabled (compiler: ...)' below.\n",
     "!git clone --depth 1 https://github.com/singhpratech/duckdbgpumetaldbram.git\n",
-    "!cd duckdbgpumetaldbram && ./scripts/build.sh"
+    "!cd duckdbgpumetaldbram && PATH=/usr/local/cuda/bin:$PATH GPUDB_REQUIRE_CUDA=1 ./scripts/build.sh 2>&1 | tee build.log | grep -E 'CUDA enabled|CUDA toolkit not found|error|Error|==>' \n",
+    "!grep -q 'CUDA enabled' duckdbgpumetaldbram/build.log && echo 'OK: CUDA backend compiled in' || (echo 'FAIL: CUDA backend NOT compiled — see build.log'; exit 1)\n"
    ]
   },
   {
@@ -145,8 +156,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# unit tests — CPU reference vs CUDA results\n",
-    "!cd duckdbgpumetaldbram && ./build-linux/test/test_gpudb"
+    "# unit tests — CPU reference vs CUDA results.\n",
+    "# Expect 'available backends: CPU CUDA' and a '--- testing backend: CUDA ---' section.\n",
+    "!cd duckdbgpumetaldbram && ./build-linux/test/test_gpudb | tee test.log\n",
+    "!grep -q 'available backends:.*CUDA' duckdbgpumetaldbram/test.log && echo 'OK: tests ran on CUDA' || (echo 'FAIL: CUDA backend not available at runtime'; exit 1)\n"
    ]
   },
   {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,9 @@ CMAKE_ARGS=(
 if [[ "${GPUDB_NO_CUDA:-}" == "1" ]]; then
     CMAKE_ARGS+=(-DGPUDB_ENABLE_CUDA=OFF)
 fi
+if [[ "${GPUDB_REQUIRE_CUDA:-}" == "1" ]]; then
+    CMAKE_ARGS+=(-DGPUDB_REQUIRE_CUDA=ON)
+fi
 if [[ "${GPUDB_NO_METAL:-}" == "1" ]]; then
     CMAKE_ARGS+=(-DGPUDB_ENABLE_METAL=OFF)
 fi

--- a/scripts/join_parity_check.sh
+++ b/scripts/join_parity_check.sh
@@ -96,6 +96,38 @@ run_case "build much larger than probe (1k vs 1M)" \
   "SELECT (range * 31 % 2000000)::BIGINT AS k, (range % 999)::BIGINT AS v FROM range(1000)" \
   "SELECT ((range * 2654435761) % 2000000)::BIGINT AS k FROM range($I)"
 
+# --- Row-returning join (gpu_join_rows_resident) — needs --multi so the
+# uploads and the table function run as sequential statements in one process.
+# Small single-threaded sizes: probe_idx refers to UPLOAD order, which only
+# matches table order when the scan isn't parallel — keep n small so the
+# sum(idx) comparisons stay deterministic.
+rows_out=$("$SQL" --multi --sql "
+CREATE TABLE probe AS SELECT (range % 200)::BIGINT AS k, range::BIGINT AS idx FROM range(4000);
+CREATE TABLE build AS SELECT ((range * 3) % 300)::BIGINT AS k, range::BIGINT AS idx FROM range(900);
+SELECT u.n FROM (SELECT gpu_upload('pk', k) AS n FROM probe) u;
+SELECT u.n FROM (SELECT gpu_upload('bk', k) AS n FROM build) u;
+SELECT CASE WHEN
+  (SELECT count(*) || '|' || coalesce(sum(probe_idx),0) FROM gpu_join_rows_resident('pk','bk','inner')) =
+  (SELECT count(*) || '|' || coalesce(sum(p.idx),0)     FROM probe p JOIN build b ON p.k=b.k)
+ AND
+  (SELECT count(*) || '|' || sum(probe_idx) || '|' || count(build_idx) FROM gpu_join_rows_resident('pk','bk','left')) =
+  (SELECT count(*) || '|' || sum(p.idx) || '|' || count(b.idx)         FROM probe p LEFT JOIN build b ON p.k=b.k)
+ AND
+  (SELECT count(*) || '|' || coalesce(sum(probe_idx),0) FROM gpu_join_rows_resident('pk','bk','semi')) =
+  (SELECT count(*) || '|' || coalesce(sum(idx),0)       FROM probe p WHERE EXISTS(SELECT 1 FROM build b WHERE b.k=p.k))
+ AND
+  (SELECT count(*) || '|' || coalesce(sum(probe_idx),0) FROM gpu_join_rows_resident('pk','bk','anti')) =
+  (SELECT count(*) || '|' || coalesce(sum(idx),0)       FROM probe p WHERE NOT EXISTS(SELECT 1 FROM build b WHERE b.k=p.k))
+ THEN 'PASS' ELSE 'FAIL' END AS rows_verdict;
+" 2>/dev/null | tail -1)
+runs=$((runs+1))
+if [ "$rows_out" = "PASS" ]; then
+  echo "[pass] row-returning join, all kinds (dup keys, upload-order indices)"
+else
+  fails=$((fails+1))
+  echo "[FAIL] row-returning join: $rows_out"
+fi
+
 echo "----"
 echo "$runs scenarios, $fails failed"
 [ "$fails" -eq 0 ]

--- a/scripts/join_parity_check.sh
+++ b/scripts/join_parity_check.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# join_parity_check.sh — adversarial parity harness for the fused resident
+# joins. Every scenario computes native DuckDB and gpudb results in the SAME
+# statement and prints PASS/FAIL per (kind × op). Deterministic data only
+# (Knuth-hash pseudorandom, skew, duplicates, boundaries) so failures
+# reproduce. Exits non-zero on any FAIL.
+#
+# Usage: ./scripts/join_parity_check.sh [build_dir]
+set -u
+BUILD_DIR="${1:-build-macos}"
+SQL="$BUILD_DIR/bin/gpudb-sql"
+[ -x "$SQL" ] || { echo "missing $SQL — run ./scripts/build.sh"; exit 2; }
+
+fails=0
+runs=0
+
+# run_case <label> <probe_sql (k BIGINT, v BIGINT)> <build_sql (k BIGINT)>
+# Verifies: 4 kinds × {sum_i64, count} exactly + 4 kinds × sum_f64 (payload
+# v::DOUBLE/3) within relative 1e-9.
+run_case() {
+  local label="$1" probe="$2" build="$3"
+  local out
+  out=$("$SQL" --sql "
+WITH probe AS ($probe),
+     build AS ($build)
+SELECT
+  -- referencing every upload's result column defeats subquery pruning (the
+  -- documented gpu_upload footgun) — keep these first three columns.
+  u1.n1, u2.n2, u3.n3,
+  CASE WHEN gpu_join_sum_resident('p.k','p.v','b')       IS NOT DISTINCT FROM (SELECT sum(p.v) FROM probe p JOIN build b ON p.k=b.k)                                      THEN 'PASS' ELSE 'FAIL' END AS inner_sum,
+  CASE WHEN gpu_left_join_sum_resident('p.k','p.v','b')  IS NOT DISTINCT FROM (SELECT sum(p.v) FROM probe p LEFT JOIN build b ON p.k=b.k)                                 THEN 'PASS' ELSE 'FAIL' END AS left_sum,
+  CASE WHEN gpu_semi_join_sum_resident('p.k','p.v','b')  IS NOT DISTINCT FROM (SELECT sum(v) FROM probe p WHERE EXISTS(SELECT 1 FROM build b WHERE b.k=p.k))              THEN 'PASS' ELSE 'FAIL' END AS semi_sum,
+  CASE WHEN gpu_anti_join_sum_resident('p.k','p.v','b')  IS NOT DISTINCT FROM (SELECT sum(v) FROM probe p WHERE NOT EXISTS(SELECT 1 FROM build b WHERE b.k=p.k))          THEN 'PASS' ELSE 'FAIL' END AS anti_sum,
+  CASE WHEN gpu_join_count_resident('p.k','b')           IS NOT DISTINCT FROM (SELECT count(*) FROM probe p JOIN build b ON p.k=b.k)                                      THEN 'PASS' ELSE 'FAIL' END AS inner_cnt,
+  CASE WHEN gpu_left_join_count_resident('p.k','b')      IS NOT DISTINCT FROM (SELECT count(*) FROM probe p LEFT JOIN build b ON p.k=b.k)                                 THEN 'PASS' ELSE 'FAIL' END AS left_cnt,
+  CASE WHEN gpu_semi_join_count_resident('p.k','b')      IS NOT DISTINCT FROM (SELECT count(*) FROM probe p WHERE EXISTS(SELECT 1 FROM build b WHERE b.k=p.k))            THEN 'PASS' ELSE 'FAIL' END AS semi_cnt,
+  CASE WHEN gpu_anti_join_count_resident('p.k','b')      IS NOT DISTINCT FROM (SELECT count(*) FROM probe p WHERE NOT EXISTS(SELECT 1 FROM build b WHERE b.k=p.k))        THEN 'PASS' ELSE 'FAIL' END AS anti_cnt,
+  CASE WHEN coalesce(abs(gpu_join_sum_resident_f64('pf.k','pf.v','b')      - (SELECT sum(p.v/3.0) FROM probe p JOIN build b ON p.k=b.k))                                 <= 1e-9*greatest(abs((SELECT sum(p.v/3.0) FROM probe p JOIN build b ON p.k=b.k)),1),      gpu_join_sum_resident_f64('pf.k','pf.v','b')      IS NULL AND (SELECT sum(p.v/3.0) FROM probe p JOIN build b ON p.k=b.k) IS NULL) THEN 'PASS' ELSE 'FAIL' END AS inner_f64,
+  CASE WHEN coalesce(abs(gpu_left_join_sum_resident_f64('pf.k','pf.v','b') - (SELECT sum(p.v/3.0) FROM probe p LEFT JOIN build b ON p.k=b.k))                            <= 1e-9*greatest(abs((SELECT sum(p.v/3.0) FROM probe p LEFT JOIN build b ON p.k=b.k)),1), gpu_left_join_sum_resident_f64('pf.k','pf.v','b') IS NULL AND (SELECT sum(p.v/3.0) FROM probe p LEFT JOIN build b ON p.k=b.k) IS NULL) THEN 'PASS' ELSE 'FAIL' END AS left_f64,
+  CASE WHEN coalesce(abs(gpu_semi_join_sum_resident_f64('pf.k','pf.v','b') - (SELECT sum(v/3.0) FROM probe p WHERE EXISTS(SELECT 1 FROM build b WHERE b.k=p.k)))         <= 1e-9*greatest(abs((SELECT sum(v/3.0) FROM probe p WHERE EXISTS(SELECT 1 FROM build b WHERE b.k=p.k))),1), gpu_semi_join_sum_resident_f64('pf.k','pf.v','b') IS NULL AND (SELECT sum(v/3.0) FROM probe p WHERE EXISTS(SELECT 1 FROM build b WHERE b.k=p.k)) IS NULL) THEN 'PASS' ELSE 'FAIL' END AS semi_f64,
+  CASE WHEN coalesce(abs(gpu_anti_join_sum_resident_f64('pf.k','pf.v','b') - (SELECT sum(v/3.0) FROM probe p WHERE NOT EXISTS(SELECT 1 FROM build b WHERE b.k=p.k)))     <= 1e-9*greatest(abs((SELECT sum(v/3.0) FROM probe p WHERE NOT EXISTS(SELECT 1 FROM build b WHERE b.k=p.k))),1), gpu_anti_join_sum_resident_f64('pf.k','pf.v','b') IS NULL AND (SELECT sum(v/3.0) FROM probe p WHERE NOT EXISTS(SELECT 1 FROM build b WHERE b.k=p.k)) IS NULL) THEN 'PASS' ELSE 'FAIL' END AS anti_f64
+FROM (SELECT gpu_upload_pair('p',  k, v)               AS n1 FROM probe) u1,
+     (SELECT gpu_upload_pair('pf', k, (v/3.0)::DOUBLE) AS n2 FROM probe) u2,
+     (SELECT gpu_upload('b', k) AS n3 FROM build) u3;
+" 2>&1 | tail -1)
+  runs=$((runs+1))
+  if echo "$out" | grep -q "FAIL\|failed\|Error"; then
+    fails=$((fails+1))
+    echo "[FAIL] $label"
+    echo "       $out"
+  else
+    echo "[pass] $label"
+  fi
+}
+
+I=1000000   # probe rows for the big scenarios
+B=300000    # build rows
+
+run_case "dup-heavy both sides (k%97 / k%53)" \
+  "SELECT (range % 97)::BIGINT AS k, (range % 1000 - 500)::BIGINT AS v FROM range($I)" \
+  "SELECT (range % 53)::BIGINT AS k FROM range(10000)"
+
+run_case "knuth-hash pseudorandom, ~50% match" \
+  "SELECT ((range * 2654435761) % 600000)::BIGINT AS k, ((range * 48271) % 20000 - 10000)::BIGINT AS v FROM range($I)" \
+  "SELECT ((range * 179426549) % 300000)::BIGINT AS k FROM range($B)"
+
+run_case "zipf-ish skew (90% of probes in 1k hot keys)" \
+  "SELECT (CASE WHEN range % 10 < 9 THEN range % 1000 ELSE range % 900000 END)::BIGINT AS k, (range % 7919)::BIGINT AS v FROM range($I)" \
+  "SELECT ((range * 7) % 450000)::BIGINT AS k FROM range($B)"
+
+run_case "int64 boundary keys" \
+  "SELECT (CASE range % 5 WHEN 0 THEN 9223372036854775807 WHEN 1 THEN -9223372036854775808 WHEN 2 THEN 0 WHEN 3 THEN -1 ELSE range END)::BIGINT AS k, (range % 101 - 50)::BIGINT AS v FROM range(100000)" \
+  "SELECT k FROM (VALUES (9223372036854775807::BIGINT), (-9223372036854775808::BIGINT), (0::BIGINT), (42::BIGINT)) t(k)"
+
+run_case "negative keys both sides" \
+  "SELECT (range % 1000 - 500)::BIGINT AS k, (range % 33 - 16)::BIGINT AS v FROM range(200000)" \
+  "SELECT (range % 800 - 400)::BIGINT AS k FROM range(5000)"
+
+run_case "no matches at all" \
+  "SELECT (range)::BIGINT AS k, (range % 11)::BIGINT AS v FROM range(100000)" \
+  "SELECT (range + 10000000)::BIGINT AS k FROM range(1000)"
+
+run_case "all rows match (build superset)" \
+  "SELECT (range % 500)::BIGINT AS k, (range % 13 - 6)::BIGINT AS v FROM range(100000)" \
+  "SELECT (range % 1000)::BIGINT AS k FROM range(100000)"
+
+run_case "single-row probe, dup build" \
+  "SELECT 7::BIGINT AS k, 100::BIGINT AS v FROM range(1)" \
+  "SELECT 7::BIGINT AS k FROM range(5)"
+
+run_case "single-row build, dup probe" \
+  "SELECT (range % 3)::BIGINT AS k, (range + 1)::BIGINT AS v FROM range(9)" \
+  "SELECT 1::BIGINT AS k FROM range(1)"
+
+run_case "build much larger than probe (1k vs 1M)" \
+  "SELECT (range * 31 % 2000000)::BIGINT AS k, (range % 999)::BIGINT AS v FROM range(1000)" \
+  "SELECT ((range * 2654435761) % 2000000)::BIGINT AS k FROM range($I)"
+
+echo "----"
+echo "$runs scenarios, $fails failed"
+[ "$fails" -eq 0 ]

--- a/scripts/local_check.sh
+++ b/scripts/local_check.sh
@@ -85,6 +85,10 @@ if [ "$NO_BENCH" = "0" ]; then
     hr "smoke groupby (1M rows × 1K groups)"
     ./build-linux/bin/gpudb-groupby-bench --rows 1000000 --groups 1000 --runs 2
     green "groupby smoke OK"
+
+    hr "smoke hashjoin (100k build × 500k probe)"
+    ./build-linux/bin/gpudb-hashjoin-bench --build 100000 --probe 500000 --runs 2
+    green "hashjoin smoke OK"
 fi
 
 if [ "$NO_EXT" = "0" ]; then

--- a/scripts/run_sql_tests.sh
+++ b/scripts/run_sql_tests.sh
@@ -15,8 +15,10 @@
 #       -- expect: <line>           expected output line, one per result row
 #       -- requires_file: <path>    skip query if file missing (relative root)
 #       -- env: KEY=VAL             set env var for this query only
-#       -- expected_fail: <reason>  query is allowed to error/segfault/mismatch;
-#                                   the suite reports it but treats overall as PASS
+#       -- expected_fail: <reason>  GUARDRAIL case: the query is EXPECTED to
+#                                   error (a misuse the extension must reject);
+#                                   reported as GUARDRAIL, counts as passing —
+#                                   if it unexpectedly succeeds, the suite fails
 #
 # Comparison is whitespace-tolerant: header row is dropped, runs of
 # whitespace are collapsed, leading/trailing space is stripped.
@@ -142,7 +144,7 @@ execute_query() {
     # would stall. 30s is generous for everything currently in tree.
     local TLIMIT="${GPUDB_SQL_TIMEOUT_SECS:-30}"
     # Suppress bash's "Segmentation fault" diagnostic when the child dies
-    # by SIGSEGV — we want our own XFAIL/FAIL line, not noise. Putting the
+    # by SIGSEGV — we want our own GUARDRAIL/FAIL line, not noise. Putting the
     # call inside { ... } 2>/dev/null with the redirection on the GROUP
     # silences the diagnostic without dropping our captured stderr (which
     # is going to $err_f via the inner redirection).
@@ -208,7 +210,7 @@ execute_query() {
         fi
     else
         if [ -n "$xfail" ]; then
-            printf "  %-32s  %sXFAIL%s  (%s)\n" \
+            printf "  %-32s  %sGUARDRAIL%s  (%s)\n" \
                 "$label" "$C_YEL" "$C_OFF" "$xfail"
             efail=$((efail + 1))
         else
@@ -342,7 +344,7 @@ run_file() {
         i=$((i + 1))
     done
 
-    echo "  ${C_DIM}-> ${pass} pass / ${fail} fail / ${efail} xfail / ${skip} skip${C_OFF}"
+    echo "  ${C_DIM}-> ${pass} pass / ${fail} fail / ${efail} guardrail / ${skip} skip${C_OFF}"
     if [ "$unexpected_pass" -gt 0 ]; then
         echo "  ${C_DIM}-> ${unexpected_pass} unexpected-pass (consider clearing expected_fail tag)${C_OFF}"
     fi
@@ -366,7 +368,7 @@ echo "${C_BOLD}== summary ==${C_OFF}"
 echo "  files:           $TOTAL_FILES"
 echo "  pass:            ${C_GREEN}$TOTAL_PASS${C_OFF}"
 echo "  fail:            ${C_RED}$TOTAL_FAIL${C_OFF}"
-echo "  xfail (expected):${C_YEL}$TOTAL_EXPECTED_FAIL${C_OFF}"
+echo "  guardrail (expected error):${C_YEL}$TOTAL_EXPECTED_FAIL${C_OFF}"
 echo "  skip:            ${C_YEL}$TOTAL_SKIP${C_OFF}"
 echo "  unexpected pass: ${C_YEL}$TOTAL_UNEXPECTED_PASS${C_OFF}"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ if(GPUDB_HAS_METAL)
         backends/metal/metal_groupby.mm
         backends/metal/metal_window.mm
         backends/metal/metal_hashjoin.mm
+        backends/metal/metal_radix_sort.mm
     )
 
     # Embed .metal source as C strings so the Objective-C++ TUs can compile

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ if(GPUDB_HAS_CUDA)
         backends/cuda/kernels/sum_kernel.cu
         backends/cuda/kernels/groupby_kernel.cu
         backends/cuda/kernels/hashjoin_kernel.cu
+        backends/cuda/kernels/join_kernel.cu
     )
 endif()
 

--- a/src/backends/backend_factory.cpp
+++ b/src/backends/backend_factory.cpp
@@ -14,6 +14,14 @@ const char* to_string(Backend b) noexcept {
     return "?";
 }
 
+// Default for backends that haven't opted into the fused resident join yet
+// (CUDA today). Non-pure so adding the op doesn't break their builds.
+JoinAggResult Aggregator::join_sum_resident_i64(const ResidentColumn&,
+                                                const ResidentColumn&,
+                                                const ResidentColumn&) {
+    throw std::runtime_error("join_sum_resident_i64: not implemented on this backend");
+}
+
 // Per-backend factory forward declarations (impls live in their respective TUs).
 // These are declared in `gpudb` so that the hybrid planner TU (which lives
 // in the same library) can call them without re-declaring.

--- a/src/backends/backend_factory.cpp
+++ b/src/backends/backend_factory.cpp
@@ -18,8 +18,16 @@ const char* to_string(Backend b) noexcept {
 // (CUDA today). Non-pure so adding the op doesn't break their builds.
 JoinAggResult Aggregator::join_sum_resident_i64(const ResidentColumn&,
                                                 const ResidentColumn&,
-                                                const ResidentColumn&) {
+                                                const ResidentColumn&,
+                                                JoinKind) {
     throw std::runtime_error("join_sum_resident_i64: not implemented on this backend");
+}
+
+JoinAggResult Aggregator::join_sum_resident_f64(const ResidentColumn&,
+                                                const ResidentColumn&,
+                                                const ResidentColumn&,
+                                                JoinKind) {
+    throw std::runtime_error("join_sum_resident_f64: not implemented on this backend");
 }
 
 // Per-backend factory forward declarations (impls live in their respective TUs).

--- a/src/backends/backend_factory.cpp
+++ b/src/backends/backend_factory.cpp
@@ -30,6 +30,12 @@ JoinAggResult Aggregator::join_sum_resident_f64(const ResidentColumn&,
     throw std::runtime_error("join_sum_resident_f64: not implemented on this backend");
 }
 
+JoinRowsResult Aggregator::join_rows_resident(const ResidentColumn&,
+                                              const ResidentColumn&,
+                                              JoinKind, std::size_t) {
+    throw std::runtime_error("join_rows_resident: not implemented on this backend");
+}
+
 // Per-backend factory forward declarations (impls live in their respective TUs).
 // These are declared in `gpudb` so that the hybrid planner TU (which lives
 // in the same library) can call them without re-declaring.

--- a/src/backends/cpu/cpu_aggregator.cpp
+++ b/src/backends/cpu/cpu_aggregator.cpp
@@ -252,6 +252,77 @@ public:
         return r;
     }
 
+    JoinRowsResult join_rows_resident(const ResidentColumn& probe_keys,
+                                      const ResidentColumn& build_keys,
+                                      JoinKind kind, std::size_t max_rows) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& pk = check_i64(probe_keys);
+        const auto& bk = check_i64(build_keys);
+
+        JoinRowsResult r{};
+        r.rows_probe = pk.rows();
+        r.rows_build = bk.rows();
+        const std::size_t n_probe = pk.rows();
+        const std::size_t n_build = bk.rows();
+        if (n_probe == 0) { r.wall_ms = elapsed_ms(t0); return r; }
+
+        // Sort (key, original index) pairs so emitted build indices refer to
+        // upload order — the same contract as the Metal perm cache.
+        std::vector<std::pair<std::int64_t, std::int64_t>> sorted(n_build);
+        for (std::size_t j = 0; j < n_build; ++j)
+            sorted[j] = { bk.as_i64()[j], static_cast<std::int64_t>(j) };
+        std::sort(sorted.begin(), sorted.end());
+
+        const std::int64_t* keys = pk.as_i64();
+        auto run_of = [&](std::int64_t k) {
+            auto lo = std::lower_bound(sorted.begin(), sorted.end(),
+                                       std::make_pair(k, std::numeric_limits<std::int64_t>::min()));
+            auto hi = std::upper_bound(sorted.begin(), sorted.end(),
+                                       std::make_pair(k, std::numeric_limits<std::int64_t>::max()));
+            return std::make_pair(lo, hi);
+        };
+
+        // Pass 1: per-row output count (the JoinKind multiplier).
+        std::size_t total = 0;
+        std::vector<std::uint32_t> cnt(n_probe);
+        for (std::size_t i = 0; i < n_probe; ++i) {
+            auto [lo, hi] = run_of(keys[i]);
+            const std::uint64_t m = static_cast<std::uint64_t>(hi - lo);
+            const std::uint64_t c = join_multiplier(m, kind);
+            cnt[i] = static_cast<std::uint32_t>(c);
+            total += c;
+        }
+        if (total > max_rows)
+            throw std::runtime_error(
+                "join_rows_resident: result has " + std::to_string(total) +
+                " rows, above the cap of " + std::to_string(max_rows) +
+                " (raise GPUDB_JOIN_ROWS_MAX_M if intentional)");
+
+        // Pass 2: fill.
+        r.probe_idx.resize(total);
+        r.build_idx.resize(total);
+        std::size_t off = 0;
+        for (std::size_t i = 0; i < n_probe; ++i) {
+            if (!cnt[i]) continue;
+            auto [lo, hi] = run_of(keys[i]);
+            const bool has_match = lo != hi;
+            if ((kind == JoinKind::INNER || kind == JoinKind::LEFT) && has_match) {
+                for (auto it = lo; it != hi; ++it) {
+                    r.probe_idx[off] = static_cast<std::int64_t>(i);
+                    r.build_idx[off] = it->second;
+                    ++off;
+                }
+            } else {
+                // LEFT-unmatched, SEMI, ANTI: single row, NULL build side.
+                r.probe_idx[off] = static_cast<std::int64_t>(i);
+                r.build_idx[off] = -1;
+                ++off;
+            }
+        }
+        r.wall_ms = elapsed_ms(t0);
+        return r;
+    }
+
 private:
     enum class ReduceKind { Sum, Min, Max };
 

--- a/src/backends/cpu/cpu_aggregator.cpp
+++ b/src/backends/cpu/cpu_aggregator.cpp
@@ -134,6 +134,58 @@ public:
         return run_agg_all_i64(r.as_i64(), r.rows());
     }
 
+    // Same algorithm as the Metal path (sorted build keys + per-probe-element
+    // binary search) so the two backends are directly comparable and produce
+    // identical results: sum accumulates in uint64 for defined wrap.
+    JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
+                                        const ResidentColumn& payload,
+                                        const ResidentColumn& build_keys) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& pk = check_i64(probe_keys);
+        const auto& pl = check_i64(payload);
+        const auto& bk = check_i64(build_keys);
+        if (pk.rows() != pl.rows())
+            throw std::runtime_error(
+                "join_sum_resident_i64: probe_keys and payload row counts differ");
+
+        JoinAggResult r{};
+        r.rows_probe = pk.rows();
+        r.rows_build = bk.rows();
+        if (pk.rows() == 0 || bk.rows() == 0) {
+            r.wall_ms = elapsed_ms(t0);
+            return r;
+        }
+
+        std::vector<std::int64_t> sorted(bk.as_i64(), bk.as_i64() + bk.rows());
+        std::sort(sorted.begin(), sorted.end());
+
+        const std::int64_t* keys = pk.as_i64();
+        const std::int64_t* pay  = pl.as_i64();
+        struct Part { std::uint64_t sum = 0; std::int64_t matched = 0; };
+        Part total = parallel_chunks<Part>(
+            pk.rows(),
+            [&](std::size_t begin, std::size_t end) {
+                Part p;
+                for (std::size_t i = begin; i < end; ++i) {
+                    auto [lo, hi] = std::equal_range(sorted.begin(), sorted.end(), keys[i]);
+                    const std::uint64_t m = static_cast<std::uint64_t>(hi - lo);
+                    if (m) {
+                        p.sum += m * static_cast<std::uint64_t>(pay[i]);
+                        p.matched += static_cast<std::int64_t>(m);
+                    }
+                }
+                return p;
+            },
+            [](Part a, const Part& b) {
+                a.sum += b.sum; a.matched += b.matched; return a;
+            });
+
+        r.sum     = static_cast<std::int64_t>(total.sum);
+        r.matched = total.matched;
+        r.wall_ms = elapsed_ms(t0);
+        return r;
+    }
+
 private:
     enum class ReduceKind { Sum, Min, Max };
 

--- a/src/backends/cpu/cpu_aggregator.cpp
+++ b/src/backends/cpu/cpu_aggregator.cpp
@@ -137,9 +137,21 @@ public:
     // Same algorithm as the Metal path (sorted build keys + per-probe-element
     // binary search) so the two backends are directly comparable and produce
     // identical results: sum accumulates in uint64 for defined wrap.
+    // Per-JoinKind contribution multiplier (see the table in gpu_backend.hpp).
+    static std::uint64_t join_multiplier(std::uint64_t m, JoinKind kind) {
+        switch (kind) {
+            case JoinKind::INNER: return m;
+            case JoinKind::LEFT:  return m ? m : 1;
+            case JoinKind::SEMI:  return m ? 1 : 0;
+            case JoinKind::ANTI:  return m ? 0 : 1;
+        }
+        return 0;
+    }
+
     JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
                                         const ResidentColumn& payload,
-                                        const ResidentColumn& build_keys) override {
+                                        const ResidentColumn& build_keys,
+                                        JoinKind kind) override {
         const auto t0 = std::chrono::steady_clock::now();
         const auto& pk = check_i64(probe_keys);
         const auto& pl = check_i64(payload);
@@ -151,7 +163,9 @@ public:
         JoinAggResult r{};
         r.rows_probe = pk.rows();
         r.rows_build = bk.rows();
-        if (pk.rows() == 0 || bk.rows() == 0) {
+        if (pk.rows() == 0 ||
+            (bk.rows() == 0 && kind == JoinKind::INNER) ||
+            (bk.rows() == 0 && kind == JoinKind::SEMI)) {
             r.wall_ms = elapsed_ms(t0);
             return r;
         }
@@ -168,10 +182,11 @@ public:
                 Part p;
                 for (std::size_t i = begin; i < end; ++i) {
                     auto [lo, hi] = std::equal_range(sorted.begin(), sorted.end(), keys[i]);
-                    const std::uint64_t m = static_cast<std::uint64_t>(hi - lo);
-                    if (m) {
-                        p.sum += m * static_cast<std::uint64_t>(pay[i]);
-                        p.matched += static_cast<std::int64_t>(m);
+                    const std::uint64_t c =
+                        join_multiplier(static_cast<std::uint64_t>(hi - lo), kind);
+                    if (c) {
+                        p.sum += c * static_cast<std::uint64_t>(pay[i]);
+                        p.matched += static_cast<std::int64_t>(c);
                     }
                 }
                 return p;
@@ -181,6 +196,57 @@ public:
             });
 
         r.sum     = static_cast<std::int64_t>(total.sum);
+        r.matched = total.matched;
+        r.wall_ms = elapsed_ms(t0);
+        return r;
+    }
+
+    JoinAggResult join_sum_resident_f64(const ResidentColumn& probe_keys,
+                                        const ResidentColumn& payload,
+                                        const ResidentColumn& build_keys,
+                                        JoinKind kind) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& pk = check_i64(probe_keys);
+        const auto& pl = check_f64(payload);
+        const auto& bk = check_i64(build_keys);
+        if (pk.rows() != pl.rows())
+            throw std::runtime_error(
+                "join_sum_resident_f64: probe_keys and payload row counts differ");
+
+        JoinAggResult r{};
+        r.rows_probe = pk.rows();
+        r.rows_build = bk.rows();
+        if (pk.rows() == 0) {
+            r.wall_ms = elapsed_ms(t0);
+            return r;
+        }
+
+        std::vector<std::int64_t> sorted(bk.as_i64(), bk.as_i64() + bk.rows());
+        std::sort(sorted.begin(), sorted.end());
+
+        const std::int64_t* keys = pk.as_i64();
+        const double*       pay  = pl.as_f64();
+        struct Part { double sum = 0.0; std::int64_t matched = 0; };
+        Part total = parallel_chunks<Part>(
+            pk.rows(),
+            [&](std::size_t begin, std::size_t end) {
+                Part p;
+                for (std::size_t i = begin; i < end; ++i) {
+                    auto [lo, hi] = std::equal_range(sorted.begin(), sorted.end(), keys[i]);
+                    const std::uint64_t c =
+                        join_multiplier(static_cast<std::uint64_t>(hi - lo), kind);
+                    if (c) {
+                        p.sum += static_cast<double>(c) * pay[i];
+                        p.matched += static_cast<std::int64_t>(c);
+                    }
+                }
+                return p;
+            },
+            [](Part a, const Part& b) {
+                a.sum += b.sum; a.matched += b.matched; return a;
+            });
+
+        r.sum_f64 = total.sum;
         r.matched = total.matched;
         r.wall_ms = elapsed_ms(t0);
         return r;

--- a/src/backends/cuda/cuda_aggregator.cpp
+++ b/src/backends/cuda/cuda_aggregator.cpp
@@ -31,6 +31,31 @@ cudaError_t gpudb_cuda_max_i64(const std::int64_t* d_in, std::size_t n,
 cudaError_t gpudb_cuda_sum_f64(const double* d_in, std::size_t n,
                                double* d_partials, double* d_out,
                                int grid, cudaStream_t s);
+cudaError_t gpudb_cuda_join_build_sort(const std::int64_t* d_keys,
+                                       std::int64_t* d_sorted, std::int64_t* d_perm,
+                                       std::size_t n, cudaStream_t s);
+cudaError_t gpudb_cuda_join_sum_i64(const std::int64_t* d_probe, const std::int64_t* d_pay,
+                                    const std::int64_t* d_build_sorted,
+                                    std::size_t n_probe, std::size_t n_build,
+                                    int kind, void* d_acc, int grid, cudaStream_t s);
+cudaError_t gpudb_cuda_join_sum_f64(const std::int64_t* d_probe, const double* d_pay,
+                                    const std::int64_t* d_build_sorted,
+                                    std::size_t n_probe, std::size_t n_build,
+                                    int kind, void* d_acc, int grid, cudaStream_t s);
+cudaError_t gpudb_cuda_join_rows_count(const std::int64_t* d_probe,
+                                       const std::int64_t* d_build_sorted,
+                                       std::size_t n_probe, std::size_t n_build,
+                                       int kind, unsigned long long* d_cnt,
+                                       int grid, cudaStream_t s);
+cudaError_t gpudb_cuda_join_rows_scan(unsigned long long* d_cnt, std::size_t n,
+                                      unsigned long long* h_total, cudaStream_t s);
+cudaError_t gpudb_cuda_join_rows_fill(const std::int64_t* d_probe,
+                                      const std::int64_t* d_build_sorted,
+                                      const std::int64_t* d_perm,
+                                      std::size_t n_probe, std::size_t n_build,
+                                      int kind, const unsigned long long* d_offs,
+                                      std::int64_t* d_out_pidx, std::int64_t* d_out_bidx,
+                                      int grid, cudaStream_t s);
 }
 
 namespace {
@@ -52,7 +77,11 @@ public:
         bytes_ = n * elem;
         if (bytes_ > 0) GPUDB_CUDA_CHECK(cudaMalloc(&dptr_, bytes_), "cudaMalloc resident");
     }
-    ~CudaResidentColumn() override { if (dptr_) cudaFree(dptr_); }
+    ~CudaResidentColumn() override {
+        if (d_sorted_) cudaFree(d_sorted_);
+        if (d_perm_)   cudaFree(d_perm_);
+        if (dptr_)     cudaFree(dptr_);
+    }
 
     Backend     backend_tag() const noexcept override { return Backend::CUDA; }
     Dtype       dtype()       const noexcept override { return dtype_; }
@@ -62,8 +91,39 @@ public:
     const void* device_ptr() const noexcept { return dptr_; }
     std::size_t bytes()      const noexcept { return bytes_; }
 
+    // Build-side join cache: keys sorted + original-index permutation, built
+    // lazily on first use as a join build side, reused across kinds AND by
+    // the row-returning join. Lives and dies with the column; device memory
+    // only, exempt from the host-side GPUDB_UPLOAD_POOL_MAX_MB cap. A
+    // device-OOM here surfaces as std::runtime_error via cuda_throw.
+    void ensure_join_cache(cudaStream_t s) const {
+        if (d_sorted_ || rows_ == 0) return;
+        void* sorted = nullptr;
+        void* perm   = nullptr;
+        GPUDB_CUDA_CHECK(cudaMalloc(&sorted, bytes_), "cudaMalloc join cache (sorted keys)");
+        cudaError_t e = cudaMalloc(&perm, rows_ * sizeof(std::int64_t));
+        if (e != cudaSuccess) { cudaFree(sorted); cuda_throw(e, "cudaMalloc join cache (perm)"); }
+        e = gpudb_cuda_join_build_sort(static_cast<const std::int64_t*>(dptr_),
+                                       static_cast<std::int64_t*>(sorted),
+                                       static_cast<std::int64_t*>(perm), rows_, s);
+        if (e != cudaSuccess) {
+            cudaFree(sorted); cudaFree(perm);
+            cuda_throw(e, "join cache build (sort_by_key)");
+        }
+        d_sorted_ = sorted;
+        d_perm_   = perm;
+    }
+    const std::int64_t* sorted_keys() const noexcept {
+        return static_cast<const std::int64_t*>(d_sorted_);
+    }
+    const std::int64_t* perm() const noexcept {
+        return static_cast<const std::int64_t*>(d_perm_);
+    }
+
 private:
-    void*       dptr_  = nullptr;
+    void*         dptr_     = nullptr;
+    mutable void* d_sorted_ = nullptr;
+    mutable void* d_perm_   = nullptr;
     std::size_t rows_  = 0;
     std::size_t bytes_ = 0;
     Dtype       dtype_;
@@ -199,8 +259,196 @@ public:
         return res;
     }
 
+    // ---- fused resident joins (v0.5) ----
+    // Same algorithm as CPU/Metal (sorted build keys + per-probe binary
+    // search) so results are directly comparable: the i64 path accumulates
+    // in uint64 (wrap addition commutes, so it bit-matches regardless of
+    // reduction order); the f64 path uses atomicAdd(double) per the
+    // tolerance contract in gpu_backend.hpp.
+    JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
+                                        const ResidentColumn& payload,
+                                        const ResidentColumn& build_keys,
+                                        JoinKind kind) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& pk = check_i64(probe_keys);
+        const auto& pl = check_i64(payload);
+        const auto& bk = check_i64(build_keys);
+        if (pk.rows() != pl.rows())
+            throw std::runtime_error(
+                "join_sum_resident_i64: probe_keys and payload row counts differ");
+
+        JoinAggResult r{};
+        r.rows_probe = pk.rows();
+        r.rows_build = bk.rows();
+        if (pk.rows() == 0 ||
+            (bk.rows() == 0 && (kind == JoinKind::INNER || kind == JoinKind::SEMI))) {
+            r.wall_ms = elapsed_ms(t0);
+            return r;
+        }
+        bk.ensure_join_cache(stream_);
+        const int grid = gpudb_cuda_grid_for(pk.rows());
+        ensure_partials_out(0, 2 * sizeof(std::uint64_t));
+
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
+        GPUDB_CUDA_CHECK(gpudb_cuda_join_sum_i64(
+                             static_cast<const std::int64_t*>(pk.device_ptr()),
+                             static_cast<const std::int64_t*>(pl.device_ptr()),
+                             bk.sorted_keys(), pk.rows(), bk.rows(),
+                             static_cast<int>(kind), d_out_, grid, stream_),
+                         "join_sum_i64 launch");
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_stop_, stream_), "ev_stop");
+        GPUDB_CUDA_CHECK(cudaEventSynchronize(ev_stop_), "ev_sync");
+        float kernel_ms = 0.0f;
+        GPUDB_CUDA_CHECK(cudaEventElapsedTime(&kernel_ms, ev_start_, ev_stop_), "elapsed");
+
+        std::uint64_t acc[2] = {0, 0};
+        GPUDB_CUDA_CHECK(cudaMemcpyAsync(acc, d_out_, sizeof(acc),
+                                         cudaMemcpyDeviceToHost, stream_), "D2H join acc");
+        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
+
+        r.sum       = static_cast<std::int64_t>(acc[0]);
+        r.matched   = static_cast<std::int64_t>(acc[1]);
+        r.kernel_ms = static_cast<double>(kernel_ms);
+        r.wall_ms   = elapsed_ms(t0);
+        return r;
+    }
+
+    JoinAggResult join_sum_resident_f64(const ResidentColumn& probe_keys,
+                                        const ResidentColumn& payload,
+                                        const ResidentColumn& build_keys,
+                                        JoinKind kind) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& pk = check_i64(probe_keys);
+        const auto& pl = check_f64(payload);
+        const auto& bk = check_i64(build_keys);
+        if (pk.rows() != pl.rows())
+            throw std::runtime_error(
+                "join_sum_resident_f64: probe_keys and payload row counts differ");
+
+        JoinAggResult r{};
+        r.rows_probe = pk.rows();
+        r.rows_build = bk.rows();
+        if (pk.rows() == 0) {
+            r.wall_ms = elapsed_ms(t0);
+            return r;
+        }
+        bk.ensure_join_cache(stream_);
+        const int grid = gpudb_cuda_grid_for(pk.rows());
+        ensure_partials_out(0, 2 * sizeof(std::uint64_t));
+
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
+        GPUDB_CUDA_CHECK(gpudb_cuda_join_sum_f64(
+                             static_cast<const std::int64_t*>(pk.device_ptr()),
+                             static_cast<const double*>(pl.device_ptr()),
+                             bk.sorted_keys(), pk.rows(), bk.rows(),
+                             static_cast<int>(kind), d_out_, grid, stream_),
+                         "join_sum_f64 launch");
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_stop_, stream_), "ev_stop");
+        GPUDB_CUDA_CHECK(cudaEventSynchronize(ev_stop_), "ev_sync");
+        float kernel_ms = 0.0f;
+        GPUDB_CUDA_CHECK(cudaEventElapsedTime(&kernel_ms, ev_start_, ev_stop_), "elapsed");
+
+        struct { double sum; std::uint64_t matched; } acc{0.0, 0};
+        static_assert(sizeof(acc) == 2 * sizeof(std::uint64_t));
+        GPUDB_CUDA_CHECK(cudaMemcpyAsync(&acc, d_out_, sizeof(acc),
+                                         cudaMemcpyDeviceToHost, stream_), "D2H join acc");
+        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
+
+        r.sum_f64   = acc.sum;
+        r.matched   = static_cast<std::int64_t>(acc.matched);
+        r.kernel_ms = static_cast<double>(kernel_ms);
+        r.wall_ms   = elapsed_ms(t0);
+        return r;
+    }
+
+    JoinRowsResult join_rows_resident(const ResidentColumn& probe_keys,
+                                      const ResidentColumn& build_keys,
+                                      JoinKind kind, std::size_t max_rows) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& pk = check_i64(probe_keys);
+        const auto& bk = check_i64(build_keys);
+
+        JoinRowsResult r{};
+        r.rows_probe = pk.rows();
+        r.rows_build = bk.rows();
+        const std::size_t np = pk.rows();
+        if (np == 0) { r.wall_ms = elapsed_ms(t0); return r; }
+        bk.ensure_join_cache(stream_);
+        const int grid = gpudb_cuda_grid_for(np);
+
+        // Reuse the one-shot input scratch for the per-probe counts, which
+        // become the output offsets in place after the exclusive scan.
+        ensure_in(np * sizeof(unsigned long long));
+        auto* d_cnt = static_cast<unsigned long long*>(d_in_);
+
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
+        GPUDB_CUDA_CHECK(gpudb_cuda_join_rows_count(
+                             static_cast<const std::int64_t*>(pk.device_ptr()),
+                             bk.sorted_keys(), np, bk.rows(),
+                             static_cast<int>(kind), d_cnt, grid, stream_),
+                         "join_rows_count launch");
+        unsigned long long total = 0;
+        GPUDB_CUDA_CHECK(gpudb_cuda_join_rows_scan(d_cnt, np, &total, stream_),
+                         "join_rows scan");
+        if (total > max_rows)
+            throw std::runtime_error(
+                "join_rows_resident: result has " + std::to_string(total) +
+                " rows, above the cap of " + std::to_string(max_rows) +
+                " (raise GPUDB_JOIN_ROWS_MAX_M if intentional)");
+
+        float kernel_ms = 0.0f;
+        double transfer_ms = 0.0;
+        if (total > 0) {
+            const std::size_t out_bytes = static_cast<std::size_t>(total) * sizeof(std::int64_t);
+            void* d_p = nullptr;
+            void* d_b = nullptr;
+            GPUDB_CUDA_CHECK(cudaMalloc(&d_p, out_bytes), "cudaMalloc join rows (probe_idx)");
+            cudaError_t e = cudaMalloc(&d_b, out_bytes);
+            if (e != cudaSuccess) { cudaFree(d_p); cuda_throw(e, "cudaMalloc join rows (build_idx)"); }
+
+            e = gpudb_cuda_join_rows_fill(
+                    static_cast<const std::int64_t*>(pk.device_ptr()),
+                    bk.sorted_keys(), bk.perm(), np, bk.rows(),
+                    static_cast<int>(kind), d_cnt,
+                    static_cast<std::int64_t*>(d_p), static_cast<std::int64_t*>(d_b),
+                    grid, stream_);
+            if (e != cudaSuccess) { cudaFree(d_p); cudaFree(d_b); cuda_throw(e, "join_rows_fill launch"); }
+            cudaEventRecord(ev_stop_, stream_);
+            cudaEventSynchronize(ev_stop_);
+            cudaEventElapsedTime(&kernel_ms, ev_start_, ev_stop_);
+
+            const auto t_xfer0 = std::chrono::steady_clock::now();
+            r.probe_idx.resize(total);
+            r.build_idx.resize(total);
+            e = cudaMemcpyAsync(r.probe_idx.data(), d_p, out_bytes,
+                                cudaMemcpyDeviceToHost, stream_);
+            if (e == cudaSuccess)
+                e = cudaMemcpyAsync(r.build_idx.data(), d_b, out_bytes,
+                                    cudaMemcpyDeviceToHost, stream_);
+            if (e == cudaSuccess) e = cudaStreamSynchronize(stream_);
+            cudaFree(d_p);
+            cudaFree(d_b);
+            if (e != cudaSuccess) cuda_throw(e, "join rows D2H");
+            transfer_ms = elapsed_ms(t_xfer0);
+        } else {
+            GPUDB_CUDA_CHECK(cudaEventRecord(ev_stop_, stream_), "ev_stop");
+            GPUDB_CUDA_CHECK(cudaEventSynchronize(ev_stop_), "ev_sync");
+            GPUDB_CUDA_CHECK(cudaEventElapsedTime(&kernel_ms, ev_start_, ev_stop_), "elapsed");
+        }
+
+        r.kernel_ms   = static_cast<double>(kernel_ms);
+        r.transfer_ms = transfer_ms;
+        r.wall_ms     = elapsed_ms(t0);
+        return r;
+    }
+
 private:
     enum class ReduceKind { Sum, Min, Max };
+
+    static double elapsed_ms(std::chrono::steady_clock::time_point t0) {
+        return std::chrono::duration<double, std::milli>(
+                   std::chrono::steady_clock::now() - t0).count();
+    }
 
     AggResult reduce_i64_resident(const CudaResidentColumn& r, ReduceKind kind, std::int64_t init) {
         AggResult res{};

--- a/src/backends/cuda/cuda_hashjoin.cpp
+++ b/src/backends/cuda/cuda_hashjoin.cpp
@@ -30,7 +30,7 @@ namespace gpudb {
 
 extern "C" {
 std::int64_t gpudb_cuda_hashjoin_empty_sentinel();
-cudaError_t gpudb_cuda_hashjoin_init(std::int64_t*, std::uint32_t, cudaStream_t);
+cudaError_t gpudb_cuda_hashjoin_init(std::int64_t*, std::int64_t*, std::uint32_t, cudaStream_t);
 cudaError_t gpudb_cuda_hashjoin_build(const std::int64_t*, std::size_t,
                                       std::int64_t*, std::int64_t*,
                                       std::uint32_t, cudaStream_t);
@@ -168,7 +168,8 @@ public:
         GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
 
         GPUDB_CUDA_CHECK(gpudb_cuda_hashjoin_init(
-            static_cast<std::int64_t*>(d_table_keys_), cap, stream_), "init");
+            static_cast<std::int64_t*>(d_table_keys_),
+            static_cast<std::int64_t*>(d_table_idx_), cap, stream_), "init");
         GPUDB_CUDA_CHECK(gpudb_cuda_hashjoin_build(
             static_cast<const std::int64_t*>(d_build_keys_), n_build,
             static_cast<std::int64_t*>(d_table_keys_),

--- a/src/backends/cuda/kernels/hashjoin_kernel.cu
+++ b/src/backends/cuda/kernels/hashjoin_kernel.cu
@@ -4,17 +4,19 @@
 //
 //   BUILD: open-addressing linear-probing hash table. Each slot stores
 //     (key: i64, build_row_idx: i64). Empty sentinel for the key field
-//     is INT64_MIN. Insertion is atomicCAS on the key word; on success
-//     we then write the row index into the parallel slot. Multiple build
-//     rows with the SAME key occupy DIFFERENT slots — for a multimap
-//     join we need every (key, idx) pair distinct, not just unique keys.
+//     is INT64_MIN. Insertion is atomicCAS on the key word. Duplicate
+//     build keys collapse into ONE slot keeping the MINIMUM build index
+//     (atomicMin on the index slot, initialized to INT64_MAX) — the
+//     "first build row wins" v1 contract in gpu_backend.hpp, matching the
+//     CPU reference. Same-key threads walk identical probe chains and stop
+//     at the first slot that is empty (claim) or already holds their key,
+//     so a key can never occupy two slots.
 //
 //   PROBE: each thread walks one probe row, hashing its key, then linear-
-//     probing slots. For every slot whose stored key == probe key, we
-//     atomically reserve the next free position in the output buffer
-//     via atomicAdd on a single counter, and write (probe_idx, build_idx)
-//     there. Probe stops when it hits an empty slot (no more matches
-//     possible in this chain).
+//     probing slots. On the (unique) slot whose stored key == probe key,
+//     it atomically reserves the next free position in the output buffer
+//     via atomicAdd on a single counter, writes (probe_idx, build_idx),
+//     and stops. Probe also stops at an empty slot (no match).
 //
 // Notes:
 //   - INT64_MIN as a build key collides with the empty sentinel. Caller
@@ -51,21 +53,22 @@ __device__ __forceinline__ std::uint32_t hash_slot(std::int64_t k, std::uint32_t
     return static_cast<std::uint32_t>(splitmix64(static_cast<std::uint64_t>(k))) & mask;
 }
 
-// Initialize the hash table: every key slot becomes empty.
-// Index slots can stay uninitialized — they're only read when the matching
-// key slot is non-empty, and we always write them before the key.
+// Initialize the hash table: every key slot becomes empty, every index slot
+// becomes INT64_MAX so the build pass can atomicMin the winning (smallest)
+// build index into it.
 __global__ void hashjoin_init_kernel(
         std::int64_t* __restrict__ table_keys,
+        std::int64_t* __restrict__ table_idx,
         std::uint32_t cap) {
     const std::uint32_t i = blockIdx.x * BLOCK + threadIdx.x;
     if (i >= cap) return;
     table_keys[i] = kEmpty;
+    table_idx[i]  = (std::int64_t)0x7fffffffffffffffLL;  // INT64_MAX
 }
 
-// BUILD: insert each (build_key[i], i) into the table.
-// Multiple build rows with the same key occupy distinct slots — that's the
-// key difference vs GROUP BY where we'd accumulate. Here every (key, idx)
-// must survive distinctly so probe can find all matches.
+// BUILD: insert each (build_key[i], i) into the table. One slot per unique
+// key; duplicate build rows race atomicMin on the index slot so the smallest
+// (first) build index deterministically wins — the v1 contract.
 __global__ void hashjoin_build_kernel(
         const std::int64_t* __restrict__ build_keys,
         std::size_t n_build,
@@ -80,19 +83,19 @@ __global__ void hashjoin_build_kernel(
         // Linear probe; bounded by cap iterations to prevent infinite loop
         // in pathological cases (table near full).
         for (std::uint32_t probe = 0; probe < cap; ++probe) {
-            std::int64_t cur = atomicCAS(
+            std::int64_t cur = static_cast<std::int64_t>(atomicCAS(
                 reinterpret_cast<unsigned long long*>(&table_keys[slot]),
                 static_cast<unsigned long long>(kEmpty),
-                static_cast<unsigned long long>(k));
-            if (static_cast<std::int64_t>(cur) == kEmpty) {
-                // We claimed this slot. Stash the build row index alongside.
-                // Single-threaded write to this slot — no atomic needed.
-                table_idx[slot] = static_cast<std::int64_t>(i);
+                static_cast<unsigned long long>(k)));
+            if (cur == kEmpty || cur == k) {
+                // Either we claimed the slot for k, or another thread holds k
+                // here already — both cases fold this row in via atomicMin so
+                // the first (lowest) build index wins.
+                atomicMin(reinterpret_cast<long long*>(&table_idx[slot]),
+                          static_cast<long long>(i));
                 break;
             }
-            // Slot already taken (by us-or-someone-else with this-or-other
-            // key). Move on. We do NOT short-circuit on cur == k: distinct
-            // build rows with the same key need distinct slots.
+            // Slot taken by a different key; keep probing.
             slot = (slot + 1u) & mask;
         }
     }
@@ -117,7 +120,7 @@ __global__ void hashjoin_probe_kernel(
         std::uint32_t slot = hash_slot(k, mask);
         for (std::uint32_t probe = 0; probe < cap; ++probe) {
             const std::int64_t tk = table_keys[slot];
-            if (tk == kEmpty) break;            // end of chain
+            if (tk == kEmpty) break;            // end of chain — no match
             if (tk == k) {
                 const std::uint32_t pos = atomicAdd(out_count, 1u);
                 if (pos < out_capacity) {
@@ -125,7 +128,7 @@ __global__ void hashjoin_probe_kernel(
                     out_build_idx[pos] = table_idx[slot];
                 }
                 // else: overflow — host re-runs with larger buffer.
-                // Continue probing in case more matches in chain.
+                break;                          // one slot per key: done
             }
             slot = (slot + 1u) & mask;
         }
@@ -137,9 +140,10 @@ extern "C" {
 std::int64_t gpudb_cuda_hashjoin_empty_sentinel() { return kEmpty; }
 
 cudaError_t gpudb_cuda_hashjoin_init(std::int64_t* table_keys,
+                                     std::int64_t* table_idx,
                                      std::uint32_t cap, cudaStream_t s) {
     const int grid = (cap + BLOCK - 1) / BLOCK;
-    hashjoin_init_kernel<<<grid, BLOCK, 0, s>>>(table_keys, cap);
+    hashjoin_init_kernel<<<grid, BLOCK, 0, s>>>(table_keys, table_idx, cap);
     return cudaGetLastError();
 }
 

--- a/src/backends/cuda/kernels/join_kernel.cu
+++ b/src/backends/cuda/kernels/join_kernel.cu
@@ -1,0 +1,269 @@
+// join_kernel.cu — fused resident equi-join kernels (v0.5).
+//
+// Algorithm matches the CPU/Metal executable spec: build keys are sorted once
+// (cached on the ResidentColumn together with the original-index permutation,
+// so the same cache serves the fused sums AND the row-returning join), and
+// each probe element binary-searches its multiplicity m in the sorted run.
+// Per-JoinKind contribution c = jmult(m, kind); sums accumulate in uint64
+// (wrap addition is commutative, so the i64 result bit-matches CPU/Metal
+// regardless of reduction order). f64 accumulation order is backend-defined
+// per the gpu_backend.hpp tolerance contract — atomicAdd(double) is fine.
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+#include <thrust/execution_policy.h>
+#include <thrust/scan.h>
+#include <thrust/reduce.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+namespace {
+
+constexpr int BLOCK = 256;
+
+using u64 = unsigned long long;
+
+__device__ inline std::size_t lower_bound_i64(const std::int64_t* __restrict__ a,
+                                              std::size_t n, std::int64_t key) {
+    std::size_t lo = 0, len = n;
+    while (len > 0) {
+        const std::size_t half = len >> 1;
+        const std::size_t mid  = lo + half;
+        if (a[mid] < key) { lo = mid + 1; len -= half + 1; }
+        else              { len = half; }
+    }
+    return lo;
+}
+
+__device__ inline std::size_t upper_bound_i64(const std::int64_t* __restrict__ a,
+                                              std::size_t n, std::int64_t key) {
+    std::size_t lo = 0, len = n;
+    while (len > 0) {
+        const std::size_t half = len >> 1;
+        const std::size_t mid  = lo + half;
+        if (a[mid] <= key) { lo = mid + 1; len -= half + 1; }
+        else               { len = half; }
+    }
+    return lo;
+}
+
+// JoinKind multiplier — must mirror CpuAggregator::join_multiplier exactly.
+// kind: 0=INNER, 1=LEFT, 2=SEMI, 3=ANTI (matches JoinKind's underlying values).
+__device__ inline u64 jmult(u64 m, int kind) {
+    switch (kind) {
+        case 0:  return m;
+        case 1:  return m ? m : 1ULL;
+        case 2:  return m ? 1ULL : 0ULL;
+        default: return m ? 0ULL : 1ULL;
+    }
+}
+
+__device__ inline u64 multiplicity(const std::int64_t* __restrict__ build_sorted,
+                                   std::size_t n_build, std::int64_t key) {
+    return static_cast<u64>(upper_bound_i64(build_sorted, n_build, key) -
+                            lower_bound_i64(build_sorted, n_build, key));
+}
+
+__global__ void join_sum_i64_kernel(const std::int64_t* __restrict__ probe,
+                                    const std::int64_t* __restrict__ pay,
+                                    const std::int64_t* __restrict__ build_sorted,
+                                    std::size_t n_probe, std::size_t n_build,
+                                    int kind, u64* __restrict__ out_sum,
+                                    u64* __restrict__ out_matched) {
+    __shared__ u64 s_sum[BLOCK];
+    __shared__ u64 s_m[BLOCK];
+    u64 sum = 0, matched = 0;
+    for (std::size_t i = blockIdx.x * BLOCK + threadIdx.x;
+         i < n_probe;
+         i += static_cast<std::size_t>(BLOCK) * gridDim.x) {
+        const u64 c = jmult(multiplicity(build_sorted, n_build, probe[i]), kind);
+        sum     += c * static_cast<u64>(pay[i]);
+        matched += c;
+    }
+    s_sum[threadIdx.x] = sum;
+    s_m[threadIdx.x]   = matched;
+    __syncthreads();
+    for (int s = BLOCK / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) {
+            s_sum[threadIdx.x] += s_sum[threadIdx.x + s];
+            s_m[threadIdx.x]   += s_m[threadIdx.x + s];
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        atomicAdd(out_sum,     s_sum[0]);
+        atomicAdd(out_matched, s_m[0]);
+    }
+}
+
+__global__ void join_sum_f64_kernel(const std::int64_t* __restrict__ probe,
+                                    const double* __restrict__ pay,
+                                    const std::int64_t* __restrict__ build_sorted,
+                                    std::size_t n_probe, std::size_t n_build,
+                                    int kind, double* __restrict__ out_sum,
+                                    u64* __restrict__ out_matched) {
+    __shared__ double s_sum[BLOCK];
+    __shared__ u64    s_m[BLOCK];
+    double sum = 0.0;
+    u64 matched = 0;
+    for (std::size_t i = blockIdx.x * BLOCK + threadIdx.x;
+         i < n_probe;
+         i += static_cast<std::size_t>(BLOCK) * gridDim.x) {
+        const u64 c = jmult(multiplicity(build_sorted, n_build, probe[i]), kind);
+        if (c) {
+            sum     += static_cast<double>(c) * pay[i];
+            matched += c;
+        }
+    }
+    s_sum[threadIdx.x] = sum;
+    s_m[threadIdx.x]   = matched;
+    __syncthreads();
+    for (int s = BLOCK / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) {
+            s_sum[threadIdx.x] += s_sum[threadIdx.x + s];
+            s_m[threadIdx.x]   += s_m[threadIdx.x + s];
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        atomicAdd(out_sum,     s_sum[0]);
+        atomicAdd(out_matched, s_m[0]);
+    }
+}
+
+// Row-returning join, pass 1: per-probe output count c (the kind multiplier).
+__global__ void join_rows_count_kernel(const std::int64_t* __restrict__ probe,
+                                       const std::int64_t* __restrict__ build_sorted,
+                                       std::size_t n_probe, std::size_t n_build,
+                                       int kind, u64* __restrict__ cnt) {
+    for (std::size_t i = blockIdx.x * BLOCK + threadIdx.x;
+         i < n_probe;
+         i += static_cast<std::size_t>(BLOCK) * gridDim.x) {
+        cnt[i] = jmult(multiplicity(build_sorted, n_build, probe[i]), kind);
+    }
+}
+
+// Row-returning join, pass 2: fill (probe_idx, build_idx) at the scanned
+// offsets. perm maps sorted position -> original upload index; build_idx -1
+// encodes SQL NULL — same contract as the CPU reference.
+__global__ void join_rows_fill_kernel(const std::int64_t* __restrict__ probe,
+                                      const std::int64_t* __restrict__ build_sorted,
+                                      const std::int64_t* __restrict__ perm,
+                                      std::size_t n_probe, std::size_t n_build,
+                                      int kind, const u64* __restrict__ offs,
+                                      std::int64_t* __restrict__ out_pidx,
+                                      std::int64_t* __restrict__ out_bidx) {
+    for (std::size_t i = blockIdx.x * BLOCK + threadIdx.x;
+         i < n_probe;
+         i += static_cast<std::size_t>(BLOCK) * gridDim.x) {
+        const std::size_t lo = lower_bound_i64(build_sorted, n_build, probe[i]);
+        const std::size_t hi = upper_bound_i64(build_sorted, n_build, probe[i]);
+        const u64 m = static_cast<u64>(hi - lo);
+        const u64 c = jmult(m, kind);
+        if (!c) continue;
+        u64 off = offs[i];
+        if ((kind == 0 || kind == 1) && m) {
+            for (std::size_t j = lo; j < hi; ++j, ++off) {
+                out_pidx[off] = static_cast<std::int64_t>(i);
+                out_bidx[off] = perm[j];
+            }
+        } else {
+            // LEFT-unmatched, SEMI, ANTI: single row, NULL build side.
+            out_pidx[off] = static_cast<std::int64_t>(i);
+            out_bidx[off] = -1;
+        }
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+int gpudb_cuda_grid_for(std::size_t n);
+
+// Build the sorted-keys + permutation cache: sorted <- keys (D2D copy),
+// perm <- 0..n-1, then sort_by_key. Thrust allocates sort scratch internally,
+// so a device-OOM surfaces here — mapped to cudaErrorMemoryAllocation.
+cudaError_t gpudb_cuda_join_build_sort(const std::int64_t* d_keys,
+                                       std::int64_t* d_sorted,
+                                       std::int64_t* d_perm,
+                                       std::size_t n, cudaStream_t s) {
+    cudaError_t e = cudaMemcpyAsync(d_sorted, d_keys, n * sizeof(std::int64_t),
+                                    cudaMemcpyDeviceToDevice, s);
+    if (e != cudaSuccess) return e;
+    try {
+        thrust::sequence(thrust::cuda::par.on(s), d_perm, d_perm + n);
+        thrust::sort_by_key(thrust::cuda::par.on(s), d_sorted, d_sorted + n, d_perm);
+    } catch (...) {
+        return cudaErrorMemoryAllocation;
+    }
+    return cudaStreamSynchronize(s);
+}
+
+cudaError_t gpudb_cuda_join_sum_i64(const std::int64_t* d_probe,
+                                    const std::int64_t* d_pay,
+                                    const std::int64_t* d_build_sorted,
+                                    std::size_t n_probe, std::size_t n_build,
+                                    int kind, void* d_acc /* [u64 sum, u64 matched] */,
+                                    int grid, cudaStream_t s) {
+    cudaError_t e = cudaMemsetAsync(d_acc, 0, 2 * sizeof(u64), s);
+    if (e != cudaSuccess) return e;
+    u64* acc = static_cast<u64*>(d_acc);
+    join_sum_i64_kernel<<<grid, BLOCK, 0, s>>>(d_probe, d_pay, d_build_sorted,
+                                               n_probe, n_build, kind, acc, acc + 1);
+    return cudaGetLastError();
+}
+
+cudaError_t gpudb_cuda_join_sum_f64(const std::int64_t* d_probe,
+                                    const double* d_pay,
+                                    const std::int64_t* d_build_sorted,
+                                    std::size_t n_probe, std::size_t n_build,
+                                    int kind, void* d_acc /* [f64 sum, u64 matched] */,
+                                    int grid, cudaStream_t s) {
+    cudaError_t e = cudaMemsetAsync(d_acc, 0, 2 * sizeof(u64), s);
+    if (e != cudaSuccess) return e;
+    join_sum_f64_kernel<<<grid, BLOCK, 0, s>>>(d_probe, d_pay, d_build_sorted,
+                                               n_probe, n_build, kind,
+                                               static_cast<double*>(d_acc),
+                                               static_cast<u64*>(d_acc) + 1);
+    return cudaGetLastError();
+}
+
+cudaError_t gpudb_cuda_join_rows_count(const std::int64_t* d_probe,
+                                       const std::int64_t* d_build_sorted,
+                                       std::size_t n_probe, std::size_t n_build,
+                                       int kind, u64* d_cnt,
+                                       int grid, cudaStream_t s) {
+    join_rows_count_kernel<<<grid, BLOCK, 0, s>>>(d_probe, d_build_sorted,
+                                                  n_probe, n_build, kind, d_cnt);
+    return cudaGetLastError();
+}
+
+// total <- sum(cnt); cnt <- exclusive_scan(cnt) in place. Synchronizes.
+cudaError_t gpudb_cuda_join_rows_scan(u64* d_cnt, std::size_t n,
+                                      u64* h_total, cudaStream_t s) {
+    try {
+        *h_total = thrust::reduce(thrust::cuda::par.on(s), d_cnt, d_cnt + n, u64{0});
+        thrust::exclusive_scan(thrust::cuda::par.on(s), d_cnt, d_cnt + n, d_cnt);
+    } catch (...) {
+        return cudaErrorMemoryAllocation;
+    }
+    return cudaStreamSynchronize(s);
+}
+
+cudaError_t gpudb_cuda_join_rows_fill(const std::int64_t* d_probe,
+                                      const std::int64_t* d_build_sorted,
+                                      const std::int64_t* d_perm,
+                                      std::size_t n_probe, std::size_t n_build,
+                                      int kind, const u64* d_offs,
+                                      std::int64_t* d_out_pidx,
+                                      std::int64_t* d_out_bidx,
+                                      int grid, cudaStream_t s) {
+    join_rows_fill_kernel<<<grid, BLOCK, 0, s>>>(d_probe, d_build_sorted, d_perm,
+                                                 n_probe, n_build, kind, d_offs,
+                                                 d_out_pidx, d_out_bidx);
+    return cudaGetLastError();
+}
+
+} // extern "C"

--- a/src/backends/hybrid_planner.cpp
+++ b/src/backends/hybrid_planner.cpp
@@ -197,9 +197,11 @@ public:
     }
     std::unique_ptr<ResidentColumn> upload_f64(const double* d, std::size_t n) override {
         // CUDA supports f64 end-to-end (sum_f64 kernel + resident path), so
-        // f64 columns go to the device there. Metal has no IEEE-754 doubles —
-        // f64 stays CPU-side on that backend, same as before.
-        if (gpu_ && gpu_backend_ == Backend::CUDA) {
+        // f64 columns go to the device there. Metal has no IEEE-754 doubles in
+        // MSL, but its f64 resident ops run as host math over UMA buffers, so
+        // the column still lives on the Metal side — which also keeps joins
+        // (i64 keys on GPU + f64 payload) on one backend.
+        if (gpu_) {
             try {
                 auto handle = gpu_->upload_f64(d, n);
                 return std::make_unique<HybridResidentColumn>(
@@ -257,7 +259,30 @@ public:
     // clearly rather than silently copying columns across.
     JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
                                         const ResidentColumn& payload,
-                                        const ResidentColumn& build_keys) override {
+                                        const ResidentColumn& build_keys,
+                                        JoinKind kind) override {
+        return dispatch_join(probe_keys, payload, build_keys,
+            [&](Aggregator& a, const ResidentColumn& p, const ResidentColumn& v,
+                const ResidentColumn& b) {
+                return a.join_sum_resident_i64(p, v, b, kind);
+            });
+    }
+
+    JoinAggResult join_sum_resident_f64(const ResidentColumn& probe_keys,
+                                        const ResidentColumn& payload,
+                                        const ResidentColumn& build_keys,
+                                        JoinKind kind) override {
+        return dispatch_join(probe_keys, payload, build_keys,
+            [&](Aggregator& a, const ResidentColumn& p, const ResidentColumn& v,
+                const ResidentColumn& b) {
+                return a.join_sum_resident_f64(p, v, b, kind);
+            });
+    }
+
+    template <class Op>
+    JoinAggResult dispatch_join(const ResidentColumn& probe_keys,
+                                const ResidentColumn& payload,
+                                const ResidentColumn& build_keys, Op&& run) {
         const auto& hp = check_hybrid(probe_keys);
         const auto& hl = check_hybrid(payload);
         const auto& hb = check_hybrid(build_keys);
@@ -265,18 +290,18 @@ public:
         const bool on_gpu = hp.on_gpu();
         if (hl.on_gpu() != on_gpu || hb.on_gpu() != on_gpu)
             throw std::runtime_error(
-                "join_sum_resident_i64: columns are resident on different backends "
+                "resident join: columns are resident on different backends "
                 "(one upload fell back to CPU) — re-upload and retry");
         if (gpu_ && on_gpu) {
             last_ = make_decision(gpu_backend_, DispatchReason::Hot_GpuAlwaysWins,
                                   n, 0, /*resident*/true, /*borderline*/false);
-            return gpu_->join_sum_resident_i64(hp.inner(), hl.inner(), hb.inner());
+            return run(*gpu_, hp.inner(), hl.inner(), hb.inner());
         }
         last_ = make_decision(Backend::CPU,
                               gpu_ ? DispatchReason::Resident_OnCpu
                                    : DispatchReason::GpuUnavailable,
                               n, 0, /*resident*/true, /*borderline*/false);
-        return cpu_->join_sum_resident_i64(hp.inner(), hl.inner(), hb.inner());
+        return run(*cpu_, hp.inner(), hl.inner(), hb.inner());
     }
 
 private:

--- a/src/backends/hybrid_planner.cpp
+++ b/src/backends/hybrid_planner.cpp
@@ -279,6 +279,28 @@ public:
             });
     }
 
+    JoinRowsResult join_rows_resident(const ResidentColumn& probe_keys,
+                                      const ResidentColumn& build_keys,
+                                      JoinKind kind, std::size_t max_rows) override {
+        const auto& hp = check_hybrid(probe_keys);
+        const auto& hb = check_hybrid(build_keys);
+        const std::size_t n = hp.rows();
+        if (hb.on_gpu() != hp.on_gpu())
+            throw std::runtime_error(
+                "resident join: columns are resident on different backends "
+                "(one upload fell back to CPU) — re-upload and retry");
+        if (gpu_ && hp.on_gpu()) {
+            last_ = make_decision(gpu_backend_, DispatchReason::Hot_GpuAlwaysWins,
+                                  n, 0, /*resident*/true, /*borderline*/false);
+            return gpu_->join_rows_resident(hp.inner(), hb.inner(), kind, max_rows);
+        }
+        last_ = make_decision(Backend::CPU,
+                              gpu_ ? DispatchReason::Resident_OnCpu
+                                   : DispatchReason::GpuUnavailable,
+                              n, 0, /*resident*/true, /*borderline*/false);
+        return cpu_->join_rows_resident(hp.inner(), hb.inner(), kind, max_rows);
+    }
+
     template <class Op>
     JoinAggResult dispatch_join(const ResidentColumn& probe_keys,
                                 const ResidentColumn& payload,

--- a/src/backends/hybrid_planner.cpp
+++ b/src/backends/hybrid_planner.cpp
@@ -251,6 +251,34 @@ public:
         return cpu_->agg_all_resident_i64(h.inner());
     }
 
+    // Fused resident join: all three columns must live on the same side —
+    // uploads route deterministically (i64 → GPU when present), so mixed
+    // placement only happens after a partial upload failure; surface that
+    // clearly rather than silently copying columns across.
+    JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
+                                        const ResidentColumn& payload,
+                                        const ResidentColumn& build_keys) override {
+        const auto& hp = check_hybrid(probe_keys);
+        const auto& hl = check_hybrid(payload);
+        const auto& hb = check_hybrid(build_keys);
+        const std::size_t n = hp.rows();
+        const bool on_gpu = hp.on_gpu();
+        if (hl.on_gpu() != on_gpu || hb.on_gpu() != on_gpu)
+            throw std::runtime_error(
+                "join_sum_resident_i64: columns are resident on different backends "
+                "(one upload fell back to CPU) — re-upload and retry");
+        if (gpu_ && on_gpu) {
+            last_ = make_decision(gpu_backend_, DispatchReason::Hot_GpuAlwaysWins,
+                                  n, 0, /*resident*/true, /*borderline*/false);
+            return gpu_->join_sum_resident_i64(hp.inner(), hl.inner(), hb.inner());
+        }
+        last_ = make_decision(Backend::CPU,
+                              gpu_ ? DispatchReason::Resident_OnCpu
+                                   : DispatchReason::GpuUnavailable,
+                              n, 0, /*resident*/true, /*borderline*/false);
+        return cpu_->join_sum_resident_i64(hp.inner(), hl.inner(), hb.inner());
+    }
+
 private:
     // Wraps either a CPU- or GPU-side ResidentColumn. The hybrid uses the
     // `on_gpu_` flag to dispatch the resident query to the right aggregator.

--- a/src/backends/hybrid_planner.cpp
+++ b/src/backends/hybrid_planner.cpp
@@ -104,6 +104,13 @@ constexpr std::size_t kGroupByGpuMinN       = 500'000;   // below: CPU wins (has
 constexpr std::size_t kGroupByGpuMaxN       = 2'000'000; // above: bitonic O(N log²N) collapses past hash O(N)
 constexpr std::size_t kGroupByLowCardGroups = 10'000;    // below: CPU's hash table is cache-resident
 
+// Hash join thresholds (Apple M4, adaptive Metal path, 2026-07-07):
+//   100k×500k: Metal 2.1 ms wall vs CPU 3.6 ms (auto → global)
+//   1M×10M:    Metal 38 ms wall vs CPU 191 ms (partitioned TG hash, 4.9×)
+// Below ~50k total rows GPU launch overhead wins for CPU.
+constexpr std::size_t kJoinSmallTotal  = 50'000;
+constexpr std::size_t kJoinMinProbe    = 10'000;
+
 // =========================================================================
 //  HybridAggregator (SUM/MIN/MAX + resident path)
 // =========================================================================
@@ -487,6 +494,84 @@ private:
     DispatchDecision                   last_{};
 };
 
+// =========================================================================
+//  HybridHashJoinProbe
+// =========================================================================
+
+class HybridHashJoinProbeImpl final : public HybridHashJoinProbe {
+public:
+    HybridHashJoinProbeImpl()
+        : cpu_(make_hashjoin_probe(Backend::CPU))
+    {
+        const Backend gpu = default_backend();
+        if (gpu != Backend::CPU) {
+            try {
+                gpu_ = make_hashjoin_probe(gpu);
+                gpu_backend_ = gpu;
+            } catch (const std::exception&) {
+                gpu_ = nullptr;
+                gpu_backend_ = Backend::CPU;
+            }
+        } else {
+            gpu_backend_ = Backend::CPU;
+        }
+    }
+
+    Backend backend() const noexcept override { return Backend::CPU; }
+
+    std::string device_name() const override {
+        std::string s = "Hybrid hash join (CPU=";
+        s += cpu_->device_name();
+        s += ", GPU=";
+        s += gpu_ ? gpu_->device_name() : std::string("<none>");
+        s += ")";
+        return s;
+    }
+
+    Backend gpu_backend() const noexcept override { return gpu_backend_; }
+    const DispatchDecision& last_decision() const noexcept override { return last_; }
+
+    JoinResult inner_join_i64(const std::int64_t* build_keys, std::size_t n_build,
+                              const std::int64_t* probe_keys, std::size_t n_probe) override {
+        const std::size_t total = n_build + n_probe;
+
+        if (!gpu_) {
+            last_ = make_decision(Backend::CPU, DispatchReason::GpuUnavailable,
+                                  total, 0, false, false);
+            return cpu_->inner_join_i64(build_keys, n_build, probe_keys, n_probe);
+        }
+
+        if (total < kJoinSmallTotal || n_probe < kJoinMinProbe) {
+            last_ = make_decision(Backend::CPU, DispatchReason::Join_SmallN_CpuWins,
+                                  total, 0, false, false);
+            return cpu_->inner_join_i64(build_keys, n_build, probe_keys, n_probe);
+        }
+
+        last_ = make_decision(gpu_backend_, DispatchReason::Join_LargeProbe_GpuWins,
+                              total, 0, false, false);
+        return gpu_->inner_join_i64(build_keys, n_build, probe_keys, n_probe);
+    }
+
+private:
+    static DispatchDecision make_decision(Backend chosen, DispatchReason reason,
+                                          std::size_t n, std::size_t eg,
+                                          bool resident, bool borderline) {
+        DispatchDecision d;
+        d.chosen          = chosen;
+        d.reason          = reason;
+        d.n               = n;
+        d.expected_groups = eg;
+        d.was_resident    = resident;
+        d.borderline      = borderline;
+        return d;
+    }
+
+    std::unique_ptr<HashJoinProbe> cpu_;
+    std::unique_ptr<HashJoinProbe> gpu_;
+    Backend                        gpu_backend_ = Backend::CPU;
+    DispatchDecision               last_{};
+};
+
 } // namespace
 
 const char* to_string(DispatchReason r) noexcept {
@@ -502,6 +587,8 @@ const char* to_string(DispatchReason r) noexcept {
         case DispatchReason::GroupBy_HighCard_GpuWins: return "GroupBy_HighCard_GpuWins";
         case DispatchReason::GroupBy_Borderline_GpuTry:return "GroupBy_Borderline_GpuTry";
         case DispatchReason::GroupBy_HugeN_CpuWins:    return "GroupBy_HugeN_CpuWins";
+        case DispatchReason::Join_SmallN_CpuWins:      return "Join_SmallN_CpuWins";
+        case DispatchReason::Join_LargeProbe_GpuWins:  return "Join_LargeProbe_GpuWins";
     }
     return "?";
 }
@@ -512,6 +599,10 @@ std::unique_ptr<HybridAggregator> make_hybrid_aggregator() {
 
 std::unique_ptr<HybridGroupByAggregator> make_hybrid_groupby_aggregator() {
     return std::make_unique<HybridGroupByAggregatorImpl>();
+}
+
+std::unique_ptr<HybridHashJoinProbe> make_hybrid_hashjoin_probe() {
+    return std::make_unique<HybridHashJoinProbeImpl>();
 }
 
 } // namespace gpudb

--- a/src/backends/metal/kernels/groupby.metal
+++ b/src/backends/metal/kernels/groupby.metal
@@ -977,3 +977,338 @@ kernel void partition_hash_aggregate_slotlock_i64(
         }
     }
 }
+
+// ============================================================================
+// Sort-merge hash join: probe keys against sorted build keys (build must be sorted).
+// Probe order is arbitrary — gid indexes probe rows directly.
+kernel void hashjoin_merge_sorted_i64(
+    device const long*  probe_keys     [[buffer(0)]],
+    device const long*  probe_orig     [[buffer(1)]],
+    device const long*  build_keys     [[buffer(2)]],
+    device const long*  build_orig     [[buffer(3)]],
+    constant uint&      n_probe        [[buffer(4)]],
+    constant uint&      n_build        [[buffer(5)]],
+    device long*        out_probe_idx  [[buffer(6)]],
+    device long*        out_build_idx  [[buffer(7)]],
+    device atomic_uint* out_count      [[buffer(8)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= n_probe) return;
+    const long pk = probe_keys[gid];
+
+    uint lo = 0u;
+    uint hi = n_build;
+    while (lo < hi) {
+        const uint mid = (lo + hi) >> 1;
+        if (build_keys[mid] < pk) lo = mid + 1u;
+        else hi = mid;
+    }
+    if (lo >= n_build || build_keys[lo] != pk) return;
+
+    const uint slot = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
+    out_probe_idx[slot] = probe_orig[gid];
+    out_build_idx[slot] = build_orig[lo];
+}
+
+// ============================================================================
+// Device-resident open-addressing hash join (slot-lock build, read-only probe).
+// Mirrors the slot-lock GROUP BY pattern but stores (key, build_row_idx).
+// v1: first build row wins on duplicate keys; at most one match per probe row.
+// ============================================================================
+
+constant uint HJ_SLOT_EMPTY     = 0u;
+constant uint HJ_SLOT_LOCKED    = 1u;
+constant uint HJ_SLOT_COMMITTED = 2u;
+constant long HJ_KEY_EMPTY      = (long)0x8000000000000000UL;
+
+inline uint hashjoin_slot(long key, uint cap_mask) {
+    const ulong h = slotlock_hash(key);
+    return (uint)(h & cap_mask);
+}
+
+// ----------------------------------------------------------------------------
+// Partitioned hash join (full radix join): one threadgroup per partition.
+//   1. Build TG hash from scattered build slice (key -> first build row index).
+//   2. Probe scattered probe slice via O(1) TG hash lookup per key.
+// Mirrors partition_hash_aggregate_slotlock_i64 but join semantics (no sum).
+// ----------------------------------------------------------------------------
+kernel void partition_hashjoin_i64(
+    device const long*  build_scatter_keys [[buffer(0)]],
+    device const long*  build_scatter_idx  [[buffer(1)]],
+    device const uint*  build_offsets      [[buffer(2)]],
+    device const long*  probe_scatter_keys [[buffer(3)]],
+    device const long*  probe_scatter_idx  [[buffer(4)]],
+    device const uint*  probe_offsets      [[buffer(5)]],
+    device atomic_uint* out_count          [[buffer(6)]],
+    device long*        out_probe          [[buffer(7)]],
+    device long*        out_build          [[buffer(8)]],
+    uint                tid                [[thread_position_in_threadgroup]],
+    uint                pid                [[threadgroup_position_in_grid]])
+{
+    threadgroup atomic_uint slot_state[SLOTLOCK_SLOT_COUNT];
+    threadgroup long        slot_keys[SLOTLOCK_SLOT_COUNT];
+    threadgroup long        slot_idx [SLOTLOCK_SLOT_COUNT];
+
+    for (uint s = tid; s < SLOTLOCK_SLOT_COUNT; s += SLOTLOCK_TG_THREADS) {
+        atomic_store_explicit(&slot_state[s], SLOT_EMPTY, memory_order_relaxed);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const uint build_lo = build_offsets[pid];
+    const uint build_hi = build_offsets[pid + 1u];
+
+    for (uint i = build_lo + tid; i < build_hi; i += SLOTLOCK_TG_THREADS) {
+        const long  k = build_scatter_keys[i];
+        const long  bidx = build_scatter_idx[i];
+        const ulong h = slotlock_hash(k);
+        uint slot = slotlock_slot_start(h);
+        for (uint attempt = 0; attempt < SLOTLOCK_SLOT_COUNT * 4u; ++attempt) {
+            const uint state = atomic_load_explicit(&slot_state[slot],
+                                                    memory_order_relaxed);
+            if (state == SLOT_EMPTY) {
+                uint expected = SLOT_EMPTY;
+                if (atomic_compare_exchange_weak_explicit(
+                        &slot_state[slot], &expected, SLOT_LOCKED,
+                        memory_order_relaxed, memory_order_relaxed))
+                {
+                    slot_keys[slot] = k;
+                    slot_idx[slot] = bidx;
+                    atomic_store_explicit(&slot_state[slot], SLOT_COMMITTED,
+                                          memory_order_relaxed);
+                    break;
+                }
+                continue;
+            }
+            if (state == SLOT_COMMITTED) {
+                if (slot_keys[slot] == k) {
+                    break; // first build row wins
+                }
+                slot = (slot + 1u) & SLOTLOCK_SLOT_MASK;
+                continue;
+            }
+            continue;
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const uint probe_lo = probe_offsets[pid];
+    const uint probe_hi = probe_offsets[pid + 1u];
+
+    for (uint i = probe_lo + tid; i < probe_hi; i += SLOTLOCK_TG_THREADS) {
+        const long  k = probe_scatter_keys[i];
+        const long  pidx = probe_scatter_idx[i];
+        const ulong h = slotlock_hash(k);
+        uint slot = slotlock_slot_start(h);
+        for (uint attempt = 0; attempt < SLOTLOCK_SLOT_COUNT * 4u; ++attempt) {
+            const uint state = atomic_load_explicit(&slot_state[slot],
+                                                    memory_order_relaxed);
+            if (state == SLOT_EMPTY) {
+                break;
+            }
+            if (state == SLOT_COMMITTED) {
+                if (slot_keys[slot] == k) {
+                    const uint pos = atomic_fetch_add_explicit(out_count, 1u,
+                                                               memory_order_relaxed);
+                    out_probe[pos] = pidx;
+                    out_build[pos] = slot_idx[slot];
+                    break;
+                }
+                slot = (slot + 1u) & SLOTLOCK_SLOT_MASK;
+                continue;
+            }
+            continue;
+        }
+    }
+}
+
+kernel void hashjoin_probe_partition_i64(
+    device const long*  probe_keys        [[buffer(0)]],
+    constant uint&      n_probe           [[buffer(1)]],
+    device const long*  scatter_keys      [[buffer(2)]],
+    device const long*  scatter_build_idx [[buffer(3)]],
+    device const uint*  partition_offsets [[buffer(4)]],
+    device long*        out_probe         [[buffer(5)]],
+    device long*        out_build         [[buffer(6)]],
+    device atomic_uint* out_count         [[buffer(7)]],
+    uint                gid               [[thread_position_in_grid]],
+    uint                gsize             [[threads_per_grid]])
+{
+    for (uint i = gid; i < n_probe; i += gsize) {
+        const long k = probe_keys[i];
+        const ulong h = slotlock_hash(k);
+        const uint  p = slotlock_partition(h);
+        const uint  lo = partition_offsets[p];
+        const uint  hi = partition_offsets[p + 1u];
+        for (uint j = lo; j < hi; ++j) {
+            if (scatter_keys[j] == k) {
+                const uint pos = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
+                out_probe[pos] = (long)i;
+                out_build[pos] = scatter_build_idx[j];
+                break;
+            }
+        }
+    }
+}
+
+kernel void hashjoin_fill_iota_i64(
+    device long*   out  [[buffer(0)]],
+    constant uint& n    [[buffer(1)]],
+    uint           gid  [[thread_position_in_grid]],
+    uint           gsize [[threads_per_grid]])
+{
+    for (uint i = gid; i < n; i += gsize) {
+        out[i] = (long)i;
+    }
+}
+
+kernel void hashjoin_init_table(
+    device atomic_uint* slot_state [[buffer(0)]],
+    device long*        slot_keys  [[buffer(1)]],
+    constant uint&      cap        [[buffer(2)]],
+    uint                gid        [[thread_position_in_grid]],
+    uint                gsize      [[threads_per_grid]])
+{
+    for (uint i = gid; i < cap; i += gsize) {
+        atomic_store_explicit(&slot_state[i], HJ_SLOT_EMPTY, memory_order_relaxed);
+        slot_keys[i] = HJ_KEY_EMPTY;
+    }
+}
+
+kernel void hashjoin_build_slotlock_i64(
+    device const long*  build_keys  [[buffer(0)]],
+    constant uint&      n_build     [[buffer(1)]],
+    device atomic_uint* slot_state  [[buffer(2)]],
+    device long*        slot_keys   [[buffer(3)]],
+    device long*        slot_idx    [[buffer(4)]],
+    constant uint&      cap         [[buffer(5)]],
+    uint                gid         [[thread_position_in_grid]],
+    uint                gsize       [[threads_per_grid]])
+{
+    const uint cap_mask = cap - 1u;
+    for (uint i = gid; i < n_build; i += gsize) {
+        const long k = build_keys[i];
+        if (k == HJ_KEY_EMPTY) continue;
+        uint slot = hashjoin_slot(k, cap_mask);
+        for (uint attempt = 0; attempt < cap; ++attempt) {
+            const uint state = atomic_load_explicit(&slot_state[slot], memory_order_relaxed);
+            if (state == HJ_SLOT_EMPTY) {
+                uint expected = HJ_SLOT_EMPTY;
+                if (atomic_compare_exchange_weak_explicit(
+                        &slot_state[slot], &expected, HJ_SLOT_LOCKED,
+                        memory_order_relaxed, memory_order_relaxed))
+                {
+                    slot_keys[slot] = k;
+                    slot_idx[slot] = (long)i;
+                    atomic_store_explicit(&slot_state[slot], HJ_SLOT_COMMITTED,
+                                          memory_order_relaxed);
+                    break;
+                }
+                continue;
+            }
+            if (state == HJ_SLOT_COMMITTED) {
+                if (slot_keys[slot] == k) {
+                    break; // first build row wins (v1 unique-build contract)
+                }
+                slot = (slot + 1u) & cap_mask;
+                continue;
+            }
+            // HJ_SLOT_LOCKED — spin on this slot
+        }
+    }
+}
+
+kernel void hashjoin_probe_slotlock_i64(
+    device const long*        probe_keys  [[buffer(0)]],
+    constant uint&            n_probe     [[buffer(1)]],
+    device const atomic_uint* slot_state  [[buffer(2)]],
+    device const long*        slot_keys   [[buffer(3)]],
+    device const long*        slot_idx    [[buffer(4)]],
+    constant uint&            cap         [[buffer(5)]],
+    device long*              out_probe   [[buffer(6)]],
+    device long*              out_build   [[buffer(7)]],
+    device atomic_uint*       out_count   [[buffer(8)]],
+    uint                      gid         [[thread_position_in_grid]],
+    uint                      gsize       [[threads_per_grid]])
+{
+    const uint cap_mask = cap - 1u;
+    for (uint i = gid; i < n_probe; i += gsize) {
+        const long k = probe_keys[i];
+        if (k == HJ_KEY_EMPTY) continue;
+        uint slot = hashjoin_slot(k, cap_mask);
+        for (uint probe = 0; probe < cap; ++probe) {
+            const uint state = atomic_load_explicit(&slot_state[slot], memory_order_relaxed);
+            if (state == HJ_SLOT_EMPTY) {
+                break;
+            }
+            if (state == HJ_SLOT_COMMITTED) {
+                const long tk = slot_keys[slot];
+                if (tk == k) {
+                    const uint pos = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
+                    out_probe[pos] = (long)i;
+                    out_build[pos] = slot_idx[slot];
+                    break;
+                }
+                if (tk == HJ_KEY_EMPTY) {
+                    break;
+                }
+            }
+            slot = (slot + 1u) & cap_mask;
+        }
+    }
+}
+
+// ============================================================================
+// GPU segment-reduce after radix sort (SUM GROUP BY).
+// Replaces the host O(N) scan over sorted (key, value) pairs at large N.
+// ============================================================================
+
+kernel void segment_run_flags_i64(
+    device const long* keys [[buffer(0)]],
+    constant uint&     n    [[buffer(1)]],
+    device uint*       flags [[buffer(2)]],
+    uint               gid  [[thread_position_in_grid]])
+{
+    if (gid >= n) return;
+    if (gid == 0u) {
+        flags[0] = 1u;
+        return;
+    }
+    flags[gid] = (keys[gid] != keys[gid - 1u]) ? 1u : 0u;
+}
+
+kernel void segment_run_mark_starts_i64(
+    device const uint* flags     [[buffer(0)]],
+    constant uint&     n          [[buffer(1)]],
+    device uint*       starts     [[buffer(2)]],
+    device atomic_uint* out_count [[buffer(3)]],
+    uint               gid        [[thread_position_in_grid]])
+{
+    if (gid >= n) return;
+    if (flags[gid] != 0u) {
+        const uint pos = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
+        starts[pos] = gid;
+    }
+}
+
+kernel void segment_run_sum_i64(
+    device const long* keys   [[buffer(0)]],
+    device const long* values [[buffer(1)]],
+    device const uint* starts [[buffer(2)]],
+    constant uint&     num_segs [[buffer(3)]],
+    constant uint&     n        [[buffer(4)]],
+    device long*       out_keys [[buffer(5)]],
+    device long*       out_sums [[buffer(6)]],
+    uint               gid      [[thread_position_in_grid]])
+{
+    if (gid >= num_segs) return;
+    uint i = starts[gid];
+    const long k = keys[i];
+    long sum = 0;
+    while (i < n && keys[i] == k) {
+        sum += values[i];
+        ++i;
+    }
+    out_keys[gid] = k;
+    out_sums[gid] = sum;
+}

--- a/src/backends/metal/kernels/groupby.metal
+++ b/src/backends/metal/kernels/groupby.metal
@@ -1045,12 +1045,23 @@ kernel void partition_hashjoin_i64(
     uint                tid                [[thread_position_in_threadgroup]],
     uint                pid                [[threadgroup_position_in_grid]])
 {
+    // Per-partition open-addressing table in threadgroup memory.
+    //  - No spinning: a LOCKED slot is skipped like a COMMITTED one (a bounded
+    //    spin on a descheduled locker silently drops the row).
+    //  - Equal keys collapse into one slot via atomic_fetch_min on the build
+    //    index, so "first build row wins" is the SMALLEST index regardless of
+    //    thread scheduling (the owner uses fetch_min too — store vs min would
+    //    race). If a stale key read (relaxed atomics) makes a thread miss the
+    //    collapse, the key simply takes another slot; the probe scans the
+    //    whole run and keeps the minimum, so the result is still exact.
     threadgroup atomic_uint slot_state[SLOTLOCK_SLOT_COUNT];
     threadgroup long        slot_keys[SLOTLOCK_SLOT_COUNT];
-    threadgroup long        slot_idx [SLOTLOCK_SLOT_COUNT];
+    threadgroup atomic_uint slot_idx [SLOTLOCK_SLOT_COUNT];
 
     for (uint s = tid; s < SLOTLOCK_SLOT_COUNT; s += SLOTLOCK_TG_THREADS) {
         atomic_store_explicit(&slot_state[s], SLOT_EMPTY, memory_order_relaxed);
+        atomic_store_explicit(&slot_idx[s], 0xFFFFFFFFu, memory_order_relaxed);
+        slot_keys[s] = HJ_KEY_EMPTY;
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
@@ -1059,7 +1070,7 @@ kernel void partition_hashjoin_i64(
 
     for (uint i = build_lo + tid; i < build_hi; i += SLOTLOCK_TG_THREADS) {
         const long  k = build_scatter_keys[i];
-        const long  bidx = build_scatter_idx[i];
+        const uint  bidx = (uint)build_scatter_idx[i];
         const ulong h = slotlock_hash(k);
         uint slot = slotlock_slot_start(h);
         for (uint attempt = 0; attempt < SLOTLOCK_SLOT_COUNT * 4u; ++attempt) {
@@ -1072,21 +1083,18 @@ kernel void partition_hashjoin_i64(
                         memory_order_relaxed, memory_order_relaxed))
                 {
                     slot_keys[slot] = k;
-                    slot_idx[slot] = bidx;
+                    atomic_fetch_min_explicit(&slot_idx[slot], bidx, memory_order_relaxed);
                     atomic_store_explicit(&slot_state[slot], SLOT_COMMITTED,
                                           memory_order_relaxed);
                     break;
                 }
-                continue;
+                continue;   // lost the CAS (or spurious failure): re-read this slot
             }
-            if (state == SLOT_COMMITTED) {
-                if (slot_keys[slot] == k) {
-                    break; // first build row wins
-                }
-                slot = (slot + 1u) & SLOTLOCK_SLOT_MASK;
-                continue;
+            if (state == SLOT_COMMITTED && slot_keys[slot] == k) {
+                atomic_fetch_min_explicit(&slot_idx[slot], bidx, memory_order_relaxed);
+                break;      // collapsed into the existing slot, smallest index kept
             }
-            continue;
+            slot = (slot + 1u) & SLOTLOCK_SLOT_MASK;   // occupied (locked or other key)
         }
     }
 
@@ -1100,24 +1108,24 @@ kernel void partition_hashjoin_i64(
         const long  pidx = probe_scatter_idx[i];
         const ulong h = slotlock_hash(k);
         uint slot = slotlock_slot_start(h);
-        for (uint attempt = 0; attempt < SLOTLOCK_SLOT_COUNT * 4u; ++attempt) {
+        uint best = 0xFFFFFFFFu;
+        for (uint attempt = 0; attempt < SLOTLOCK_SLOT_COUNT; ++attempt) {
             const uint state = atomic_load_explicit(&slot_state[slot],
                                                     memory_order_relaxed);
             if (state == SLOT_EMPTY) {
                 break;
             }
-            if (state == SLOT_COMMITTED) {
-                if (slot_keys[slot] == k) {
-                    const uint pos = atomic_fetch_add_explicit(out_count, 1u,
-                                                               memory_order_relaxed);
-                    out_probe[pos] = pidx;
-                    out_build[pos] = slot_idx[slot];
-                    break;
-                }
-                slot = (slot + 1u) & SLOTLOCK_SLOT_MASK;
-                continue;
+            if (slot_keys[slot] == k) {
+                const uint bi = atomic_load_explicit(&slot_idx[slot], memory_order_relaxed);
+                if (bi < best) best = bi;
             }
-            continue;
+            slot = (slot + 1u) & SLOTLOCK_SLOT_MASK;
+        }
+        if (best != 0xFFFFFFFFu) {
+            const uint pos = atomic_fetch_add_explicit(out_count, 1u,
+                                                       memory_order_relaxed);
+            out_probe[pos] = pidx;
+            out_build[pos] = (long)best;
         }
     }
 }
@@ -1190,30 +1198,28 @@ kernel void hashjoin_build_slotlock_i64(
         const long k = build_keys[i];
         if (k == HJ_KEY_EMPTY) continue;
         uint slot = hashjoin_slot(k, cap_mask);
+        // Wait-free insert: every build row claims its own slot. A slot that
+        // is LOCKED or COMMITTED by another thread is simply skipped — we never
+        // spin (GPUs give no cross-threadgroup forward-progress guarantee, so a
+        // bounded spin can give up while the locker is descheduled and the row
+        // is silently lost) and we never read slot_keys here (all MSL atomics
+        // are relaxed, so a key written by another thread may not be visible
+        // yet). Duplicate keys therefore occupy several slots; the probe scans
+        // the whole run and keeps the smallest build index (first row wins).
         for (uint attempt = 0; attempt < cap; ++attempt) {
-            const uint state = atomic_load_explicit(&slot_state[slot], memory_order_relaxed);
-            if (state == HJ_SLOT_EMPTY) {
-                uint expected = HJ_SLOT_EMPTY;
-                if (atomic_compare_exchange_weak_explicit(
-                        &slot_state[slot], &expected, HJ_SLOT_LOCKED,
-                        memory_order_relaxed, memory_order_relaxed))
-                {
-                    slot_keys[slot] = k;
-                    slot_idx[slot] = (long)i;
-                    atomic_store_explicit(&slot_state[slot], HJ_SLOT_COMMITTED,
-                                          memory_order_relaxed);
-                    break;
-                }
-                continue;
+            uint expected = HJ_SLOT_EMPTY;
+            if (atomic_compare_exchange_weak_explicit(
+                    &slot_state[slot], &expected, HJ_SLOT_LOCKED,
+                    memory_order_relaxed, memory_order_relaxed))
+            {
+                slot_keys[slot] = k;
+                slot_idx[slot] = (long)i;
+                atomic_store_explicit(&slot_state[slot], HJ_SLOT_COMMITTED,
+                                      memory_order_relaxed);
+                break;
             }
-            if (state == HJ_SLOT_COMMITTED) {
-                if (slot_keys[slot] == k) {
-                    break; // first build row wins (v1 unique-build contract)
-                }
-                slot = (slot + 1u) & cap_mask;
-                continue;
-            }
-            // HJ_SLOT_LOCKED — spin on this slot
+            if (expected == HJ_SLOT_EMPTY) continue;   // spurious CAS failure: retry this slot
+            slot = (slot + 1u) & cap_mask;              // occupied (locked or committed): next
         }
     }
 }
@@ -1236,24 +1242,26 @@ kernel void hashjoin_probe_slotlock_i64(
         const long k = probe_keys[i];
         if (k == HJ_KEY_EMPTY) continue;
         uint slot = hashjoin_slot(k, cap_mask);
+        // The build kernel finished before this dispatch, so every non-EMPTY
+        // slot is COMMITTED and its key/idx are visible. Duplicate build keys
+        // may sit in several slots of the same run: scan the whole run (up to
+        // the first EMPTY slot) and keep the smallest build index.
+        long best = -1;
         for (uint probe = 0; probe < cap; ++probe) {
             const uint state = atomic_load_explicit(&slot_state[slot], memory_order_relaxed);
             if (state == HJ_SLOT_EMPTY) {
                 break;
             }
-            if (state == HJ_SLOT_COMMITTED) {
-                const long tk = slot_keys[slot];
-                if (tk == k) {
-                    const uint pos = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
-                    out_probe[pos] = (long)i;
-                    out_build[pos] = slot_idx[slot];
-                    break;
-                }
-                if (tk == HJ_KEY_EMPTY) {
-                    break;
-                }
+            if (slot_keys[slot] == k) {
+                const long bi = slot_idx[slot];
+                if (best < 0 || bi < best) best = bi;
             }
             slot = (slot + 1u) & cap_mask;
+        }
+        if (best >= 0) {
+            const uint pos = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
+            out_probe[pos] = (long)i;
+            out_build[pos] = best;
         }
     }
 }

--- a/src/backends/metal/kernels/sum.metal
+++ b/src/backends/metal/kernels/sum.metal
@@ -258,3 +258,95 @@ kernel void agg_all_partials_i64(
 // CPU path inside metal_aggregator.mm (transfer cost is zero on UMA, so the
 // overhead is just the host-side reduction). See the host file for the
 // fallback implementation.
+
+// ===================== fused join-sum (v0.5) =====================
+//
+// Inner equi-join + SUM in one pass, against a build-side key column that
+// has been radix-sorted once and cached on its resident column. Each probe
+// element binary-searches its multiplicity m in the sorted build keys and
+// contributes m * payload[i]; probe keys and payload stream sequentially.
+// Multiply and accumulate are ulong (unsigned wrap — the cross-backend rule;
+// the CPU reference does the same, so results are bit-identical).
+
+kernel void join_sum_i64(
+    device const long*  probe_keys   [[buffer(0)]],
+    device const long*  payload      [[buffer(1)]],
+    device const long*  build_sorted [[buffer(2)]],
+    device long*        partials     [[buffer(3)]],   // 2 per block: sum, matched
+    constant uint&      n_probe      [[buffer(4)]],
+    constant uint&      n_build      [[buffer(5)]],
+    uint                tid          [[thread_position_in_threadgroup]],
+    uint                gid          [[thread_position_in_grid]],
+    uint                gsize        [[threads_per_grid]],
+    uint                block_id     [[threadgroup_position_in_grid]])
+{
+    threadgroup long shm_sum[BLOCK];
+    threadgroup long shm_cnt[BLOCK];
+
+    ulong local_sum = 0;
+    long  local_cnt = 0;
+    for (uint i = gid; i < n_probe; i += gsize) {
+        const long k = probe_keys[i];
+        // lower_bound
+        uint lo = 0, hi = n_build;
+        while (lo < hi) {
+            const uint mid = (lo + hi) >> 1;
+            if (build_sorted[mid] < k) lo = mid + 1; else hi = mid;
+        }
+        const uint first = lo;
+        // upper_bound, resuming from lower_bound
+        hi = n_build;
+        while (lo < hi) {
+            const uint mid = (lo + hi) >> 1;
+            if (build_sorted[mid] <= k) lo = mid + 1; else hi = mid;
+        }
+        const uint m = lo - first;
+        if (m != 0) {
+            local_sum += (ulong)m * (ulong)payload[i];
+            local_cnt += (long)m;
+        }
+    }
+    shm_sum[tid] = (long)local_sum;
+    shm_cnt[tid] = local_cnt;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = BLOCK / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            shm_sum[tid] += shm_sum[tid + s];
+            shm_cnt[tid] += shm_cnt[tid + s];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tid == 0) {
+        partials[2 * block_id]     = shm_sum[0];
+        partials[2 * block_id + 1] = shm_cnt[0];
+    }
+}
+
+kernel void join_sum_partials_i64(
+    device const long* partials [[buffer(0)]],
+    device long*       out      [[buffer(1)]],    // out[0]=sum, out[1]=matched
+    constant uint&     n_blocks [[buffer(2)]],
+    uint               tid      [[thread_position_in_threadgroup]])
+{
+    threadgroup long shm_sum[BLOCK];
+    threadgroup long shm_cnt[BLOCK];
+    long ls = 0, lc = 0;
+    for (uint i = tid; i < n_blocks; i += BLOCK) {
+        ls += partials[2 * i];
+        lc += partials[2 * i + 1];
+    }
+    shm_sum[tid] = ls;
+    shm_cnt[tid] = lc;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = BLOCK / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            shm_sum[tid] += shm_sum[tid + s];
+            shm_cnt[tid] += shm_cnt[tid + s];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tid == 0) {
+        out[0] = shm_sum[0];
+        out[1] = shm_cnt[0];
+    }
+}

--- a/src/backends/metal/kernels/sum.metal
+++ b/src/backends/metal/kernels/sum.metal
@@ -399,3 +399,36 @@ kernel void join_mult_i64(
         mult[i] = c;
     }
 }
+
+// Lookup variant for the row-returning join: per probe element, write the
+// build-side match count m[i] and the first-match position first[i] in the
+// SORTED build keys (meaningful only when m[i] > 0). Kind-independent —
+// the host applies the JoinKind emission rules using these two arrays plus
+// the sort permutation.
+kernel void join_lookup_i64(
+    device const long*  probe_keys   [[buffer(0)]],
+    device const long*  build_sorted [[buffer(1)]],
+    device uint*        mcount       [[buffer(2)]],
+    device uint*        first        [[buffer(3)]],
+    constant uint&      n_probe      [[buffer(4)]],
+    constant uint&      n_build      [[buffer(5)]],
+    uint                gid          [[thread_position_in_grid]],
+    uint                gsize        [[threads_per_grid]])
+{
+    for (uint i = gid; i < n_probe; i += gsize) {
+        const long k = probe_keys[i];
+        uint lo = 0, hi = n_build;
+        while (lo < hi) {
+            const uint mid = (lo + hi) >> 1;
+            if (build_sorted[mid] < k) lo = mid + 1; else hi = mid;
+        }
+        const uint f = lo;
+        hi = n_build;
+        while (lo < hi) {
+            const uint mid = (lo + hi) >> 1;
+            if (build_sorted[mid] <= k) lo = mid + 1; else hi = mid;
+        }
+        mcount[i] = lo - f;
+        first[i]  = f;
+    }
+}

--- a/src/backends/metal/kernels/sum.metal
+++ b/src/backends/metal/kernels/sum.metal
@@ -268,6 +268,8 @@ kernel void agg_all_partials_i64(
 // Multiply and accumulate are ulong (unsigned wrap — the cross-backend rule;
 // the CPU reference does the same, so results are bit-identical).
 
+// mode: 0=INNER (c=m), 1=LEFT (c=max(m,1)), 2=SEMI (c=m?1:0), 3=ANTI (c=m?0:1)
+// — mirrors gpudb::JoinKind; see the multiplier table in gpu_backend.hpp.
 kernel void join_sum_i64(
     device const long*  probe_keys   [[buffer(0)]],
     device const long*  payload      [[buffer(1)]],
@@ -275,6 +277,7 @@ kernel void join_sum_i64(
     device long*        partials     [[buffer(3)]],   // 2 per block: sum, matched
     constant uint&      n_probe      [[buffer(4)]],
     constant uint&      n_build      [[buffer(5)]],
+    constant uint&      mode         [[buffer(6)]],
     uint                tid          [[thread_position_in_threadgroup]],
     uint                gid          [[thread_position_in_grid]],
     uint                gsize        [[threads_per_grid]],
@@ -301,9 +304,16 @@ kernel void join_sum_i64(
             if (build_sorted[mid] <= k) lo = mid + 1; else hi = mid;
         }
         const uint m = lo - first;
-        if (m != 0) {
-            local_sum += (ulong)m * (ulong)payload[i];
-            local_cnt += (long)m;
+        uint c;
+        switch (mode) {
+            case 1:  c = m ? m : 1; break;   // LEFT
+            case 2:  c = m ? 1 : 0; break;   // SEMI
+            case 3:  c = m ? 0 : 1; break;   // ANTI
+            default: c = m;         break;   // INNER
+        }
+        if (c != 0) {
+            local_sum += (ulong)c * (ulong)payload[i];
+            local_cnt += (long)c;
         }
     }
     shm_sum[tid] = (long)local_sum;
@@ -348,5 +358,44 @@ kernel void join_sum_partials_i64(
     if (tid == 0) {
         out[0] = shm_sum[0];
         out[1] = shm_cnt[0];
+    }
+}
+
+// Multiplicity-only variant for the f64-payload join: the GPU performs the
+// binary searches (the random-access part it is fast at) and writes each
+// probe element's per-kind contribution count c[i]; the host then streams
+// sum += c[i] * payload_f64[i] in one sequential pass (no doubles in MSL).
+kernel void join_mult_i64(
+    device const long*  probe_keys   [[buffer(0)]],
+    device const long*  build_sorted [[buffer(1)]],
+    device uint*        mult         [[buffer(2)]],
+    constant uint&      n_probe      [[buffer(3)]],
+    constant uint&      n_build      [[buffer(4)]],
+    constant uint&      mode         [[buffer(5)]],
+    uint                gid          [[thread_position_in_grid]],
+    uint                gsize        [[threads_per_grid]])
+{
+    for (uint i = gid; i < n_probe; i += gsize) {
+        const long k = probe_keys[i];
+        uint lo = 0, hi = n_build;
+        while (lo < hi) {
+            const uint mid = (lo + hi) >> 1;
+            if (build_sorted[mid] < k) lo = mid + 1; else hi = mid;
+        }
+        const uint first = lo;
+        hi = n_build;
+        while (lo < hi) {
+            const uint mid = (lo + hi) >> 1;
+            if (build_sorted[mid] <= k) lo = mid + 1; else hi = mid;
+        }
+        const uint m = lo - first;
+        uint c;
+        switch (mode) {
+            case 1:  c = m ? m : 1; break;   // LEFT
+            case 2:  c = m ? 1 : 0; break;   // SEMI
+            case 3:  c = m ? 0 : 1; break;   // ANTI
+            default: c = m;         break;   // INNER
+        }
+        mult[i] = c;
     }
 }

--- a/src/backends/metal/metal_aggregator.mm
+++ b/src/backends/metal/metal_aggregator.mm
@@ -22,11 +22,14 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
+#include <vector>
 
 namespace gpudb {
 
@@ -81,6 +84,7 @@ public:
             ps_agg_all_partials_i64_  = make_pso(lib, @"agg_all_partials_i64");
             ps_join_sum_i64_          = make_pso(lib, @"join_sum_i64");
             ps_join_sum_partials_i64_ = make_pso(lib, @"join_sum_partials_i64");
+            ps_join_mult_i64_         = make_pso(lib, @"join_mult_i64");
 
             partials_buf_ = [device_ newBufferWithLength:(kMaxGrid * sizeof(std::int64_t))
                                                  options:MTLResourceStorageModeShared];
@@ -170,9 +174,37 @@ public:
         }
     }
 
+    // Get (or lazily build + cache) the radix-sorted copy of a build-key
+    // column. Sort cost is reported through *sort_kernel_ms on the call that
+    // pays it; later calls reuse the cache for free.
+    id<MTLBuffer> ensure_sorted_cache(const ResidentColumn& build_col,
+                                      double* sort_kernel_ms) {
+        const auto& bk = check_i64(build_col);
+        id<MTLBuffer> sorted = bk.sorted_cache();
+        if (sorted) return sorted;
+        if (bk.rows() > 0xFFFFFFFFull)
+            throw std::runtime_error("resident join: > 2^32 build rows unsupported");
+        if (!sorter_)
+            sorter_ = std::make_unique<metal_detail::MetalRadixSort>(device_, queue_);
+        const auto* keys = static_cast<const std::int64_t*>([bk.buffer() contents]);
+        auto view = sorter_->sort_device(keys, keys,
+                                         static_cast<std::uint32_t>(bk.rows()));
+        sorted = [device_ newBufferWithLength:bk.rows() * sizeof(std::int64_t)
+                                      options:MTLResourceStorageModeShared];
+        if (!sorted)
+            throw std::runtime_error(
+                "resident join: device allocation for sorted build cache failed");
+        std::memcpy([sorted contents], [view.keys contents],
+                    bk.rows() * sizeof(std::int64_t));
+        bk.set_sorted_cache(sorted);
+        *sort_kernel_ms += view.kernel_ms;
+        return sorted;
+    }
+
     JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
                                         const ResidentColumn& payload,
-                                        const ResidentColumn& build_keys) override {
+                                        const ResidentColumn& build_keys,
+                                        JoinKind kind) override {
         @autoreleasepool {
             const auto t_wall0 = std::chrono::steady_clock::now();
             const auto& pk = check_i64(probe_keys);
@@ -185,7 +217,7 @@ public:
             JoinAggResult r{};
             r.rows_probe = pk.rows();
             r.rows_build = bk.rows();
-            if (pk.rows() == 0 || bk.rows() == 0) {
+            if (pk.rows() == 0) {
                 r.wall_ms = std::chrono::duration<double, std::milli>(
                                 std::chrono::steady_clock::now() - t_wall0).count();
                 return r;
@@ -194,32 +226,13 @@ public:
             if (pk.rows() > 0xFFFFFFFFull || bk.rows() > 0xFFFFFFFFull)
                 throw std::runtime_error("join_sum_resident_i64: > 2^32 rows unsupported");
 
-            // Sorted build-key cache: radix-sort once, reuse on every later
-            // join against this build column. The sort cost lands on the first
-            // call's wall/kernel time — the amortization is the whole point.
             double sort_kernel_ms = 0.0;
-            id<MTLBuffer> sorted = bk.sorted_cache();
-            if (!sorted) {
-                if (!sorter_)
-                    sorter_ = std::make_unique<metal_detail::MetalRadixSort>(device_, queue_);
-                const auto* keys =
-                    static_cast<const std::int64_t*>([bk.buffer() contents]);
-                auto view = sorter_->sort_device(keys, keys,
-                                                 static_cast<std::uint32_t>(bk.rows()));
-                sorted = [device_ newBufferWithLength:bk.rows() * sizeof(std::int64_t)
-                                              options:MTLResourceStorageModeShared];
-                if (!sorted)
-                    throw std::runtime_error(
-                        "join_sum_resident_i64: device allocation for sorted build cache failed");
-                std::memcpy([sorted contents], [view.keys contents],
-                            bk.rows() * sizeof(std::int64_t));
-                bk.set_sorted_cache(sorted);
-                sort_kernel_ms = view.kernel_ms;
-            }
+            id<MTLBuffer> sorted = ensure_sorted_cache(bk, &sort_kernel_ms);
 
             const NSUInteger grid = pick_grid(pk.rows());
             const std::uint32_t np32 = static_cast<std::uint32_t>(pk.rows());
             const std::uint32_t nb32 = static_cast<std::uint32_t>(bk.rows());
+            const std::uint32_t mode = static_cast<std::uint32_t>(kind);
 
             id<MTLCommandBuffer>         cb = [queue_ commandBuffer];
             id<MTLComputeCommandEncoder> ce = [cb computeCommandEncoder];
@@ -233,6 +246,7 @@ public:
             [ce setBuffer:partials_quad_buf_ offset:0 atIndex:3];
             [ce setBytes:&np32 length:sizeof(np32) atIndex:4];
             [ce setBytes:&nb32 length:sizeof(nb32) atIndex:5];
+            [ce setBytes:&mode length:sizeof(mode) atIndex:6];
             [ce dispatchThreadgroups:MTLSizeMake(grid, 1, 1)
                threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
 
@@ -254,6 +268,111 @@ public:
             r.matched     = out[1];
             r.kernel_ms   = cb_kernel_ms(cb) + sort_kernel_ms;
             r.transfer_ms = 0.0;  // UMA
+            r.wall_ms     = std::chrono::duration<double, std::milli>(
+                                std::chrono::steady_clock::now() - t_wall0).count();
+            return r;
+        }
+    }
+
+    // f64 payload: no doubles in MSL, so the probe pass runs as a parallel
+    // HOST loop over the UMA buffers — but it still reuses the GPU-built
+    // sorted-key cache, so repeated f64 joins skip the sort like i64 ones.
+    // Same pattern as sum_resident_f64 (host math on device-held data).
+    JoinAggResult join_sum_resident_f64(const ResidentColumn& probe_keys,
+                                        const ResidentColumn& payload,
+                                        const ResidentColumn& build_keys,
+                                        JoinKind kind) override {
+        @autoreleasepool {
+            const auto t_wall0 = std::chrono::steady_clock::now();
+            const auto& pk = check_i64(probe_keys);
+            const auto& pl = check_f64(payload);
+            const auto& bk = check_i64(build_keys);
+            if (pk.rows() != pl.rows())
+                throw std::runtime_error(
+                    "join_sum_resident_f64: probe_keys and payload row counts differ");
+
+            JoinAggResult r{};
+            r.rows_probe = pk.rows();
+            r.rows_build = bk.rows();
+            if (pk.rows() == 0) {
+                r.wall_ms = std::chrono::duration<double, std::milli>(
+                                std::chrono::steady_clock::now() - t_wall0).count();
+                return r;
+            }
+
+            if (pk.rows() > 0xFFFFFFFFull || bk.rows() > 0xFFFFFFFFull)
+                throw std::runtime_error("join_sum_resident_f64: > 2^32 rows unsupported");
+
+            double sort_kernel_ms = 0.0;
+            id<MTLBuffer> sorted_buf = ensure_sorted_cache(bk, &sort_kernel_ms);
+            const std::size_t n_probe = pk.rows();
+            const std::size_t n_build = bk.rows();
+
+            // Stage 1 (GPU): per-element contribution counts — the random-
+            // access binary searches the GPU is fast at.
+            const std::size_t mult_bytes = n_probe * sizeof(std::uint32_t);
+            if (!mult_buf_ || [mult_buf_ length] < mult_bytes) {
+                mult_buf_ = [device_ newBufferWithLength:mult_bytes
+                                                 options:MTLResourceStorageModeShared];
+                if (!mult_buf_)
+                    throw std::runtime_error(
+                        "join_sum_resident_f64: multiplicity buffer allocation failed");
+            }
+            const NSUInteger grid = pick_grid(n_probe);
+            const std::uint32_t np32 = static_cast<std::uint32_t>(n_probe);
+            const std::uint32_t nb32 = static_cast<std::uint32_t>(n_build);
+            const std::uint32_t mode = static_cast<std::uint32_t>(kind);
+
+            id<MTLCommandBuffer>         cb = [queue_ commandBuffer];
+            id<MTLComputeCommandEncoder> ce = [cb computeCommandEncoder];
+            [ce setComputePipelineState:ps_join_mult_i64_];
+            [ce setBuffer:pk.buffer() offset:0 atIndex:0];
+            [ce setBuffer:sorted_buf  offset:0 atIndex:1];
+            [ce setBuffer:mult_buf_   offset:0 atIndex:2];
+            [ce setBytes:&np32 length:sizeof(np32) atIndex:3];
+            [ce setBytes:&nb32 length:sizeof(nb32) atIndex:4];
+            [ce setBytes:&mode length:sizeof(mode) atIndex:5];
+            [ce dispatchThreadgroups:MTLSizeMake(grid, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+            [ce endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+
+            // Stage 2 (host, parallel): one sequential multiply-add stream —
+            // no random access, saturates memory bandwidth.
+            const auto* mult = static_cast<const std::uint32_t*>([mult_buf_ contents]);
+            const auto* pay  = static_cast<const double*>([pl.buffer() contents]);
+            const unsigned hw = std::thread::hardware_concurrency();
+            const std::size_t workers =
+                std::max<std::size_t>(1, std::min<std::size_t>(hw ? hw : 1,
+                                                               n_probe / 65536 + 1));
+            std::vector<double>       sums(workers, 0.0);
+            std::vector<std::int64_t> cnts(workers, 0);
+            std::vector<std::thread>  threads;
+            const std::size_t per = n_probe / workers;
+            for (std::size_t w = 0; w < workers; ++w) {
+                const std::size_t begin = w * per;
+                const std::size_t end   = (w + 1 == workers) ? n_probe : begin + per;
+                threads.emplace_back([&, w, begin, end] {
+                    double s = 0.0; std::int64_t c_total = 0;
+                    for (std::size_t i = begin; i < end; ++i) {
+                        const std::uint32_t c = mult[i];
+                        if (c) {
+                            s += static_cast<double>(c) * pay[i];
+                            c_total += c;
+                        }
+                    }
+                    sums[w] = s; cnts[w] = c_total;
+                });
+            }
+            for (auto& t : threads) t.join();
+            double sum = 0.0; std::int64_t matched = 0;
+            for (std::size_t w = 0; w < workers; ++w) { sum += sums[w]; matched += cnts[w]; }
+
+            r.sum_f64     = sum;
+            r.matched     = matched;
+            r.kernel_ms   = cb_kernel_ms(cb) + sort_kernel_ms;
+            r.transfer_ms = 0.0;
             r.wall_ms     = std::chrono::duration<double, std::milli>(
                                 std::chrono::steady_clock::now() - t_wall0).count();
             return r;
@@ -524,9 +643,14 @@ private:
     id<MTLComputePipelineState> ps_agg_all_partials_i64_ = nil;
     id<MTLComputePipelineState> ps_join_sum_i64_          = nil;
     id<MTLComputePipelineState> ps_join_sum_partials_i64_ = nil;
+    id<MTLComputePipelineState> ps_join_mult_i64_         = nil;
 
     // Lazily constructed: only joins pay for the radix-sort pipelines.
     std::unique_ptr<metal_detail::MetalRadixSort> sorter_;
+
+    // Per-probe-element multiplicity scratch for the f64 join path (u32 per
+    // row); grown on demand, reused across calls.
+    id<MTLBuffer> mult_buf_ = nil;
 
     id<MTLBuffer> input_buf_         = nil;  // grows on demand (slow-path memcpy)
     id<MTLBuffer> partials_buf_      = nil;  // sized for kMaxGrid * sizeof(int64)

--- a/src/backends/metal/metal_aggregator.mm
+++ b/src/backends/metal/metal_aggregator.mm
@@ -17,6 +17,7 @@
 
 #include "gpu_backend.hpp"
 #include "metal_kernel_sources.hpp"
+#include "metal_radix_sort.hpp"
 
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
@@ -78,6 +79,8 @@ public:
             ps_max_partials_i64_  = make_pso(lib, @"max_partials_i64");
             ps_agg_all_i64_           = make_pso(lib, @"agg_all_i64");
             ps_agg_all_partials_i64_  = make_pso(lib, @"agg_all_partials_i64");
+            ps_join_sum_i64_          = make_pso(lib, @"join_sum_i64");
+            ps_join_sum_partials_i64_ = make_pso(lib, @"join_sum_partials_i64");
 
             partials_buf_ = [device_ newBufferWithLength:(kMaxGrid * sizeof(std::int64_t))
                                                  options:MTLResourceStorageModeShared];
@@ -167,6 +170,96 @@ public:
         }
     }
 
+    JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
+                                        const ResidentColumn& payload,
+                                        const ResidentColumn& build_keys) override {
+        @autoreleasepool {
+            const auto t_wall0 = std::chrono::steady_clock::now();
+            const auto& pk = check_i64(probe_keys);
+            const auto& pl = check_i64(payload);
+            const auto& bk = check_i64(build_keys);
+            if (pk.rows() != pl.rows())
+                throw std::runtime_error(
+                    "join_sum_resident_i64: probe_keys and payload row counts differ");
+
+            JoinAggResult r{};
+            r.rows_probe = pk.rows();
+            r.rows_build = bk.rows();
+            if (pk.rows() == 0 || bk.rows() == 0) {
+                r.wall_ms = std::chrono::duration<double, std::milli>(
+                                std::chrono::steady_clock::now() - t_wall0).count();
+                return r;
+            }
+            // Kernel indices are 32-bit (same convention as every kernel here).
+            if (pk.rows() > 0xFFFFFFFFull || bk.rows() > 0xFFFFFFFFull)
+                throw std::runtime_error("join_sum_resident_i64: > 2^32 rows unsupported");
+
+            // Sorted build-key cache: radix-sort once, reuse on every later
+            // join against this build column. The sort cost lands on the first
+            // call's wall/kernel time — the amortization is the whole point.
+            double sort_kernel_ms = 0.0;
+            id<MTLBuffer> sorted = bk.sorted_cache();
+            if (!sorted) {
+                if (!sorter_)
+                    sorter_ = std::make_unique<metal_detail::MetalRadixSort>(device_, queue_);
+                const auto* keys =
+                    static_cast<const std::int64_t*>([bk.buffer() contents]);
+                auto view = sorter_->sort_device(keys, keys,
+                                                 static_cast<std::uint32_t>(bk.rows()));
+                sorted = [device_ newBufferWithLength:bk.rows() * sizeof(std::int64_t)
+                                              options:MTLResourceStorageModeShared];
+                if (!sorted)
+                    throw std::runtime_error(
+                        "join_sum_resident_i64: device allocation for sorted build cache failed");
+                std::memcpy([sorted contents], [view.keys contents],
+                            bk.rows() * sizeof(std::int64_t));
+                bk.set_sorted_cache(sorted);
+                sort_kernel_ms = view.kernel_ms;
+            }
+
+            const NSUInteger grid = pick_grid(pk.rows());
+            const std::uint32_t np32 = static_cast<std::uint32_t>(pk.rows());
+            const std::uint32_t nb32 = static_cast<std::uint32_t>(bk.rows());
+
+            id<MTLCommandBuffer>         cb = [queue_ commandBuffer];
+            id<MTLComputeCommandEncoder> ce = [cb computeCommandEncoder];
+
+            // Pass 1: per-threadgroup join+reduce. partials_quad_buf_ holds
+            // 4 longs per block; we use the first 2 (sum, matched).
+            [ce setComputePipelineState:ps_join_sum_i64_];
+            [ce setBuffer:pk.buffer()       offset:0 atIndex:0];
+            [ce setBuffer:pl.buffer()       offset:0 atIndex:1];
+            [ce setBuffer:sorted            offset:0 atIndex:2];
+            [ce setBuffer:partials_quad_buf_ offset:0 atIndex:3];
+            [ce setBytes:&np32 length:sizeof(np32) atIndex:4];
+            [ce setBytes:&nb32 length:sizeof(nb32) atIndex:5];
+            [ce dispatchThreadgroups:MTLSizeMake(grid, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
+            // Pass 2: reduce block partials to (sum, matched).
+            const std::uint32_t nblocks = static_cast<std::uint32_t>(grid);
+            [ce setComputePipelineState:ps_join_sum_partials_i64_];
+            [ce setBuffer:partials_quad_buf_ offset:0 atIndex:0];
+            [ce setBuffer:out_quad_buf_      offset:0 atIndex:1];
+            [ce setBytes:&nblocks length:sizeof(nblocks) atIndex:2];
+            [ce dispatchThreadgroups:MTLSizeMake(1, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
+            [ce endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+
+            const auto* out = static_cast<const std::int64_t*>([out_quad_buf_ contents]);
+            r.sum         = out[0];
+            r.matched     = out[1];
+            r.kernel_ms   = cb_kernel_ms(cb) + sort_kernel_ms;
+            r.transfer_ms = 0.0;  // UMA
+            r.wall_ms     = std::chrono::duration<double, std::milli>(
+                                std::chrono::steady_clock::now() - t_wall0).count();
+            return r;
+        }
+    }
+
 private:
     class MetalResidentColumn final : public ResidentColumn {
     public:
@@ -176,10 +269,17 @@ private:
         Dtype       dtype()       const noexcept override { return dtype_; }
         std::size_t rows()        const noexcept override { return rows_; }
         id<MTLBuffer> buffer()    const noexcept { return buf_; }
+
+        // Build-side sorted-key cache for the fused join (see gpu_backend.hpp:
+        // backend-private, dies with the column, exempt from the host pool cap).
+        // Mutable: built lazily on first join use of a const handle.
+        id<MTLBuffer> sorted_cache() const noexcept { return sorted_; }
+        void set_sorted_cache(id<MTLBuffer> b) const noexcept { sorted_ = b; }
     private:
         id<MTLBuffer> buf_;
         std::size_t   rows_;
         Dtype         dtype_;
+        mutable id<MTLBuffer> sorted_ = nil;
     };
 
     std::unique_ptr<ResidentColumn>
@@ -422,6 +522,11 @@ private:
     id<MTLComputePipelineState> ps_max_partials_i64_ = nil;
     id<MTLComputePipelineState> ps_agg_all_i64_          = nil;
     id<MTLComputePipelineState> ps_agg_all_partials_i64_ = nil;
+    id<MTLComputePipelineState> ps_join_sum_i64_          = nil;
+    id<MTLComputePipelineState> ps_join_sum_partials_i64_ = nil;
+
+    // Lazily constructed: only joins pay for the radix-sort pipelines.
+    std::unique_ptr<metal_detail::MetalRadixSort> sorter_;
 
     id<MTLBuffer> input_buf_         = nil;  // grows on demand (slow-path memcpy)
     id<MTLBuffer> partials_buf_      = nil;  // sized for kMaxGrid * sizeof(int64)

--- a/src/backends/metal/metal_aggregator.mm
+++ b/src/backends/metal/metal_aggregator.mm
@@ -85,6 +85,7 @@ public:
             ps_join_sum_i64_          = make_pso(lib, @"join_sum_i64");
             ps_join_sum_partials_i64_ = make_pso(lib, @"join_sum_partials_i64");
             ps_join_mult_i64_         = make_pso(lib, @"join_mult_i64");
+            ps_join_lookup_i64_       = make_pso(lib, @"join_lookup_i64");
 
             partials_buf_ = [device_ newBufferWithLength:(kMaxGrid * sizeof(std::int64_t))
                                                  options:MTLResourceStorageModeShared];
@@ -186,17 +187,24 @@ public:
             throw std::runtime_error("resident join: > 2^32 build rows unsupported");
         if (!sorter_)
             sorter_ = std::make_unique<metal_detail::MetalRadixSort>(device_, queue_);
+        const std::size_t n = bk.rows();
         const auto* keys = static_cast<const std::int64_t*>([bk.buffer() contents]);
-        auto view = sorter_->sort_device(keys, keys,
-                                         static_cast<std::uint32_t>(bk.rows()));
-        sorted = [device_ newBufferWithLength:bk.rows() * sizeof(std::int64_t)
-                                      options:MTLResourceStorageModeShared];
-        if (!sorted)
+        // Sort (key, original-index) pairs: the payload comes back as the
+        // permutation the row join needs.
+        std::vector<std::int64_t> idx(n);
+        for (std::size_t j = 0; j < n; ++j) idx[j] = static_cast<std::int64_t>(j);
+        auto view = sorter_->sort_device(keys, idx.data(),
+                                         static_cast<std::uint32_t>(n));
+        sorted             = [device_ newBufferWithLength:n * sizeof(std::int64_t)
+                                                  options:MTLResourceStorageModeShared];
+        id<MTLBuffer> perm = [device_ newBufferWithLength:n * sizeof(std::int64_t)
+                                                  options:MTLResourceStorageModeShared];
+        if (!sorted || !perm)
             throw std::runtime_error(
                 "resident join: device allocation for sorted build cache failed");
-        std::memcpy([sorted contents], [view.keys contents],
-                    bk.rows() * sizeof(std::int64_t));
-        bk.set_sorted_cache(sorted);
+        std::memcpy([sorted contents], [view.keys contents],     n * sizeof(std::int64_t));
+        std::memcpy([perm contents],   [view.payloads contents], n * sizeof(std::int64_t));
+        bk.set_sorted_cache(sorted, perm);
         *sort_kernel_ms += view.kernel_ms;
         return sorted;
     }
@@ -379,6 +387,140 @@ public:
         }
     }
 
+    JoinRowsResult join_rows_resident(const ResidentColumn& probe_keys,
+                                      const ResidentColumn& build_keys,
+                                      JoinKind kind, std::size_t max_rows) override {
+        @autoreleasepool {
+            const auto t_wall0 = std::chrono::steady_clock::now();
+            const auto& pk = check_i64(probe_keys);
+            const auto& bk = check_i64(build_keys);
+
+            JoinRowsResult r{};
+            r.rows_probe = pk.rows();
+            r.rows_build = bk.rows();
+            const std::size_t n_probe = pk.rows();
+            const std::size_t n_build = bk.rows();
+            if (n_probe == 0) {
+                r.wall_ms = std::chrono::duration<double, std::milli>(
+                                std::chrono::steady_clock::now() - t_wall0).count();
+                return r;
+            }
+            if (n_probe > 0xFFFFFFFFull || n_build > 0xFFFFFFFFull)
+                throw std::runtime_error("join_rows_resident: > 2^32 rows unsupported");
+
+            double sort_kernel_ms = 0.0;
+            id<MTLBuffer> sorted_buf = ensure_sorted_cache(bk, &sort_kernel_ms);
+            id<MTLBuffer> perm_buf   = bk.perm_cache();
+
+            // Stage 1 (GPU): match count + first sorted position per probe.
+            const std::size_t u32_bytes = n_probe * sizeof(std::uint32_t);
+            if (!mult_buf_ || [mult_buf_ length] < u32_bytes)
+                mult_buf_ = [device_ newBufferWithLength:u32_bytes
+                                                 options:MTLResourceStorageModeShared];
+            if (!first_buf_ || [first_buf_ length] < u32_bytes)
+                first_buf_ = [device_ newBufferWithLength:u32_bytes
+                                                  options:MTLResourceStorageModeShared];
+            if (!mult_buf_ || !first_buf_)
+                throw std::runtime_error("join_rows_resident: scratch allocation failed");
+
+            const NSUInteger grid = pick_grid(n_probe);
+            const std::uint32_t np32 = static_cast<std::uint32_t>(n_probe);
+            const std::uint32_t nb32 = static_cast<std::uint32_t>(n_build);
+            id<MTLCommandBuffer>         cb = [queue_ commandBuffer];
+            id<MTLComputeCommandEncoder> ce = [cb computeCommandEncoder];
+            [ce setComputePipelineState:ps_join_lookup_i64_];
+            [ce setBuffer:pk.buffer() offset:0 atIndex:0];
+            [ce setBuffer:sorted_buf  offset:0 atIndex:1];
+            [ce setBuffer:mult_buf_   offset:0 atIndex:2];
+            [ce setBuffer:first_buf_  offset:0 atIndex:3];
+            [ce setBytes:&np32 length:sizeof(np32) atIndex:4];
+            [ce setBytes:&nb32 length:sizeof(nb32) atIndex:5];
+            [ce dispatchThreadgroups:MTLSizeMake(grid, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+            [ce endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+
+            // Stage 2 (host, parallel): chunked prefix-sum of the per-kind
+            // output counts, then a parallel fill from the perm cache.
+            const auto* mc    = static_cast<const std::uint32_t*>([mult_buf_ contents]);
+            const auto* first = static_cast<const std::uint32_t*>([first_buf_ contents]);
+            const auto* perm  = static_cast<const std::int64_t*>([perm_buf contents]);
+
+            auto count_of = [&](std::size_t i) -> std::size_t {
+                const std::uint32_t m = mc[i];
+                switch (kind) {
+                    case JoinKind::LEFT:  return m ? m : 1;
+                    case JoinKind::SEMI:  return m ? 1 : 0;
+                    case JoinKind::ANTI:  return m ? 0 : 1;
+                    default:              return m;
+                }
+            };
+
+            const unsigned hw = std::thread::hardware_concurrency();
+            const std::size_t workers =
+                std::max<std::size_t>(1, std::min<std::size_t>(hw ? hw : 1,
+                                                               n_probe / 65536 + 1));
+            const std::size_t per = (n_probe + workers - 1) / workers;
+            std::vector<std::size_t> chunk_total(workers, 0);
+            {
+                std::vector<std::thread> ts;
+                for (std::size_t w = 0; w < workers; ++w) {
+                    const std::size_t b = w * per, e = std::min(n_probe, b + per);
+                    ts.emplace_back([&, w, b, e] {
+                        std::size_t s = 0;
+                        for (std::size_t i = b; i < e; ++i) s += count_of(i);
+                        chunk_total[w] = s;
+                    });
+                }
+                for (auto& t : ts) t.join();
+            }
+            std::size_t total = 0;
+            std::vector<std::size_t> chunk_off(workers, 0);
+            for (std::size_t w = 0; w < workers; ++w) { chunk_off[w] = total; total += chunk_total[w]; }
+            if (total > max_rows)
+                throw std::runtime_error(
+                    "join_rows_resident: result has " + std::to_string(total) +
+                    " rows, above the cap of " + std::to_string(max_rows) +
+                    " (raise GPUDB_JOIN_ROWS_MAX_M if intentional)");
+
+            r.probe_idx.resize(total);
+            r.build_idx.resize(total);
+            {
+                std::vector<std::thread> ts;
+                for (std::size_t w = 0; w < workers; ++w) {
+                    const std::size_t b = w * per, e = std::min(n_probe, b + per);
+                    ts.emplace_back([&, w, b, e] {
+                        std::size_t off = chunk_off[w];
+                        for (std::size_t i = b; i < e; ++i) {
+                            const std::uint32_t m = mc[i];
+                            const bool matched = m != 0;
+                            if ((kind == JoinKind::INNER || kind == JoinKind::LEFT) && matched) {
+                                const std::uint32_t f = first[i];
+                                for (std::uint32_t t2 = 0; t2 < m; ++t2) {
+                                    r.probe_idx[off] = static_cast<std::int64_t>(i);
+                                    r.build_idx[off] = perm[f + t2];
+                                    ++off;
+                                }
+                            } else if (count_of(i)) {
+                                r.probe_idx[off] = static_cast<std::int64_t>(i);
+                                r.build_idx[off] = -1;
+                                ++off;
+                            }
+                        }
+                    });
+                }
+                for (auto& t : ts) t.join();
+            }
+
+            r.kernel_ms   = cb_kernel_ms(cb) + sort_kernel_ms;
+            r.transfer_ms = 0.0;
+            r.wall_ms     = std::chrono::duration<double, std::milli>(
+                                std::chrono::steady_clock::now() - t_wall0).count();
+            return r;
+        }
+    }
+
 private:
     class MetalResidentColumn final : public ResidentColumn {
     public:
@@ -389,16 +531,23 @@ private:
         std::size_t rows()        const noexcept override { return rows_; }
         id<MTLBuffer> buffer()    const noexcept { return buf_; }
 
-        // Build-side sorted-key cache for the fused join (see gpu_backend.hpp:
-        // backend-private, dies with the column, exempt from the host pool cap).
-        // Mutable: built lazily on first join use of a const handle.
+        // Build-side sorted-key cache for the fused/row joins (see
+        // gpu_backend.hpp: backend-private, dies with the column, exempt from
+        // the host pool cap). perm holds the sort permutation as ORIGINAL
+        // upload indices (i64), aligned with the sorted keys — the row join
+        // uses it to emit original build indices. Mutable: built lazily on
+        // first join use of a const handle.
         id<MTLBuffer> sorted_cache() const noexcept { return sorted_; }
-        void set_sorted_cache(id<MTLBuffer> b) const noexcept { sorted_ = b; }
+        id<MTLBuffer> perm_cache()   const noexcept { return perm_; }
+        void set_sorted_cache(id<MTLBuffer> keys, id<MTLBuffer> perm) const noexcept {
+            sorted_ = keys; perm_ = perm;
+        }
     private:
         id<MTLBuffer> buf_;
         std::size_t   rows_;
         Dtype         dtype_;
         mutable id<MTLBuffer> sorted_ = nil;
+        mutable id<MTLBuffer> perm_   = nil;
     };
 
     std::unique_ptr<ResidentColumn>
@@ -644,6 +793,7 @@ private:
     id<MTLComputePipelineState> ps_join_sum_i64_          = nil;
     id<MTLComputePipelineState> ps_join_sum_partials_i64_ = nil;
     id<MTLComputePipelineState> ps_join_mult_i64_         = nil;
+    id<MTLComputePipelineState> ps_join_lookup_i64_       = nil;
 
     // Lazily constructed: only joins pay for the radix-sort pipelines.
     std::unique_ptr<metal_detail::MetalRadixSort> sorter_;
@@ -651,6 +801,8 @@ private:
     // Per-probe-element multiplicity scratch for the f64 join path (u32 per
     // row); grown on demand, reused across calls.
     id<MTLBuffer> mult_buf_ = nil;
+    // First-match-position scratch for the row-returning join (u32 per row).
+    id<MTLBuffer> first_buf_ = nil;
 
     id<MTLBuffer> input_buf_         = nil;  // grows on demand (slow-path memcpy)
     id<MTLBuffer> partials_buf_      = nil;  // sized for kMaxGrid * sizeof(int64)

--- a/src/backends/metal/metal_groupby.mm
+++ b/src/backends/metal/metal_groupby.mm
@@ -94,6 +94,9 @@ public:
             ps_partition_scatter_ = make_pso(lib, @"partition_scatter_hash");
             ps_partition_aggregate_slotlock_ =
                 make_pso(lib, @"partition_hash_aggregate_slotlock_i64");
+            ps_seg_flags_  = make_pso(lib, @"segment_run_flags_i64");
+            ps_seg_mark_   = make_pso(lib, @"segment_run_mark_starts_i64");
+            ps_seg_sum_    = make_pso(lib, @"segment_run_sum_i64");
         }
     }
 
@@ -103,7 +106,7 @@ public:
         @autoreleasepool {
             std::ostringstream os;
             os << [[device_ name] UTF8String]
-               << " (Metal, LSD radix sort + host segment-reduce)";
+               << " (Metal, LSD radix sort + GPU segment-reduce)";
             return os.str();
         }
     }
@@ -374,80 +377,82 @@ public:
             [ce dispatchThreadgroups:MTLSizeMake((n32 + kBlock - 1) / kBlock, 1, 1)
                threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
 
+            // ---- GPU segment-reduce (replaces host scan at large N) ----
+            const std::size_t bytes_flags = static_cast<std::size_t>(n32) * sizeof(std::uint32_t);
+            if (!b_seg_flags_ || [b_seg_flags_ length] < bytes_flags) {
+                b_seg_flags_ = [device_ newBufferWithLength:bytes_flags
+                                                    options:MTLResourceStorageModeShared];
+            }
+            if (!b_seg_starts_ || [b_seg_starts_ length] < bytes_flags) {
+                b_seg_starts_ = [device_ newBufferWithLength:bytes_flags
+                                                     options:MTLResourceStorageModeShared];
+            }
+            if (!b_sl_out_count_ || [b_sl_out_count_ length] < sizeof(std::uint32_t)) {
+                b_sl_out_count_ = [device_ newBufferWithLength:sizeof(std::uint32_t)
+                                                       options:MTLResourceStorageModeShared];
+            }
+            if (!b_sl_out_keys_ || [b_sl_out_keys_ length] < bytes_kv) {
+                b_sl_out_keys_ = [device_ newBufferWithLength:bytes_kv
+                                                      options:MTLResourceStorageModeShared];
+            }
+            if (!b_sl_out_sums_ || [b_sl_out_sums_ length] < bytes_kv) {
+                b_sl_out_sums_ = [device_ newBufferWithLength:bytes_kv
+                                                      options:MTLResourceStorageModeShared];
+            }
+
+            [ce setComputePipelineState:ps_seg_flags_];
+            [ce setBuffer:in_keys offset:0 atIndex:0];
+            [ce setBytes:&n32 length:sizeof(n32) atIndex:1];
+            [ce setBuffer:b_seg_flags_ offset:0 atIndex:2];
+            [ce dispatchThreadgroups:MTLSizeMake((n32 + kBlock - 1) / kBlock, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
+            std::memset([b_sl_out_count_ contents], 0, sizeof(std::uint32_t));
+
+            [ce setComputePipelineState:ps_seg_mark_];
+            [ce setBuffer:b_seg_flags_ offset:0 atIndex:0];
+            [ce setBytes:&n32 length:sizeof(n32) atIndex:1];
+            [ce setBuffer:b_seg_starts_ offset:0 atIndex:2];
+            [ce setBuffer:b_sl_out_count_ offset:0 atIndex:3];
+            [ce dispatchThreadgroups:MTLSizeMake((n32 + kBlock - 1) / kBlock, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
             [ce endEncoding];
             [cb commit];
             [cb waitUntilCompleted];
 
-            const double kernel_ms_total = ([cb GPUEndTime] - [cb GPUStartTime]) * 1000.0;
+            const double kernel_ms_radix = ([cb GPUEndTime] - [cb GPUStartTime]) * 1000.0;
 
-            // ---- Host segment-reduce (parallel) ----
-            // Sorted (key, value) array. Divide into NTHREADS chunks; each
-            // thread emits (key, sum) pairs for the runs entirely inside its
-            // chunk. Boundary keys (a run that spans the chunk edge) are
-            // stitched together in a final single-thread pass over the
-            // per-thread results.
-            const std::int64_t* sk = static_cast<const std::int64_t*>([in_keys   contents]);
-            const std::int64_t* sv = static_cast<const std::int64_t*>([in_values contents]);
+            const std::uint32_t num_segs =
+                *static_cast<const std::uint32_t*>([b_sl_out_count_ contents]);
 
-            constexpr int kSegThreads = 8;
-            if (n >= 16384) {
-                std::vector<std::vector<std::int64_t>> tk(kSegThreads), ts(kSegThreads);
-
-                // Align each chunk start to a run boundary so no run is split.
-                std::array<std::size_t, kSegThreads + 1> starts;
-                starts[0] = 0;
-                for (int t = 1; t < kSegThreads; ++t) {
-                    std::size_t s = (n / kSegThreads) * t;
-                    while (s < n && s > 0 && sk[s] == sk[s - 1]) ++s;
-                    starts[t] = s;
-                }
-                starts[kSegThreads] = n;
-
-                std::vector<std::thread> workers;
-                workers.reserve(kSegThreads);
-                for (int t = 0; t < kSegThreads; ++t) {
-                    workers.emplace_back([&, t] {
-                        const std::size_t lo = starts[t];
-                        const std::size_t hi = starts[t + 1];
-                        std::size_t i = lo;
-                        while (i < hi) {
-                            const std::int64_t k = sk[i];
-                            std::int64_t sum = 0;
-                            std::size_t j = i;
-                            while (j < hi && sk[j] == k) { sum += sv[j]; ++j; }
-                            tk[t].push_back(k);
-                            ts[t].push_back(sum);
-                            i = j;
-                        }
-                    });
-                }
-                for (auto& w : workers) w.join();
-
-                // Concatenate (no boundary stitching needed: starts[] aligned to runs).
-                std::size_t total = 0;
-                for (int t = 0; t < kSegThreads; ++t) total += tk[t].size();
-                r.keys.reserve(total);
-                r.sums.reserve(total);
-                for (int t = 0; t < kSegThreads; ++t) {
-                    r.keys.insert(r.keys.end(), tk[t].begin(), tk[t].end());
-                    r.sums.insert(r.sums.end(), ts[t].begin(), ts[t].end());
-                }
-            } else {
-                r.keys.reserve(64);
-                r.sums.reserve(64);
-                std::size_t i = 0;
-                while (i < n) {
-                    const std::int64_t k = sk[i];
-                    std::int64_t sum = 0;
-                    std::size_t j = i;
-                    while (j < n && sk[j] == k) { sum += sv[j]; ++j; }
-                    r.keys.push_back(k);
-                    r.sums.push_back(sum);
-                    i = j;
-                }
+            double kernel_ms_seg = 0.0;
+            if (num_segs > 0) {
+                id<MTLCommandBuffer> cb_seg = [queue_ commandBuffer];
+                id<MTLComputeCommandEncoder> ce_seg = [cb_seg computeCommandEncoder];
+                [ce_seg setComputePipelineState:ps_seg_sum_];
+                [ce_seg setBuffer:in_keys offset:0 atIndex:0];
+                [ce_seg setBuffer:in_values offset:0 atIndex:1];
+                [ce_seg setBuffer:b_seg_starts_ offset:0 atIndex:2];
+                [ce_seg setBytes:&num_segs length:sizeof(num_segs) atIndex:3];
+                [ce_seg setBytes:&n32 length:sizeof(n32) atIndex:4];
+                [ce_seg setBuffer:b_sl_out_keys_ offset:0 atIndex:5];
+                [ce_seg setBuffer:b_sl_out_sums_ offset:0 atIndex:6];
+                const NSUInteger seg_tg = (num_segs + kBlock - 1) / kBlock;
+                [ce_seg dispatchThreadgroups:MTLSizeMake(seg_tg, 1, 1)
+                    threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+                [ce_seg endEncoding];
+                [cb_seg commit];
+                [cb_seg waitUntilCompleted];
+                kernel_ms_seg = ([cb_seg GPUEndTime] - [cb_seg GPUStartTime]) * 1000.0;
             }
 
-            r.kernel_ms   = kernel_ms_total;
+            const std::int64_t* ok = static_cast<const std::int64_t*>([b_sl_out_keys_ contents]);
+            const std::int64_t* os_ = static_cast<const std::int64_t*>([b_sl_out_sums_ contents]);
+            r.keys.assign(ok, ok + num_segs);
+            r.sums.assign(os_, os_ + num_segs);
+
+            r.kernel_ms   = kernel_ms_radix + kernel_ms_seg;
             r.transfer_ms = 0.0;
             r.wall_ms     = std::chrono::duration<double, std::milli>(
                                 std::chrono::steady_clock::now() - t_wall0).count();
@@ -718,6 +723,9 @@ private:
     id<MTLComputePipelineState> ps_partition_count_              = nil;
     id<MTLComputePipelineState> ps_partition_scatter_            = nil;
     id<MTLComputePipelineState> ps_partition_aggregate_slotlock_ = nil;
+    id<MTLComputePipelineState> ps_seg_flags_ = nil;
+    id<MTLComputePipelineState> ps_seg_mark_ = nil;
+    id<MTLComputePipelineState> ps_seg_sum_ = nil;
     id<MTLBuffer> b_bucket_total_  = nil;
     id<MTLBuffer> b_bucket_offset_ = nil;
     id<MTLBuffer> b_minmax_partials_ = nil;
@@ -735,6 +743,8 @@ private:
     id<MTLBuffer> b_sl_out_count_          = nil;
     id<MTLBuffer> b_sl_out_keys_           = nil;
     id<MTLBuffer> b_sl_out_sums_           = nil;
+    id<MTLBuffer> b_seg_flags_           = nil;
+    id<MTLBuffer> b_seg_starts_            = nil;
     bool path_logged_ = false;
 };
 

--- a/src/backends/metal/metal_hashjoin.mm
+++ b/src/backends/metal/metal_hashjoin.mm
@@ -1,68 +1,81 @@
-// metal_hashjoin.mm — HASH JOIN on Metal.
+// metal_hashjoin.mm — Metal inner equi-join on int64 keys.
 //
-// STATUS: SCAFFOLD — currently delegates to the CPU implementation under
-// the hood (Backend::METAL with CPU work). This is the same pattern the
-// original Metal groupby used before being replaced with a real GPU kernel.
-// Numbers in BENCHMARK.md will therefore match the CPU baseline; a
-// follow-up branch (`feat/metal-hashjoin-real`) will replace this body with
-// a real GPU sort-merge join when the CUDA hash-join lands on main.
+// Primary path: auto-selected per join size.
+//   build ≤ 500k: global slot-lock in one command buffer (lowest sync overhead).
+//   build > 500k: partitioned scatter + per-partition TG hash (full radix join).
+//   Build scatter is cached when the same build_keys pointer is probed again.
 //
-// =========================================================================
-// PLANNED ALGORITHM: SORT-MERGE JOIN
-// =========================================================================
-//
-// Why not a direct port of CUDA's open-addressing hash join?
-//   The CUDA path uses an open-addressing hash table whose insertion needs
-//   64-bit atomic compare-and-swap. Apple Silicon GPUs (Apple7+/M-series)
-//   ship 64-bit atomic_fetch_add/sub/min/max under the int64Atomics feature
-//   set, but NOT 64-bit atomic_compare_exchange. The MSL compiler rejects
-//   `atomic_compare_exchange_weak_explicit(device atomic_ulong*, ...)`.
-//   This is the same constraint already documented in metal_groupby.mm.
-//
-// Apple-native shape: SORT-MERGE JOIN.
-//   1) Radix-sort the build-side keys, producing
-//        sorted_build_keys[0..n_build) and a parallel
-//        sorted_build_indices[0..n_build) that maps a sorted slot back to
-//        the original build-side row index.
-//   2) Radix-sort the probe-side keys the same way (we keep a parallel
-//        sorted_probe_indices[0..n_probe) mapping sorted slot → original
-//        probe-side row index, so we can emit the right probe row index).
-//   3) Merge: for each sorted_probe_keys[i], binary-search into
-//        sorted_build_keys for the FIRST match. If found, emit the pair
-//        (sorted_probe_indices[i], sorted_build_indices[match]).
-//        Binary search per probe is O(log n_build); the search itself
-//        parallelizes trivially across probe rows (one threadgroup per
-//        chunk of probes). For very high probe counts a "merge path"
-//        partition can balance work, but binary-search-per-probe is the
-//        simplest first cut.
-//
-// REUSE: the radix-sort kernels we already have for GROUP BY in
-// `src/backends/metal/kernels/groupby.metal` can be reused with one small
-// adapter — today they sort (key, value) pairs, but the join needs to sort
-// (key, original_index). That's the same "sort an array of N pairs of int64"
-// shape — only the second column's interpretation changes. A single helper
-// like `radix_sort_pairs_i64(keys, payload, n)` would serve both. We will
-// extract this when we replace the body of inner_join_i64 below.
-//
-// Output ordering note: the merge phase will produce matched pairs in
-// SORTED-BY-KEY order, not in original probe order. That's fine for the
-// JoinResult contract (callers needing original probe order can sort by
-// probe_indices client-side; the bench's `result_equals` already
-// canonicalizes via std::sort).
+// Override with GPUDB_METAL_HASHJOIN_PATH:
+//   partition — partitioned scatter + per-partition TG hash join (large builds)
+//   partition_scan — partitioned scatter + linear scan probe (debug/fallback)
+//   global    — force single global slot-lock table
+//   merge     — radix-sort build + binary-search probe
 
 #include "gpu_backend.hpp"
+#include "metal_radix_sort.hpp"
+#include "metal_kernel_sources.hpp"
 
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 
+#include <algorithm>
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
 #include <cstdint>
+#include <cstring>
+#include <limits>
 #include <sstream>
-#include <unordered_map>
+#include <stdexcept>
+#include <vector>
 
 namespace gpudb {
 
 namespace {
+
+constexpr NSUInteger kBlock = 256;
+constexpr std::int64_t kEmptySentinel = static_cast<std::int64_t>(0x8000000000000000ULL);
+constexpr std::uint32_t kMinCap = 1u << 10;
+constexpr std::uint32_t kMaxCap = 1u << 28;
+
+// Match groupby.metal slot-lock partition constants.
+constexpr std::uint32_t kNumPartitions = 32768;
+constexpr std::uint32_t kCountThreads = 256;
+constexpr std::uint32_t kCountWork = 256;
+
+[[noreturn]] void metal_throw(const char* what, NSError* err) {
+    std::ostringstream os;
+    os << "Metal hashjoin " << what;
+    if (err) os << ": " << [[err localizedDescription] UTF8String];
+    throw std::runtime_error(os.str());
+}
+
+std::uint32_t next_pow2(std::uint64_t v) {
+    if (v < 2) return 2;
+    --v;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v |= v >> 32;
+    return static_cast<std::uint32_t>(v + 1);
+}
+
+std::uint32_t pick_table_capacity(std::size_t n_build) {
+    std::uint64_t target = static_cast<std::uint64_t>(n_build) * 2;
+    std::uint32_t cap = next_pow2(target);
+    if (cap < kMinCap) cap = kMinCap;
+    if (cap > kMaxCap) cap = kMaxCap;
+    return cap;
+}
+
+void ensure_buffer(id<MTLDevice> device, id<MTLBuffer>& buf, std::size_t& cap_bytes,
+                   std::size_t need_bytes) {
+    if (need_bytes <= cap_bytes) return;
+    buf = [device newBufferWithLength:need_bytes options:MTLResourceStorageModeShared];
+    cap_bytes = need_bytes;
+}
 
 class MetalHashJoinProbe final : public HashJoinProbe {
 public:
@@ -70,6 +83,31 @@ public:
         @autoreleasepool {
             device_ = MTLCreateSystemDefaultDevice();
             if (!device_) throw std::runtime_error("MTLCreateSystemDefaultDevice returned nil");
+            queue_ = [device_ newCommandQueue];
+            if (!queue_) throw std::runtime_error("Failed to create Metal command queue");
+
+            NSError* err = nil;
+            NSString* src = [NSString stringWithUTF8String:metal::kGroupByKernelSource];
+            MTLCompileOptions* opts = [MTLCompileOptions new];
+            if (@available(macOS 15.0, *)) {
+                [opts setLanguageVersion:MTLLanguageVersion3_2];
+            } else {
+                [opts setLanguageVersion:MTLLanguageVersion3_1];
+            }
+            id<MTLLibrary> lib = [device_ newLibraryWithSource:src options:opts error:&err];
+            if (!lib) metal_throw("compile groupby.metal", err);
+
+            ps_merge_ = make_pso(device_, lib, @"hashjoin_merge_sorted_i64");
+            ps_init_ = make_pso(device_, lib, @"hashjoin_init_table");
+            ps_build_ = make_pso(device_, lib, @"hashjoin_build_slotlock_i64");
+            ps_probe_global_ = make_pso(device_, lib, @"hashjoin_probe_slotlock_i64");
+            ps_partition_count_ = make_pso(device_, lib, @"partition_count_hash");
+            ps_partition_scatter_ = make_pso(device_, lib, @"partition_scatter_hash");
+            ps_probe_partition_ = make_pso(device_, lib, @"hashjoin_probe_partition_i64");
+            ps_partition_hashjoin_ = make_pso(device_, lib, @"partition_hashjoin_i64");
+            ps_fill_iota_ = make_pso(device_, lib, @"hashjoin_fill_iota_i64");
+
+            radix_ = std::make_unique<metal_detail::MetalRadixSort>(device_, queue_);
         }
     }
 
@@ -78,49 +116,512 @@ public:
     std::string device_name() const override {
         @autoreleasepool {
             std::ostringstream os;
-            os << [[device_ name] UTF8String]
-               << " (Metal — HASH JOIN scaffold; CPU fallback until sort-merge kernel lands)";
+            os << [[device_ name] UTF8String] << " (Metal hash join)";
             return os.str();
         }
     }
 
     JoinResult inner_join_i64(const std::int64_t* build_keys, std::size_t n_build,
                               const std::int64_t* probe_keys, std::size_t n_probe) override {
-        // Scaffold body: identical to cpu_hashjoin's reference. Kept here
-        // (rather than calling make_cpu_hashjoin_probe()) so the Metal TU
-        // builds cleanly without needing a header for the CPU factory and
-        // so the swap-to-real-GPU diff is local to THIS file.
         const auto t0 = std::chrono::steady_clock::now();
 
         JoinResult r;
         r.rows_build = n_build;
         r.rows_probe = n_probe;
-
-        std::unordered_map<std::int64_t, std::int64_t> table;
-        table.reserve(n_build);
-        for (std::size_t j = 0; j < n_build; ++j) {
-            table.emplace(build_keys[j], static_cast<std::int64_t>(j));
+        if (n_build == 0 || n_probe == 0) {
+            r.wall_ms = std::chrono::duration<double, std::milli>(
+                            std::chrono::steady_clock::now() - t0)
+                            .count();
+            return r;
+        }
+        if (n_build > std::numeric_limits<std::uint32_t>::max() ||
+            n_probe > std::numeric_limits<std::uint32_t>::max()) {
+            throw std::runtime_error("hash join: row count exceeds uint32 limit");
         }
 
-        r.probe_indices.reserve(n_probe);
-        r.build_indices.reserve(n_probe);
-        for (std::size_t i = 0; i < n_probe; ++i) {
-            auto it = table.find(probe_keys[i]);
-            if (it == table.end()) continue;
-            r.probe_indices.push_back(static_cast<std::int64_t>(i));
-            r.build_indices.push_back(it->second);
+        for (std::size_t i = 0; i < n_build; ++i) {
+            if (build_keys[i] == kEmptySentinel) {
+                throw std::runtime_error(
+                    "build key INT64_MIN clashes with empty sentinel; not yet supported");
+            }
         }
-        r.matched = r.probe_indices.size();
 
-        r.kernel_ms   = 0.0;   // no GPU work (yet)
-        r.transfer_ms = 0.0;   // UMA, and we never touched GPU memory
-        r.wall_ms     = std::chrono::duration<double, std::milli>(
-                            std::chrono::steady_clock::now() - t0).count();
+        const auto n_build32 = static_cast<std::uint32_t>(n_build);
+        const auto n_probe32 = static_cast<std::uint32_t>(n_probe);
+
+        const char* env = std::getenv("GPUDB_METAL_HASHJOIN_PATH");
+        enum class Path { Partition, PartitionScan, Global, Merge };
+        Path path;
+        if (env) {
+            path = Path::Partition;
+            if (std::strcmp(env, "global") == 0 || std::strcmp(env, "hash") == 0) path = Path::Global;
+            else if (std::strcmp(env, "merge") == 0) path = Path::Merge;
+            else if (std::strcmp(env, "partition_scan") == 0) path = Path::PartitionScan;
+            else if (std::strcmp(env, "partition") == 0) path = Path::Partition;
+        } else {
+            // Auto-select: global fused CB wins below ~500k build (one sync, no scatter).
+            // Partitioned scatter scales past that (no O(cap) table init, no global CAS).
+            const std::uint64_t need = static_cast<std::uint64_t>(n_build) * 2;
+            if (need > kMaxCap) {
+                path = Path::Merge;
+            } else if (n_build <= 500'000) {
+                path = Path::Global;
+            } else {
+                path = Path::Partition;
+            }
+        }
+
+        if (!path_logged_) {
+            const char* name = (path == Path::Partition)     ? "partitioned TG hash"
+                                : (path == Path::PartitionScan) ? "partitioned linear scan"
+                                : (path == Path::Global)        ? "global slot-lock"
+                                                                : "sort-merge";
+            std::fprintf(stderr, "[gpudb metal hashjoin] using %s path\n", name);
+            path_logged_ = true;
+        }
+
+        switch (path) {
+        case Path::Partition:
+            return join_hash_partitioned(build_keys, n_build32, probe_keys, n_probe32, t0, false);
+        case Path::PartitionScan:
+            return join_hash_partitioned(build_keys, n_build32, probe_keys, n_probe32, t0, true);
+        case Path::Global:
+            return join_hash_global(build_keys, n_build32, probe_keys, n_probe32,
+                                    pick_table_capacity(n_build), t0);
+        case Path::Merge:
+            return join_sort_merge(build_keys, n_build32, probe_keys, n_probe32, t0);
+        }
         return r;
     }
 
 private:
+    static id<MTLComputePipelineState> make_pso(id<MTLDevice> device, id<MTLLibrary> lib,
+                                                 NSString* name) {
+        NSError* err = nil;
+        id<MTLFunction> fn = [lib newFunctionWithName:name];
+        if (!fn) {
+            std::ostringstream os;
+            os << "no function " << [name UTF8String];
+            throw std::runtime_error(os.str());
+        }
+        id<MTLComputePipelineState> ps = [device newComputePipelineStateWithFunction:fn error:&err];
+        if (!ps) metal_throw("newComputePipelineState", err);
+        return ps;
+    }
+
+    static void host_exclusive_scan(const id<MTLBuffer>& counts_buf, id<MTLBuffer>& offsets_buf,
+                                    std::size_t& cap_offsets_bytes, id<MTLDevice> device,
+                                    std::uint32_t n_partitions, std::uint32_t expected_total) {
+        const std::size_t bytes_partition = n_partitions * sizeof(std::uint32_t);
+        const std::size_t bytes_offsets = (n_partitions + 1) * sizeof(std::uint32_t);
+        ensure_buffer(device, offsets_buf, cap_offsets_bytes, bytes_offsets);
+        const std::uint32_t* counts =
+            static_cast<const std::uint32_t*>([counts_buf contents]);
+        std::uint32_t* offsets = static_cast<std::uint32_t*>([offsets_buf contents]);
+        std::uint32_t running = 0;
+        for (std::uint32_t p = 0; p < n_partitions; ++p) {
+            offsets[p] = running;
+            running += counts[p];
+        }
+        offsets[n_partitions] = running;
+        if (expected_total != 0 && running != expected_total) {
+            throw std::runtime_error("hashjoin partition count mismatch");
+        }
+        (void)bytes_partition;
+    }
+
+    JoinResult join_hash_partitioned(const std::int64_t* build_keys, std::uint32_t n_build,
+                                     const std::int64_t* probe_keys, std::uint32_t n_probe,
+                                     std::chrono::steady_clock::time_point t0, bool linear_scan) {
+        JoinResult r;
+        r.rows_build = n_build;
+        r.rows_probe = n_probe;
+
+        constexpr std::uint32_t kTgThreads = 64;
+
+        const std::size_t bytes_build = static_cast<std::size_t>(n_build) * sizeof(std::int64_t);
+        const std::size_t bytes_probe = static_cast<std::size_t>(n_probe) * sizeof(std::int64_t);
+        const std::size_t bytes_partition = kNumPartitions * sizeof(std::uint32_t);
+
+        const bool build_cache_hit =
+            build_scatter_valid_ && cached_build_keys_ == build_keys && cached_n_build_ == n_build;
+
+        @autoreleasepool {
+            ensure_buffer(device_, b_build_keys_, cap_build_bytes_, bytes_build);
+            ensure_buffer(device_, b_build_idx_, cap_build_idx_bytes_, bytes_build);
+            ensure_buffer(device_, b_probe_keys_, cap_probe_bytes_, bytes_probe);
+            ensure_buffer(device_, b_probe_idx_, cap_probe_idx_bytes_, bytes_probe);
+            ensure_buffer(device_, b_scatter_build_keys_, cap_scatter_build_keys_bytes_, bytes_build);
+            ensure_buffer(device_, b_scatter_build_idx_, cap_scatter_build_idx_bytes_, bytes_build);
+            ensure_buffer(device_, b_scatter_probe_keys_, cap_scatter_probe_keys_bytes_, bytes_probe);
+            ensure_buffer(device_, b_scatter_probe_idx_, cap_scatter_probe_idx_bytes_, bytes_probe);
+            ensure_buffer(device_, b_partition_counts_, cap_partition_counts_bytes_, bytes_partition);
+            ensure_buffer(device_, b_partition_writepos_, cap_partition_writepos_bytes_, bytes_partition);
+            ensure_buffer(device_, b_out_probe_, cap_out_probe_bytes_, bytes_probe);
+            ensure_buffer(device_, b_out_build_, cap_out_build_bytes_, bytes_probe);
+            if (!b_out_count_ || [b_out_count_ length] < sizeof(std::uint32_t)) {
+                b_out_count_ = [device_ newBufferWithLength:sizeof(std::uint32_t)
+                                                    options:MTLResourceStorageModeShared];
+            }
+
+            std::memcpy([b_probe_keys_ contents], probe_keys, bytes_probe);
+            std::memset([b_out_count_ contents], 0, sizeof(std::uint32_t));
+
+            const std::uint32_t blocks_build = (n_build + kCountWork - 1) / kCountWork;
+            const std::uint32_t blocks_probe = (n_probe + kCountWork - 1) / kCountWork;
+
+            double kernel_ms = 0.0;
+
+            if (!build_cache_hit) {
+                std::memcpy([b_build_keys_ contents], build_keys, bytes_build);
+                std::memset([b_partition_counts_ contents], 0, bytes_partition);
+
+                id<MTLCommandBuffer> cb_build01 = [queue_ commandBuffer];
+                id<MTLComputeCommandEncoder> ce_build01 = [cb_build01 computeCommandEncoder];
+                [ce_build01 setComputePipelineState:ps_fill_iota_];
+                [ce_build01 setBuffer:b_build_idx_ offset:0 atIndex:0];
+                [ce_build01 setBytes:&n_build length:sizeof(n_build) atIndex:1];
+                [ce_build01 dispatchThreadgroups:MTLSizeMake(blocks_build, 1, 1)
+                   threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+
+                [ce_build01 setComputePipelineState:ps_partition_count_];
+                [ce_build01 setBuffer:b_build_keys_ offset:0 atIndex:0];
+                [ce_build01 setBytes:&n_build length:sizeof(n_build) atIndex:1];
+                [ce_build01 setBuffer:b_partition_counts_ offset:0 atIndex:2];
+                [ce_build01 dispatchThreadgroups:MTLSizeMake(blocks_build, 1, 1)
+                   threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+                [ce_build01 endEncoding];
+                [cb_build01 commit];
+                [cb_build01 waitUntilCompleted];
+                kernel_ms += ([cb_build01 GPUEndTime] - [cb_build01 GPUStartTime]) * 1000.0;
+
+                host_exclusive_scan(b_partition_counts_, b_build_partition_offsets_,
+                                    cap_build_partition_offsets_bytes_, device_, kNumPartitions,
+                                    n_build);
+
+                std::memset([b_partition_writepos_ contents], 0, bytes_partition);
+
+                id<MTLCommandBuffer> cb_build2 = [queue_ commandBuffer];
+                id<MTLComputeCommandEncoder> ce_build2 = [cb_build2 computeCommandEncoder];
+                [ce_build2 setComputePipelineState:ps_partition_scatter_];
+                [ce_build2 setBuffer:b_build_keys_ offset:0 atIndex:0];
+                [ce_build2 setBuffer:b_build_idx_ offset:0 atIndex:1];
+                [ce_build2 setBytes:&n_build length:sizeof(n_build) atIndex:2];
+                [ce_build2 setBuffer:b_build_partition_offsets_ offset:0 atIndex:3];
+                [ce_build2 setBuffer:b_partition_writepos_ offset:0 atIndex:4];
+                [ce_build2 setBuffer:b_scatter_build_keys_ offset:0 atIndex:5];
+                [ce_build2 setBuffer:b_scatter_build_idx_ offset:0 atIndex:6];
+                [ce_build2 dispatchThreadgroups:MTLSizeMake(blocks_build, 1, 1)
+                   threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+                [ce_build2 endEncoding];
+                [cb_build2 commit];
+                [cb_build2 waitUntilCompleted];
+                kernel_ms += ([cb_build2 GPUEndTime] - [cb_build2 GPUStartTime]) * 1000.0;
+
+                cached_build_keys_ = build_keys;
+                cached_n_build_ = n_build;
+                build_scatter_valid_ = true;
+            }
+
+            std::memset([b_partition_counts_ contents], 0, bytes_partition);
+
+            id<MTLCommandBuffer> cb_probe01 = [queue_ commandBuffer];
+            id<MTLComputeCommandEncoder> ce_probe01 = [cb_probe01 computeCommandEncoder];
+            [ce_probe01 setComputePipelineState:ps_fill_iota_];
+            [ce_probe01 setBuffer:b_probe_idx_ offset:0 atIndex:0];
+            [ce_probe01 setBytes:&n_probe length:sizeof(n_probe) atIndex:1];
+            [ce_probe01 dispatchThreadgroups:MTLSizeMake(blocks_probe, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+
+            [ce_probe01 setComputePipelineState:ps_partition_count_];
+            [ce_probe01 setBuffer:b_probe_keys_ offset:0 atIndex:0];
+            [ce_probe01 setBytes:&n_probe length:sizeof(n_probe) atIndex:1];
+            [ce_probe01 setBuffer:b_partition_counts_ offset:0 atIndex:2];
+            [ce_probe01 dispatchThreadgroups:MTLSizeMake(blocks_probe, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+            [ce_probe01 endEncoding];
+            [cb_probe01 commit];
+            [cb_probe01 waitUntilCompleted];
+            kernel_ms += ([cb_probe01 GPUEndTime] - [cb_probe01 GPUStartTime]) * 1000.0;
+
+            host_exclusive_scan(b_partition_counts_, b_probe_partition_offsets_,
+                                cap_probe_partition_offsets_bytes_, device_, kNumPartitions,
+                                n_probe);
+
+            std::memset([b_partition_writepos_ contents], 0, bytes_partition);
+
+            id<MTLCommandBuffer> cb_final = [queue_ commandBuffer];
+            id<MTLComputeCommandEncoder> ce_final = [cb_final computeCommandEncoder];
+
+            [ce_final setComputePipelineState:ps_partition_scatter_];
+            [ce_final setBuffer:b_probe_keys_ offset:0 atIndex:0];
+            [ce_final setBuffer:b_probe_idx_ offset:0 atIndex:1];
+            [ce_final setBytes:&n_probe length:sizeof(n_probe) atIndex:2];
+            [ce_final setBuffer:b_probe_partition_offsets_ offset:0 atIndex:3];
+            [ce_final setBuffer:b_partition_writepos_ offset:0 atIndex:4];
+            [ce_final setBuffer:b_scatter_probe_keys_ offset:0 atIndex:5];
+            [ce_final setBuffer:b_scatter_probe_idx_ offset:0 atIndex:6];
+            [ce_final dispatchThreadgroups:MTLSizeMake(blocks_probe, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+
+            if (linear_scan) {
+                [ce_final setComputePipelineState:ps_probe_partition_];
+                [ce_final setBuffer:b_probe_keys_ offset:0 atIndex:0];
+                [ce_final setBytes:&n_probe length:sizeof(n_probe) atIndex:1];
+                [ce_final setBuffer:b_scatter_build_keys_ offset:0 atIndex:2];
+                [ce_final setBuffer:b_scatter_build_idx_ offset:0 atIndex:3];
+                [ce_final setBuffer:b_build_partition_offsets_ offset:0 atIndex:4];
+                [ce_final setBuffer:b_out_probe_ offset:0 atIndex:5];
+                [ce_final setBuffer:b_out_build_ offset:0 atIndex:6];
+                [ce_final setBuffer:b_out_count_ offset:0 atIndex:7];
+                [ce_final dispatchThreadgroups:MTLSizeMake(blocks_probe, 1, 1)
+                   threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+            } else {
+                [ce_final setComputePipelineState:ps_partition_hashjoin_];
+                [ce_final setBuffer:b_scatter_build_keys_ offset:0 atIndex:0];
+                [ce_final setBuffer:b_scatter_build_idx_ offset:0 atIndex:1];
+                [ce_final setBuffer:b_build_partition_offsets_ offset:0 atIndex:2];
+                [ce_final setBuffer:b_scatter_probe_keys_ offset:0 atIndex:3];
+                [ce_final setBuffer:b_scatter_probe_idx_ offset:0 atIndex:4];
+                [ce_final setBuffer:b_probe_partition_offsets_ offset:0 atIndex:5];
+                [ce_final setBuffer:b_out_count_ offset:0 atIndex:6];
+                [ce_final setBuffer:b_out_probe_ offset:0 atIndex:7];
+                [ce_final setBuffer:b_out_build_ offset:0 atIndex:8];
+                [ce_final dispatchThreadgroups:MTLSizeMake(kNumPartitions, 1, 1)
+                   threadsPerThreadgroup:MTLSizeMake(kTgThreads, 1, 1)];
+            }
+
+            [ce_final endEncoding];
+            [cb_final commit];
+            [cb_final waitUntilCompleted];
+            kernel_ms += ([cb_final GPUEndTime] - [cb_final GPUStartTime]) * 1000.0;
+
+            const std::uint32_t matched = *static_cast<const std::uint32_t*>([b_out_count_ contents]);
+            r.matched = matched;
+            r.probe_indices.resize(matched);
+            r.build_indices.resize(matched);
+            if (matched > 0) {
+                std::memcpy(r.probe_indices.data(), [b_out_probe_ contents], matched * sizeof(std::int64_t));
+                std::memcpy(r.build_indices.data(), [b_out_build_ contents], matched * sizeof(std::int64_t));
+            }
+            r.kernel_ms = kernel_ms;
+        }
+
+        r.transfer_ms = 0.0;
+        r.wall_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+        return r;
+    }
+
+    JoinResult join_hash_global(const std::int64_t* build_keys, std::uint32_t n_build,
+                                const std::int64_t* probe_keys, std::uint32_t n_probe,
+                                std::uint32_t table_cap,
+                                std::chrono::steady_clock::time_point t0) {
+        JoinResult r;
+        r.rows_build = n_build;
+        r.rows_probe = n_probe;
+
+        const std::size_t bytes_build = static_cast<std::size_t>(n_build) * sizeof(std::int64_t);
+        const std::size_t bytes_probe = static_cast<std::size_t>(n_probe) * sizeof(std::int64_t);
+        const std::size_t bytes_table = static_cast<std::size_t>(table_cap) * sizeof(std::int64_t);
+        const std::size_t bytes_state = static_cast<std::size_t>(table_cap) * sizeof(std::uint32_t);
+
+        @autoreleasepool {
+            ensure_buffer(device_, b_build_keys_, cap_build_bytes_, bytes_build);
+            ensure_buffer(device_, b_probe_keys_, cap_probe_bytes_, bytes_probe);
+            ensure_buffer(device_, b_table_state_, cap_table_state_bytes_, bytes_state);
+            ensure_buffer(device_, b_table_keys_, cap_table_keys_bytes_, bytes_table);
+            ensure_buffer(device_, b_table_idx_, cap_table_idx_bytes_, bytes_table);
+            ensure_buffer(device_, b_out_probe_, cap_out_probe_bytes_, bytes_probe);
+            ensure_buffer(device_, b_out_build_, cap_out_build_bytes_, bytes_probe);
+            if (!b_out_count_ || [b_out_count_ length] < sizeof(std::uint32_t)) {
+                b_out_count_ = [device_ newBufferWithLength:sizeof(std::uint32_t)
+                                                    options:MTLResourceStorageModeShared];
+            }
+
+            std::memcpy([b_build_keys_ contents], build_keys, bytes_build);
+            std::memcpy([b_probe_keys_ contents], probe_keys, bytes_probe);
+            std::memset([b_out_count_ contents], 0, sizeof(std::uint32_t));
+
+            id<MTLCommandBuffer> cb = [queue_ commandBuffer];
+            id<MTLComputeCommandEncoder> ce = [cb computeCommandEncoder];
+
+            const NSUInteger init_tg = (table_cap + kBlock - 1) / kBlock;
+            [ce setComputePipelineState:ps_init_];
+            [ce setBuffer:b_table_state_ offset:0 atIndex:0];
+            [ce setBuffer:b_table_keys_ offset:0 atIndex:1];
+            [ce setBytes:&table_cap length:sizeof(table_cap) atIndex:2];
+            [ce dispatchThreadgroups:MTLSizeMake(init_tg, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
+            const NSUInteger build_tg = std::min<NSUInteger>((n_build + kBlock - 1) / kBlock, 4096);
+            [ce setComputePipelineState:ps_build_];
+            [ce setBuffer:b_build_keys_ offset:0 atIndex:0];
+            [ce setBytes:&n_build length:sizeof(n_build) atIndex:1];
+            [ce setBuffer:b_table_state_ offset:0 atIndex:2];
+            [ce setBuffer:b_table_keys_ offset:0 atIndex:3];
+            [ce setBuffer:b_table_idx_ offset:0 atIndex:4];
+            [ce setBytes:&table_cap length:sizeof(table_cap) atIndex:5];
+            [ce dispatchThreadgroups:MTLSizeMake(build_tg, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
+            const NSUInteger probe_tg = std::min<NSUInteger>((n_probe + kBlock - 1) / kBlock, 4096);
+            [ce setComputePipelineState:ps_probe_global_];
+            [ce setBuffer:b_probe_keys_ offset:0 atIndex:0];
+            [ce setBytes:&n_probe length:sizeof(n_probe) atIndex:1];
+            [ce setBuffer:b_table_state_ offset:0 atIndex:2];
+            [ce setBuffer:b_table_keys_ offset:0 atIndex:3];
+            [ce setBuffer:b_table_idx_ offset:0 atIndex:4];
+            [ce setBytes:&table_cap length:sizeof(table_cap) atIndex:5];
+            [ce setBuffer:b_out_probe_ offset:0 atIndex:6];
+            [ce setBuffer:b_out_build_ offset:0 atIndex:7];
+            [ce setBuffer:b_out_count_ offset:0 atIndex:8];
+            [ce dispatchThreadgroups:MTLSizeMake(probe_tg, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
+            [ce endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+
+            r.kernel_ms = ([cb GPUEndTime] - [cb GPUStartTime]) * 1000.0;
+
+            const std::uint32_t matched = *static_cast<const std::uint32_t*>([b_out_count_ contents]);
+            r.matched = matched;
+            r.probe_indices.resize(matched);
+            r.build_indices.resize(matched);
+            if (matched > 0) {
+                std::memcpy(r.probe_indices.data(), [b_out_probe_ contents], matched * sizeof(std::int64_t));
+                std::memcpy(r.build_indices.data(), [b_out_build_ contents], matched * sizeof(std::int64_t));
+            }
+        }
+
+        r.transfer_ms = 0.0;
+        r.wall_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+        return r;
+    }
+
+    JoinResult join_sort_merge(const std::int64_t* build_keys, std::uint32_t n_build,
+                               const std::int64_t* probe_keys, std::uint32_t n_probe,
+                               std::chrono::steady_clock::time_point t0) {
+        JoinResult r;
+        r.rows_build = n_build;
+        r.rows_probe = n_probe;
+
+        std::vector<std::int64_t> build_idx(n_build);
+        for (std::uint32_t j = 0; j < n_build; ++j) build_idx[j] = static_cast<std::int64_t>(j);
+
+        std::vector<std::int64_t> probe_idx(n_probe);
+        for (std::uint32_t i = 0; i < n_probe; ++i) probe_idx[i] = static_cast<std::int64_t>(i);
+
+        double kernel_ms = 0.0;
+        const auto sorted =
+            radix_->sort_device(build_keys, build_idx.data(), n_build);
+        kernel_ms += sorted.kernel_ms;
+
+        const std::size_t bytes_probe = static_cast<std::size_t>(n_probe) * sizeof(std::int64_t);
+
+        @autoreleasepool {
+            ensure_buffer(device_, b_probe_keys_, cap_probe_bytes_, bytes_probe);
+            ensure_buffer(device_, b_probe_idx_, cap_probe_idx_bytes_, bytes_probe);
+            ensure_buffer(device_, b_out_probe_, cap_out_probe_bytes_, bytes_probe);
+            ensure_buffer(device_, b_out_build_, cap_out_build_bytes_, bytes_probe);
+            if (!b_out_count_ || [b_out_count_ length] < sizeof(std::uint32_t)) {
+                b_out_count_ = [device_ newBufferWithLength:sizeof(std::uint32_t)
+                                                    options:MTLResourceStorageModeShared];
+            }
+
+            std::memcpy([b_probe_keys_ contents], probe_keys, bytes_probe);
+            std::memcpy([b_probe_idx_ contents], probe_idx.data(), bytes_probe);
+            std::memset([b_out_count_ contents], 0, sizeof(std::uint32_t));
+
+            id<MTLCommandBuffer> cb = [queue_ commandBuffer];
+            id<MTLComputeCommandEncoder> ce = [cb computeCommandEncoder];
+            [ce setComputePipelineState:ps_merge_];
+            [ce setBuffer:b_probe_keys_ offset:0 atIndex:0];
+            [ce setBuffer:b_probe_idx_ offset:0 atIndex:1];
+            [ce setBuffer:sorted.keys offset:0 atIndex:2];
+            [ce setBuffer:sorted.payloads offset:0 atIndex:3];
+            [ce setBytes:&n_probe length:sizeof(n_probe) atIndex:4];
+            [ce setBytes:&n_build length:sizeof(n_build) atIndex:5];
+            [ce setBuffer:b_out_probe_ offset:0 atIndex:6];
+            [ce setBuffer:b_out_build_ offset:0 atIndex:7];
+            [ce setBuffer:b_out_count_ offset:0 atIndex:8];
+
+            const NSUInteger tg = (n_probe + 255) / 256;
+            [ce dispatchThreadgroups:MTLSizeMake(tg, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+            [ce endEncoding];
+            [cb commit];
+            [cb waitUntilCompleted];
+
+            kernel_ms += ([cb GPUEndTime] - [cb GPUStartTime]) * 1000.0;
+
+            const std::uint32_t matched = *static_cast<const std::uint32_t*>([b_out_count_ contents]);
+            r.matched = matched;
+            r.probe_indices.resize(matched);
+            r.build_indices.resize(matched);
+            if (matched > 0) {
+                std::memcpy(r.probe_indices.data(), [b_out_probe_ contents], matched * sizeof(std::int64_t));
+                std::memcpy(r.build_indices.data(), [b_out_build_ contents], matched * sizeof(std::int64_t));
+            }
+        }
+
+        r.kernel_ms = kernel_ms;
+        r.transfer_ms = 0.0;
+        r.wall_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+        return r;
+    }
+
     id<MTLDevice> device_ = nil;
+    id<MTLCommandQueue> queue_ = nil;
+    id<MTLComputePipelineState> ps_merge_ = nil;
+    id<MTLComputePipelineState> ps_init_ = nil;
+    id<MTLComputePipelineState> ps_build_ = nil;
+    id<MTLComputePipelineState> ps_probe_global_ = nil;
+    id<MTLComputePipelineState> ps_partition_count_ = nil;
+    id<MTLComputePipelineState> ps_partition_scatter_ = nil;
+    id<MTLComputePipelineState> ps_probe_partition_ = nil;
+    id<MTLComputePipelineState> ps_partition_hashjoin_ = nil;
+    id<MTLComputePipelineState> ps_fill_iota_ = nil;
+    std::unique_ptr<metal_detail::MetalRadixSort> radix_;
+
+    id<MTLBuffer> b_build_keys_ = nil;
+    id<MTLBuffer> b_build_idx_ = nil;
+    id<MTLBuffer> b_probe_keys_ = nil;
+    id<MTLBuffer> b_probe_idx_ = nil;
+    id<MTLBuffer> b_scatter_build_keys_ = nil;
+    id<MTLBuffer> b_scatter_build_idx_ = nil;
+    id<MTLBuffer> b_scatter_probe_keys_ = nil;
+    id<MTLBuffer> b_scatter_probe_idx_ = nil;
+    id<MTLBuffer> b_partition_counts_ = nil;
+    id<MTLBuffer> b_build_partition_offsets_ = nil;
+    id<MTLBuffer> b_probe_partition_offsets_ = nil;
+    id<MTLBuffer> b_partition_writepos_ = nil;
+    id<MTLBuffer> b_table_state_ = nil;
+    id<MTLBuffer> b_table_keys_ = nil;
+    id<MTLBuffer> b_table_idx_ = nil;
+    id<MTLBuffer> b_out_probe_ = nil;
+    id<MTLBuffer> b_out_build_ = nil;
+    id<MTLBuffer> b_out_count_ = nil;
+    std::size_t cap_build_bytes_ = 0;
+    std::size_t cap_build_idx_bytes_ = 0;
+    std::size_t cap_probe_bytes_ = 0;
+    std::size_t cap_probe_idx_bytes_ = 0;
+    std::size_t cap_scatter_build_keys_bytes_ = 0;
+    std::size_t cap_scatter_build_idx_bytes_ = 0;
+    std::size_t cap_scatter_probe_keys_bytes_ = 0;
+    std::size_t cap_scatter_probe_idx_bytes_ = 0;
+    std::size_t cap_partition_counts_bytes_ = 0;
+    std::size_t cap_build_partition_offsets_bytes_ = 0;
+    std::size_t cap_probe_partition_offsets_bytes_ = 0;
+    std::size_t cap_partition_writepos_bytes_ = 0;
+    std::size_t cap_table_state_bytes_ = 0;
+    std::size_t cap_table_keys_bytes_ = 0;
+    std::size_t cap_table_idx_bytes_ = 0;
+    std::size_t cap_out_probe_bytes_ = 0;
+    std::size_t cap_out_build_bytes_ = 0;
+    bool path_logged_ = false;
+    const std::int64_t* cached_build_keys_ = nullptr;
+    std::uint32_t cached_n_build_ = 0;
+    bool build_scatter_valid_ = false;
 };
 
 } // namespace

--- a/src/backends/metal/metal_hashjoin.mm
+++ b/src/backends/metal/metal_hashjoin.mm
@@ -283,6 +283,9 @@ private:
                 [ce_build01 setBytes:&n_build length:sizeof(n_build) atIndex:1];
                 [ce_build01 dispatchThreadgroups:MTLSizeMake(blocks_build, 1, 1)
                    threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+                // Make this dispatch's buffer writes visible to the next dispatch in the
+                // same encoder (not guaranteed on every device without a barrier).
+                [ce_build01 memoryBarrierWithScope:MTLBarrierScopeBuffers];
 
                 [ce_build01 setComputePipelineState:ps_partition_count_];
                 [ce_build01 setBuffer:b_build_keys_ offset:0 atIndex:0];
@@ -290,6 +293,9 @@ private:
                 [ce_build01 setBuffer:b_partition_counts_ offset:0 atIndex:2];
                 [ce_build01 dispatchThreadgroups:MTLSizeMake(blocks_build, 1, 1)
                    threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+                // Make this dispatch's buffer writes visible to the next dispatch in the
+                // same encoder (not guaranteed on every device without a barrier).
+                [ce_build01 memoryBarrierWithScope:MTLBarrierScopeBuffers];
                 [ce_build01 endEncoding];
                 [cb_build01 commit];
                 [cb_build01 waitUntilCompleted];
@@ -313,6 +319,9 @@ private:
                 [ce_build2 setBuffer:b_scatter_build_idx_ offset:0 atIndex:6];
                 [ce_build2 dispatchThreadgroups:MTLSizeMake(blocks_build, 1, 1)
                    threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+                // Make this dispatch's buffer writes visible to the next dispatch in the
+                // same encoder (not guaranteed on every device without a barrier).
+                [ce_build2 memoryBarrierWithScope:MTLBarrierScopeBuffers];
                 [ce_build2 endEncoding];
                 [cb_build2 commit];
                 [cb_build2 waitUntilCompleted];
@@ -332,6 +341,9 @@ private:
             [ce_probe01 setBytes:&n_probe length:sizeof(n_probe) atIndex:1];
             [ce_probe01 dispatchThreadgroups:MTLSizeMake(blocks_probe, 1, 1)
                threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+            // Make this dispatch's buffer writes visible to the next dispatch in the
+            // same encoder (not guaranteed on every device without a barrier).
+            [ce_probe01 memoryBarrierWithScope:MTLBarrierScopeBuffers];
 
             [ce_probe01 setComputePipelineState:ps_partition_count_];
             [ce_probe01 setBuffer:b_probe_keys_ offset:0 atIndex:0];
@@ -339,6 +351,9 @@ private:
             [ce_probe01 setBuffer:b_partition_counts_ offset:0 atIndex:2];
             [ce_probe01 dispatchThreadgroups:MTLSizeMake(blocks_probe, 1, 1)
                threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+            // Make this dispatch's buffer writes visible to the next dispatch in the
+            // same encoder (not guaranteed on every device without a barrier).
+            [ce_probe01 memoryBarrierWithScope:MTLBarrierScopeBuffers];
             [ce_probe01 endEncoding];
             [cb_probe01 commit];
             [cb_probe01 waitUntilCompleted];
@@ -363,6 +378,9 @@ private:
             [ce_final setBuffer:b_scatter_probe_idx_ offset:0 atIndex:6];
             [ce_final dispatchThreadgroups:MTLSizeMake(blocks_probe, 1, 1)
                threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+            // Make this dispatch's buffer writes visible to the next dispatch in the
+            // same encoder (not guaranteed on every device without a barrier).
+            [ce_final memoryBarrierWithScope:MTLBarrierScopeBuffers];
 
             if (linear_scan) {
                 [ce_final setComputePipelineState:ps_probe_partition_];
@@ -376,6 +394,9 @@ private:
                 [ce_final setBuffer:b_out_count_ offset:0 atIndex:7];
                 [ce_final dispatchThreadgroups:MTLSizeMake(blocks_probe, 1, 1)
                    threadsPerThreadgroup:MTLSizeMake(kCountThreads, 1, 1)];
+                // Make this dispatch's buffer writes visible to the next dispatch in the
+                // same encoder (not guaranteed on every device without a barrier).
+                [ce_final memoryBarrierWithScope:MTLBarrierScopeBuffers];
             } else {
                 [ce_final setComputePipelineState:ps_partition_hashjoin_];
                 [ce_final setBuffer:b_scatter_build_keys_ offset:0 atIndex:0];
@@ -389,6 +410,9 @@ private:
                 [ce_final setBuffer:b_out_build_ offset:0 atIndex:8];
                 [ce_final dispatchThreadgroups:MTLSizeMake(kNumPartitions, 1, 1)
                    threadsPerThreadgroup:MTLSizeMake(kTgThreads, 1, 1)];
+                // Make this dispatch's buffer writes visible to the next dispatch in the
+                // same encoder (not guaranteed on every device without a barrier).
+                [ce_final memoryBarrierWithScope:MTLBarrierScopeBuffers];
             }
 
             [ce_final endEncoding];
@@ -452,6 +476,9 @@ private:
             [ce setBytes:&table_cap length:sizeof(table_cap) atIndex:2];
             [ce dispatchThreadgroups:MTLSizeMake(init_tg, 1, 1)
                threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+            // Make this dispatch's buffer writes visible to the next dispatch in the
+            // same encoder (not guaranteed on every device without a barrier).
+            [ce memoryBarrierWithScope:MTLBarrierScopeBuffers];
 
             const NSUInteger build_tg = std::min<NSUInteger>((n_build + kBlock - 1) / kBlock, 4096);
             [ce setComputePipelineState:ps_build_];
@@ -463,6 +490,9 @@ private:
             [ce setBytes:&table_cap length:sizeof(table_cap) atIndex:5];
             [ce dispatchThreadgroups:MTLSizeMake(build_tg, 1, 1)
                threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+            // Make this dispatch's buffer writes visible to the next dispatch in the
+            // same encoder (not guaranteed on every device without a barrier).
+            [ce memoryBarrierWithScope:MTLBarrierScopeBuffers];
 
             const NSUInteger probe_tg = std::min<NSUInteger>((n_probe + kBlock - 1) / kBlock, 4096);
             [ce setComputePipelineState:ps_probe_global_];
@@ -477,6 +507,9 @@ private:
             [ce setBuffer:b_out_count_ offset:0 atIndex:8];
             [ce dispatchThreadgroups:MTLSizeMake(probe_tg, 1, 1)
                threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+            // Make this dispatch's buffer writes visible to the next dispatch in the
+            // same encoder (not guaranteed on every device without a barrier).
+            [ce memoryBarrierWithScope:MTLBarrierScopeBuffers];
 
             [ce endEncoding];
             [cb commit];
@@ -548,6 +581,9 @@ private:
 
             const NSUInteger tg = (n_probe + 255) / 256;
             [ce dispatchThreadgroups:MTLSizeMake(tg, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+            // Make this dispatch's buffer writes visible to the next dispatch in the
+            // same encoder (not guaranteed on every device without a barrier).
+            [ce memoryBarrierWithScope:MTLBarrierScopeBuffers];
             [ce endEncoding];
             [cb commit];
             [cb waitUntilCompleted];

--- a/src/backends/metal/metal_radix_sort.hpp
+++ b/src/backends/metal/metal_radix_sort.hpp
@@ -1,0 +1,60 @@
+// metal_radix_sort.hpp — shared LSD radix sort for (int64 key, int64 payload) pairs.
+// Used by Metal hash-join (and available for future window/join operators).
+#pragma once
+
+#import <Metal/Metal.h>
+
+#include <cstdint>
+
+namespace gpudb::metal_detail {
+
+//! Stable LSD radix sort of int64 keys with int64 payloads (UMA buffers).
+class MetalRadixSort {
+public:
+    MetalRadixSort(id<MTLDevice> device, id<MTLCommandQueue> queue);
+
+    //! Sort n pairs. `keys_out` / `payloads_out` may alias `keys` / `payloads`.
+    //! Returns GPU kernel time in milliseconds (radix passes only).
+    double sort_host(const std::int64_t* keys, const std::int64_t* payloads, std::uint32_t n,
+                     std::int64_t* keys_out, std::int64_t* payloads_out);
+
+    //! Sort on GPU; sorted data stays in UMA buffers until the next sort call.
+    struct DeviceView {
+        id<MTLBuffer> keys = nil;
+        id<MTLBuffer> payloads = nil;
+        double kernel_ms = 0.0;
+    };
+    DeviceView sort_device(const std::int64_t* keys, const std::int64_t* payloads, std::uint32_t n);
+
+private:
+    double run_sort_on_staged(std::uint32_t n, id<MTLBuffer>& in_keys, id<MTLBuffer>& in_vals);
+
+    void ensure_sort_buffers(std::uint32_t n, std::uint32_t num_blocks);
+
+    void ensure_library();
+    id<MTLComputePipelineState> make_pso(NSString* name);
+
+    id<MTLDevice> device_ = nil;
+    id<MTLCommandQueue> queue_ = nil;
+    id<MTLLibrary> lib_ = nil;
+
+    id<MTLComputePipelineState> ps_radix_flip_ = nil;
+    id<MTLComputePipelineState> ps_radix_histogram_ = nil;
+    id<MTLComputePipelineState> ps_radix_scatter_ = nil;
+    id<MTLComputePipelineState> ps_radix_bucket_totals_ = nil;
+    id<MTLComputePipelineState> ps_radix_bucket_offsets_ = nil;
+    id<MTLComputePipelineState> ps_radix_per_bucket_scan_ = nil;
+    id<MTLComputePipelineState> ps_radix_minmax_ = nil;
+
+    id<MTLBuffer> b_keys_a_ = nil;
+    id<MTLBuffer> b_keys_b_ = nil;
+    id<MTLBuffer> b_vals_a_ = nil;
+    id<MTLBuffer> b_vals_b_ = nil;
+    id<MTLBuffer> b_hist_ = nil;
+    id<MTLBuffer> b_scan_ = nil;
+    id<MTLBuffer> b_bucket_total_ = nil;
+    id<MTLBuffer> b_bucket_offset_ = nil;
+    id<MTLBuffer> b_minmax_partials_ = nil;
+};
+
+} // namespace gpudb::metal_detail

--- a/src/backends/metal/metal_radix_sort.mm
+++ b/src/backends/metal/metal_radix_sort.mm
@@ -1,0 +1,269 @@
+// metal_radix_sort.mm — LSD radix sort for (int64, int64) pairs on Apple Silicon.
+
+#include "metal_radix_sort.hpp"
+#include "metal_kernel_sources.hpp"
+
+#import <Foundation/Foundation.h>
+
+#include <algorithm>
+#include <chrono>
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+namespace gpudb::metal_detail {
+
+namespace {
+
+constexpr NSUInteger kBlock = 256;
+
+[[noreturn]] void metal_throw(const char* what, NSError* err) {
+    std::ostringstream os;
+    os << "Metal radix " << what;
+    if (err) os << ": " << [[err localizedDescription] UTF8String];
+    throw std::runtime_error(os.str());
+}
+
+} // namespace
+
+MetalRadixSort::MetalRadixSort(id<MTLDevice> device, id<MTLCommandQueue> queue)
+    : device_(device), queue_(queue) {
+    ensure_library();
+}
+
+void MetalRadixSort::ensure_library() {
+    if (lib_) return;
+    @autoreleasepool {
+        NSError* err = nil;
+        NSString* src = [NSString stringWithUTF8String:metal::kGroupByKernelSource];
+        MTLCompileOptions* opts = [MTLCompileOptions new];
+        if (@available(macOS 15.0, *)) {
+            [opts setLanguageVersion:MTLLanguageVersion3_2];
+        } else {
+            [opts setLanguageVersion:MTLLanguageVersion3_1];
+        }
+        lib_ = [device_ newLibraryWithSource:src options:opts error:&err];
+        if (!lib_) metal_throw("compile groupby.metal", err);
+
+        ps_radix_flip_ = make_pso(@"radix_flip_sign_bit");
+        ps_radix_histogram_ = make_pso(@"radix_histogram");
+        ps_radix_scatter_ = make_pso(@"radix_scatter");
+        ps_radix_bucket_totals_ = make_pso(@"radix_bucket_totals");
+        ps_radix_bucket_offsets_ = make_pso(@"radix_bucket_offsets");
+        ps_radix_per_bucket_scan_ = make_pso(@"radix_per_bucket_scan");
+        ps_radix_minmax_ = make_pso(@"radix_minmax_i64");
+    }
+}
+
+id<MTLComputePipelineState> MetalRadixSort::make_pso(NSString* name) {
+    @autoreleasepool {
+        id<MTLFunction> fn = [lib_ newFunctionWithName:name];
+        if (!fn) {
+            std::ostringstream os;
+            os << "no function " << [name UTF8String];
+            throw std::runtime_error(os.str());
+        }
+        NSError* err = nil;
+        id<MTLComputePipelineState> pso = [device_ newComputePipelineStateWithFunction:fn error:&err];
+        if (!pso) metal_throw("newComputePipelineState", err);
+        return pso;
+    }
+}
+
+void MetalRadixSort::ensure_sort_buffers(std::uint32_t n, std::uint32_t num_blocks) {
+    constexpr std::uint32_t RADIX_BUCKETS = 256;
+    const std::size_t bytes_kv = static_cast<std::size_t>(n) * sizeof(std::int64_t);
+    const std::size_t bytes_hist =
+        static_cast<std::size_t>(num_blocks) * RADIX_BUCKETS * sizeof(std::uint32_t);
+    const std::size_t bytes_buckets = RADIX_BUCKETS * sizeof(std::uint32_t);
+
+    if (!b_keys_a_ || [b_keys_a_ length] < bytes_kv) {
+        b_keys_a_ = [device_ newBufferWithLength:bytes_kv options:MTLResourceStorageModeShared];
+        b_keys_b_ = [device_ newBufferWithLength:bytes_kv options:MTLResourceStorageModeShared];
+        b_vals_a_ = [device_ newBufferWithLength:bytes_kv options:MTLResourceStorageModeShared];
+        b_vals_b_ = [device_ newBufferWithLength:bytes_kv options:MTLResourceStorageModeShared];
+    }
+    if (!b_hist_ || [b_hist_ length] < bytes_hist) {
+        b_hist_ = [device_ newBufferWithLength:bytes_hist options:MTLResourceStorageModeShared];
+        b_scan_ = [device_ newBufferWithLength:bytes_hist options:MTLResourceStorageModeShared];
+    }
+    if (!b_bucket_total_ || [b_bucket_total_ length] < bytes_buckets) {
+        b_bucket_total_ = [device_ newBufferWithLength:bytes_buckets options:MTLResourceStorageModeShared];
+        b_bucket_offset_ = [device_ newBufferWithLength:bytes_buckets options:MTLResourceStorageModeShared];
+    }
+}
+
+double MetalRadixSort::run_sort_on_staged(std::uint32_t n, id<MTLBuffer>& in_keys,
+                                          id<MTLBuffer>& in_vals) {
+    constexpr std::uint32_t RADIX_BUCKETS = 256;
+    constexpr std::uint32_t RADIX_BLOCK_SIZE = 256;
+    constexpr std::uint32_t RADIX_WORK_PER_BLOCK = 1024;
+    const std::uint32_t num_blocks = (n + RADIX_WORK_PER_BLOCK - 1) / RADIX_WORK_PER_BLOCK;
+
+    id<MTLBuffer> out_keys = b_keys_b_;
+    id<MTLBuffer> out_vals = b_vals_b_;
+    if (in_keys != b_keys_a_) {
+        out_keys = b_keys_a_;
+        out_vals = b_vals_a_;
+    }
+
+    constexpr NSUInteger kMinMaxGrid = 256;
+    const std::size_t bytes_minmax = kMinMaxGrid * 4 * sizeof(std::int32_t);
+    if (!b_minmax_partials_ || [b_minmax_partials_ length] < bytes_minmax) {
+        b_minmax_partials_ = [device_ newBufferWithLength:bytes_minmax
+                                                  options:MTLResourceStorageModeShared];
+    }
+
+    std::uint8_t active_bytes = 0xFF;
+    {
+        id<MTLCommandBuffer> cb_mm = [queue_ commandBuffer];
+        id<MTLComputeCommandEncoder> ce_mm = [cb_mm computeCommandEncoder];
+        [ce_mm setComputePipelineState:ps_radix_minmax_];
+        [ce_mm setBuffer:in_keys offset:0 atIndex:0];
+        [ce_mm setBytes:&n length:sizeof(n) atIndex:1];
+        [ce_mm setBuffer:b_minmax_partials_ offset:0 atIndex:2];
+        [ce_mm setBuffer:b_minmax_partials_ offset:kMinMaxGrid * 2 * sizeof(std::int32_t) atIndex:3];
+        [ce_mm dispatchThreadgroups:MTLSizeMake(kMinMaxGrid, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        [ce_mm endEncoding];
+        [cb_mm commit];
+        [cb_mm waitUntilCompleted];
+
+        const std::int32_t* parts = static_cast<const std::int32_t*>([b_minmax_partials_ contents]);
+        std::int64_t mn = INT64_MAX, mx = INT64_MIN;
+        for (NSUInteger b = 0; b < kMinMaxGrid; ++b) {
+            const std::uint64_t mlo = static_cast<std::uint32_t>(parts[b * 2 + 0]);
+            const std::uint64_t mhi = static_cast<std::uint32_t>(parts[b * 2 + 1]);
+            const std::uint64_t Mlo = static_cast<std::uint32_t>(parts[(kMinMaxGrid + b) * 2 + 0]);
+            const std::uint64_t Mhi = static_cast<std::uint32_t>(parts[(kMinMaxGrid + b) * 2 + 1]);
+            std::int64_t bm, bM;
+            const std::uint64_t bmu = (mhi << 32) | mlo;
+            const std::uint64_t bMu = (Mhi << 32) | Mlo;
+            std::memcpy(&bm, &bmu, sizeof(std::int64_t));
+            std::memcpy(&bM, &bMu, sizeof(std::int64_t));
+            if (bm < mn) mn = bm;
+            if (bM > mx) mx = bM;
+        }
+        const std::uint64_t mn_u = static_cast<std::uint64_t>(mn) ^ 0x8000000000000000ULL;
+        const std::uint64_t mx_u = static_cast<std::uint64_t>(mx) ^ 0x8000000000000000ULL;
+        active_bytes = 0;
+        for (std::uint32_t p = 0; p < 8; ++p) {
+            const std::uint64_t shift = p * 8;
+            const std::uint8_t mn_b = static_cast<std::uint8_t>((mn_u >> shift) & 0xFFu);
+            const std::uint8_t mx_b = static_cast<std::uint8_t>((mx_u >> shift) & 0xFFu);
+            if (mn_b != mx_b) active_bytes |= (1u << p);
+        }
+        if (active_bytes == 0) active_bytes = 0x01;
+    }
+
+    id<MTLCommandBuffer> cb = [queue_ commandBuffer];
+    id<MTLComputeCommandEncoder> ce = [cb computeCommandEncoder];
+
+    [ce setComputePipelineState:ps_radix_flip_];
+    [ce setBuffer:in_keys offset:0 atIndex:0];
+    [ce setBytes:&n length:sizeof(n) atIndex:1];
+    [ce dispatchThreadgroups:MTLSizeMake((n + kBlock - 1) / kBlock, 1, 1)
+           threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
+    for (std::uint32_t pass = 0; pass < 8; ++pass) {
+        if (!(active_bytes & (1u << pass))) continue;
+        const std::uint32_t shift = pass * 8u;
+
+        [ce setComputePipelineState:ps_radix_histogram_];
+        [ce setBuffer:in_keys offset:0 atIndex:0];
+        [ce setBytes:&n length:sizeof(n) atIndex:1];
+        [ce setBytes:&shift length:sizeof(shift) atIndex:2];
+        [ce setBuffer:b_hist_ offset:0 atIndex:3];
+        [ce dispatchThreadgroups:MTLSizeMake(num_blocks, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(RADIX_BLOCK_SIZE, 1, 1)];
+
+        [ce setComputePipelineState:ps_radix_bucket_totals_];
+        [ce setBuffer:b_hist_ offset:0 atIndex:0];
+        [ce setBytes:&num_blocks length:sizeof(num_blocks) atIndex:1];
+        [ce setBuffer:b_bucket_total_ offset:0 atIndex:2];
+        [ce dispatchThreadgroups:MTLSizeMake(RADIX_BUCKETS, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(RADIX_BLOCK_SIZE, 1, 1)];
+
+        [ce setComputePipelineState:ps_radix_bucket_offsets_];
+        [ce setBuffer:b_bucket_total_ offset:0 atIndex:0];
+        [ce setBuffer:b_bucket_offset_ offset:0 atIndex:1];
+        [ce dispatchThreadgroups:MTLSizeMake(1, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(RADIX_BLOCK_SIZE, 1, 1)];
+
+        [ce setComputePipelineState:ps_radix_per_bucket_scan_];
+        [ce setBuffer:b_hist_ offset:0 atIndex:0];
+        [ce setBytes:&num_blocks length:sizeof(num_blocks) atIndex:1];
+        [ce setBuffer:b_bucket_offset_ offset:0 atIndex:2];
+        [ce setBuffer:b_scan_ offset:0 atIndex:3];
+        [ce dispatchThreadgroups:MTLSizeMake(RADIX_BUCKETS, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(RADIX_BLOCK_SIZE, 1, 1)];
+
+        [ce setComputePipelineState:ps_radix_scatter_];
+        [ce setBuffer:in_keys offset:0 atIndex:0];
+        [ce setBuffer:in_vals offset:0 atIndex:1];
+        [ce setBytes:&n length:sizeof(n) atIndex:2];
+        [ce setBytes:&shift length:sizeof(shift) atIndex:3];
+        [ce setBuffer:b_scan_ offset:0 atIndex:4];
+        [ce setBuffer:out_keys offset:0 atIndex:5];
+        [ce setBuffer:out_vals offset:0 atIndex:6];
+        [ce dispatchThreadgroups:MTLSizeMake(num_blocks, 1, 1)
+               threadsPerThreadgroup:MTLSizeMake(RADIX_BLOCK_SIZE, 1, 1)];
+
+        std::swap(in_keys, out_keys);
+        std::swap(in_vals, out_vals);
+    }
+
+    [ce setComputePipelineState:ps_radix_flip_];
+    [ce setBuffer:in_keys offset:0 atIndex:0];
+    [ce setBytes:&n length:sizeof(n) atIndex:1];
+    [ce dispatchThreadgroups:MTLSizeMake((n + kBlock - 1) / kBlock, 1, 1)
+           threadsPerThreadgroup:MTLSizeMake(kBlock, 1, 1)];
+
+    [ce endEncoding];
+    [cb commit];
+    [cb waitUntilCompleted];
+
+    return ([cb GPUEndTime] - [cb GPUStartTime]) * 1000.0;
+}
+
+MetalRadixSort::DeviceView MetalRadixSort::sort_device(const std::int64_t* keys,
+                                                       const std::int64_t* payloads,
+                                                       std::uint32_t n) {
+    DeviceView view;
+    if (n == 0) return view;
+    if (n > std::numeric_limits<std::uint32_t>::max()) {
+        throw std::runtime_error("radix sort: n too large for uint32 indexing");
+    }
+
+    constexpr std::uint32_t RADIX_WORK_PER_BLOCK = 1024;
+    const std::uint32_t num_blocks = (n + RADIX_WORK_PER_BLOCK - 1) / RADIX_WORK_PER_BLOCK;
+    const std::size_t bytes_kv = static_cast<std::size_t>(n) * sizeof(std::int64_t);
+
+    @autoreleasepool {
+        ensure_sort_buffers(n, num_blocks);
+        std::memcpy([b_keys_a_ contents], keys, bytes_kv);
+        std::memcpy([b_vals_a_ contents], payloads, bytes_kv);
+
+        id<MTLBuffer> in_keys = b_keys_a_;
+        id<MTLBuffer> in_vals = b_vals_a_;
+        view.kernel_ms = run_sort_on_staged(n, in_keys, in_vals);
+        view.keys = in_keys;
+        view.payloads = in_vals;
+    }
+    return view;
+}
+
+double MetalRadixSort::sort_host(const std::int64_t* keys, const std::int64_t* payloads, std::uint32_t n,
+                                 std::int64_t* keys_out, std::int64_t* payloads_out) {
+    if (n == 0) return 0.0;
+    const auto view = sort_device(keys, payloads, n);
+    const std::size_t bytes_kv = static_cast<std::size_t>(n) * sizeof(std::int64_t);
+    std::memcpy(keys_out, [view.keys contents], bytes_kv);
+    std::memcpy(payloads_out, [view.payloads contents], bytes_kv);
+    return view.kernel_ms;
+}
+
+} // namespace gpudb::metal_detail

--- a/src/extension/CMakeLists.txt
+++ b/src/extension/CMakeLists.txt
@@ -29,7 +29,8 @@ endif()
 add_library(gpudb_duckdb SHARED
     duckdb_loadable.cpp
     gpu_sum_extension.cpp
-    gpu_resident.cpp)
+    gpu_resident.cpp
+    gpu_join_extension.cpp)
 
 target_include_directories(gpudb_duckdb PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/extension/CMakeLists.txt
+++ b/src/extension/CMakeLists.txt
@@ -132,7 +132,7 @@ set(DUCKDB_LIBS_DIR "${CMAKE_SOURCE_DIR}/third_party/duckdb-libs")
 
 if(EXISTS "${DUCKDB_LIBS_DIR}/duckdb.h")
     # Compiled WITHOUT GPUDB_C_STRUCT_ABI: uses real duckdb.h + real libduckdb.
-    add_library(gpudb_ext STATIC gpu_sum_extension.cpp gpu_resident.cpp)
+    add_library(gpudb_ext STATIC gpu_sum_extension.cpp gpu_resident.cpp gpu_join_extension.cpp)
     target_include_directories(gpudb_ext PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${DUCKDB_LIBS_DIR})

--- a/src/extension/duckdb_loadable.cpp
+++ b/src/extension/duckdb_loadable.cpp
@@ -21,6 +21,7 @@
 #include "duckdb_extension.h"
 
 #include "gpu_sum_extension.hpp"
+#include "gpu_join_extension.hpp"
 
 #include <exception>
 
@@ -28,8 +29,9 @@ DUCKDB_EXTENSION_ENTRYPOINT(duckdb_connection connection,
                             duckdb_extension_info info,
                             struct duckdb_extension_access *access) {
     try {
-        // Registers gpu_sum / gpu_min / gpu_max on the auto-opened connection.
+        // Registers gpu_sum / gpu_min / gpu_max / gpu_inner_join on the auto-opened connection.
         gpudb_ext::register_gpu_sum(connection);
+        gpudb_ext::register_gpu_join(connection);
     } catch (const std::exception &e) {
         if (access && access->set_error) {
             access->set_error(info, e.what());

--- a/src/extension/duckdb_loadable.cpp
+++ b/src/extension/duckdb_loadable.cpp
@@ -29,9 +29,9 @@ DUCKDB_EXTENSION_ENTRYPOINT(duckdb_connection connection,
                             duckdb_extension_info info,
                             struct duckdb_extension_access *access) {
     try {
-        // Registers gpu_sum / gpu_min / gpu_max / gpu_inner_join on the auto-opened connection.
+        // Registers gpu_sum / gpu_min / gpu_max, the resident surface, and
+        // gpu_inner_join on the auto-opened connection.
         gpudb_ext::register_gpu_sum(connection);
-        gpudb_ext::register_gpu_join(connection);
     } catch (const std::exception &e) {
         if (access && access->set_error) {
             access->set_error(info, e.what());

--- a/src/extension/gpu_join_extension.cpp
+++ b/src/extension/gpu_join_extension.cpp
@@ -1,0 +1,166 @@
+// gpu_join_extension.cpp — gpu_inner_join() table function for DuckDB.
+//
+// Usage:
+//   SELECT probe_idx, build_idx
+//   FROM gpu_inner_join([10, 20, 30], [20, 40, 99]);
+//
+// v1 contract matches HashJoinProbe: unique build keys, first match wins.
+
+#include "gpu_join_extension.hpp"
+#include "gpu_backend.hpp"
+
+#if defined(GPUDB_C_STRUCT_ABI)
+DUCKDB_EXTENSION_EXTERN
+#endif
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace gpudb_ext {
+namespace {
+
+struct JoinBindData {
+    std::vector<std::int64_t> build_keys;
+    std::vector<std::int64_t> probe_keys;
+};
+
+struct JoinInitData {
+    std::vector<std::int64_t> probe_indices;
+    std::vector<std::int64_t> build_indices;
+    std::size_t offset = 0;
+};
+
+gpudb::HybridHashJoinProbe& shared_hybrid_join() {
+    static std::unique_ptr<gpudb::HybridHashJoinProbe> hj =
+        gpudb::make_hybrid_hashjoin_probe();
+    return *hj;
+}
+
+std::mutex& join_call_mutex() {
+    static std::mutex m;
+    return m;
+}
+
+std::vector<std::int64_t> list_to_i64(duckdb_value list_val) {
+    const idx_t n = duckdb_get_list_size(list_val);
+    std::vector<std::int64_t> out;
+    out.reserve(static_cast<std::size_t>(n));
+    for (idx_t i = 0; i < n; ++i) {
+        duckdb_value child = duckdb_get_list_child(list_val, i);
+        out.push_back(duckdb_get_int64(child));
+        duckdb_destroy_value(&child);
+    }
+    return out;
+}
+
+void join_bind(duckdb_bind_info info) {
+    if (duckdb_bind_get_parameter_count(info) != 2) {
+        duckdb_bind_set_error(info, "gpu_inner_join expects two LIST(BIGINT) arguments");
+        return;
+    }
+
+    duckdb_value build_list = duckdb_bind_get_parameter(info, 0);
+    duckdb_value probe_list = duckdb_bind_get_parameter(info, 1);
+    if (!build_list || !probe_list) {
+        if (build_list) duckdb_destroy_value(&build_list);
+        if (probe_list) duckdb_destroy_value(&probe_list);
+        duckdb_bind_set_error(info, "gpu_inner_join: null argument");
+        return;
+    }
+
+    auto* bind = new JoinBindData();
+    try {
+        bind->build_keys = list_to_i64(build_list);
+        bind->probe_keys = list_to_i64(probe_list);
+    } catch (...) {
+        delete bind;
+        duckdb_destroy_value(&build_list);
+        duckdb_destroy_value(&probe_list);
+        duckdb_bind_set_error(info, "gpu_inner_join: failed to read LIST arguments");
+        return;
+    }
+    duckdb_destroy_value(&build_list);
+    duckdb_destroy_value(&probe_list);
+
+    duckdb_logical_type bigint = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+    duckdb_bind_add_result_column(info, "probe_idx", bigint);
+    duckdb_bind_add_result_column(info, "build_idx", bigint);
+    duckdb_destroy_logical_type(&bigint);
+
+    duckdb_bind_set_bind_data(info, bind, [](void* p) { delete static_cast<JoinBindData*>(p); });
+}
+
+void join_init(duckdb_init_info info) {
+    auto* bind = static_cast<JoinBindData*>(duckdb_init_get_bind_data(info));
+    auto* init = new JoinInitData();
+    try {
+        std::lock_guard<std::mutex> lock(join_call_mutex());
+        auto r = shared_hybrid_join().inner_join_i64(
+            bind->build_keys.data(), bind->build_keys.size(),
+            bind->probe_keys.data(), bind->probe_keys.size());
+        init->probe_indices = std::move(r.probe_indices);
+        init->build_indices = std::move(r.build_indices);
+    } catch (const std::exception& e) {
+        delete init;
+        duckdb_init_set_error(info, e.what());
+        return;
+    }
+    duckdb_init_set_init_data(info, init, [](void* p) { delete static_cast<JoinInitData*>(p); });
+}
+
+void join_function(duckdb_function_info info, duckdb_data_chunk output) {
+    auto* init = static_cast<JoinInitData*>(duckdb_function_get_init_data(info));
+    if (!init) return;
+
+    const std::size_t remaining = init->probe_indices.size() - init->offset;
+    if (remaining == 0) return;
+
+    constexpr idx_t kChunk = 2048;
+    const idx_t out_n = static_cast<idx_t>(std::min<std::size_t>(remaining, kChunk));
+
+    duckdb_vector v_probe = duckdb_data_chunk_get_vector(output, 0);
+    duckdb_vector v_build = duckdb_data_chunk_get_vector(output, 1);
+    auto* probe_out = static_cast<std::int64_t*>(duckdb_vector_get_data(v_probe));
+    auto* build_out = static_cast<std::int64_t*>(duckdb_vector_get_data(v_build));
+
+    for (idx_t i = 0; i < out_n; ++i) {
+        probe_out[i] = init->probe_indices[init->offset + static_cast<std::size_t>(i)];
+        build_out[i] = init->build_indices[init->offset + static_cast<std::size_t>(i)];
+    }
+
+    duckdb_data_chunk_set_size(output, out_n);
+    init->offset += static_cast<std::size_t>(out_n);
+}
+
+} // namespace
+
+void register_gpu_join(duckdb_connection con) {
+    duckdb_logical_type bigint = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+    duckdb_logical_type list_bigint = duckdb_create_list_type(bigint);
+
+    duckdb_table_function fn = duckdb_create_table_function();
+    duckdb_table_function_set_name(fn, "gpu_inner_join");
+    duckdb_table_function_add_parameter(fn, list_bigint);
+    duckdb_table_function_add_parameter(fn, list_bigint);
+    duckdb_table_function_set_bind(fn, join_bind);
+    duckdb_table_function_set_init(fn, join_init);
+    duckdb_table_function_set_function(fn, join_function);
+
+    duckdb_destroy_logical_type(&list_bigint);
+    duckdb_destroy_logical_type(&bigint);
+
+    if (duckdb_register_table_function(con, fn) == DuckDBError) {
+        duckdb_destroy_table_function(&fn);
+        throw std::runtime_error("gpu_inner_join registration failed");
+    }
+    duckdb_destroy_table_function(&fn);
+    std::fprintf(stderr, "[gpudb] registered gpu_inner_join (hybrid hash join)\n");
+}
+
+} // namespace gpudb_ext

--- a/src/extension/gpu_join_extension.cpp
+++ b/src/extension/gpu_join_extension.cpp
@@ -13,8 +13,10 @@
 DUCKDB_EXTENSION_EXTERN
 #endif
 
+#include <cctype>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <mutex>
@@ -138,6 +140,141 @@ void join_function(duckdb_function_info info, duckdb_data_chunk output) {
     init->offset += static_cast<std::size_t>(out_n);
 }
 
+// ---------------------------------------------------------------------------
+// gpu_join_rows_resident(probe VARCHAR, build VARCHAR, kind VARCHAR)
+// -> (probe_idx BIGINT, build_idx BIGINT)  — the row-returning resident join.
+// kind: 'inner' | 'left' | 'semi' | 'anti' (case-insensitive). build_idx is
+// NULL for LEFT-unmatched / SEMI / ANTI rows. Output capped at
+// GPUDB_JOIN_ROWS_MAX_M million rows (default 100) with a clean error.
+// ---------------------------------------------------------------------------
+
+std::size_t join_rows_cap() {
+    static const std::size_t cap = [] {
+        unsigned long long m = 100;   // 100M rows ≈ 1.6 GB of index pairs
+        if (const char* s = std::getenv("GPUDB_JOIN_ROWS_MAX_M")) {
+            char* end = nullptr;
+            const unsigned long long v = std::strtoull(s, &end, 10);
+            if (end && *end == '\0' && v > 0) m = v;
+        }
+        return static_cast<std::size_t>(m) * 1000000;
+    }();
+    return cap;
+}
+
+struct RowsBindData {
+    std::string probe, build;
+    gpudb::JoinKind kind = gpudb::JoinKind::INNER;
+};
+
+std::string value_to_string(duckdb_value v) {
+    char* s = duckdb_get_varchar(v);
+    std::string out = s ? s : "";
+    if (s) duckdb_free(s);
+    return out;
+}
+
+void rows_bind(duckdb_bind_info info) {
+    duckdb_value pv = duckdb_bind_get_parameter(info, 0);
+    duckdb_value bv = duckdb_bind_get_parameter(info, 1);
+    duckdb_value kv = duckdb_bind_get_parameter(info, 2);
+    if (!pv || !bv || !kv) {
+        if (pv) duckdb_destroy_value(&pv);
+        if (bv) duckdb_destroy_value(&bv);
+        if (kv) duckdb_destroy_value(&kv);
+        duckdb_bind_set_error(info, "gpu_join_rows_resident: null argument");
+        return;
+    }
+    auto* bind = new RowsBindData();
+    bind->probe = value_to_string(pv);
+    bind->build = value_to_string(bv);
+    std::string kind = value_to_string(kv);
+    duckdb_destroy_value(&pv);
+    duckdb_destroy_value(&bv);
+    duckdb_destroy_value(&kv);
+    for (auto& c : kind) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    if      (kind == "inner") bind->kind = gpudb::JoinKind::INNER;
+    else if (kind == "left")  bind->kind = gpudb::JoinKind::LEFT;
+    else if (kind == "semi")  bind->kind = gpudb::JoinKind::SEMI;
+    else if (kind == "anti")  bind->kind = gpudb::JoinKind::ANTI;
+    else {
+        delete bind;
+        duckdb_bind_set_error(info,
+            "gpu_join_rows_resident: kind must be 'inner', 'left', 'semi' or "
+            "'anti' (right/full compose from these with sides swapped)");
+        return;
+    }
+
+    duckdb_logical_type bigint = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+    duckdb_bind_add_result_column(info, "probe_idx", bigint);
+    duckdb_bind_add_result_column(info, "build_idx", bigint);
+    duckdb_destroy_logical_type(&bigint);
+    duckdb_bind_set_bind_data(info, bind, [](void* p) { delete static_cast<RowsBindData*>(p); });
+}
+
+struct RowsInitData {
+    gpudb::JoinRowsResult rows;
+    std::size_t offset = 0;
+};
+
+void rows_init(duckdb_init_info info) {
+    auto* bind = static_cast<RowsBindData*>(duckdb_init_get_bind_data(info));
+    auto* init = new RowsInitData();
+    try {
+        std::lock_guard<std::mutex> lock(resident_mutex());
+        gpudb::ResidentColumn* probe = find_resident_column(bind->probe);
+        gpudb::ResidentColumn* build = find_resident_column(bind->build);
+        if (!probe || !build)
+            throw std::runtime_error(
+                "gpu_join_rows_resident: no resident column named '" +
+                (probe ? bind->build : bind->probe) +
+                "' — create it with gpu_upload/gpu_upload_pair");
+        init->rows = resident_aggregator().join_rows_resident(
+            *probe, *build, bind->kind, join_rows_cap());
+        char buf[256];
+        std::snprintf(buf, sizeof(buf),
+            "op=join_rows_resident rows_probe=%zu rows_build=%zu out_rows=%zu "
+            "wall_ms=%.3f kernel_ms=%.3f transfer_ms=%.3f",
+            init->rows.rows_probe, init->rows.rows_build,
+            init->rows.probe_idx.size(),
+            init->rows.wall_ms, init->rows.kernel_ms, init->rows.transfer_ms);
+        resident_set_last_stats(buf);
+    } catch (const std::exception& e) {
+        delete init;
+        duckdb_init_set_error(info, e.what());
+        return;
+    }
+    duckdb_init_set_init_data(info, init, [](void* p) { delete static_cast<RowsInitData*>(p); });
+}
+
+void rows_function(duckdb_function_info info, duckdb_data_chunk output) {
+    auto* init = static_cast<RowsInitData*>(duckdb_function_get_init_data(info));
+    if (!init) return;
+    const std::size_t remaining = init->rows.probe_idx.size() - init->offset;
+    if (remaining == 0) return;
+
+    constexpr idx_t kChunk = 2048;
+    const idx_t out_n = static_cast<idx_t>(std::min<std::size_t>(remaining, kChunk));
+    duckdb_vector v_probe = duckdb_data_chunk_get_vector(output, 0);
+    duckdb_vector v_build = duckdb_data_chunk_get_vector(output, 1);
+    auto* probe_out = static_cast<std::int64_t*>(duckdb_vector_get_data(v_probe));
+    auto* build_out = static_cast<std::int64_t*>(duckdb_vector_get_data(v_build));
+    duckdb_vector_ensure_validity_writable(v_build);
+    uint64_t* build_validity = duckdb_vector_get_validity(v_build);
+
+    for (idx_t i = 0; i < out_n; ++i) {
+        const std::size_t s = init->offset + static_cast<std::size_t>(i);
+        probe_out[i] = init->rows.probe_idx[s];
+        const std::int64_t b = init->rows.build_idx[s];
+        if (b < 0) {
+            duckdb_validity_set_row_invalid(build_validity, i);
+        } else {
+            build_out[i] = b;
+        }
+    }
+    duckdb_data_chunk_set_size(output, out_n);
+    init->offset += static_cast<std::size_t>(out_n);
+}
+
 } // namespace
 
 void register_gpu_join(duckdb_connection con) {
@@ -160,7 +297,24 @@ void register_gpu_join(duckdb_connection con) {
         throw std::runtime_error("gpu_inner_join registration failed");
     }
     duckdb_destroy_table_function(&fn);
-    std::fprintf(stderr, "[gpudb] registered gpu_inner_join (hybrid hash join)\n");
+
+    duckdb_logical_type varchar = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+    duckdb_table_function rfn = duckdb_create_table_function();
+    duckdb_table_function_set_name(rfn, "gpu_join_rows_resident");
+    duckdb_table_function_add_parameter(rfn, varchar);   // probe keys name
+    duckdb_table_function_add_parameter(rfn, varchar);   // build keys name
+    duckdb_table_function_add_parameter(rfn, varchar);   // kind
+    duckdb_table_function_set_bind(rfn, rows_bind);
+    duckdb_table_function_set_init(rfn, rows_init);
+    duckdb_table_function_set_function(rfn, rows_function);
+    duckdb_destroy_logical_type(&varchar);
+    if (duckdb_register_table_function(con, rfn) == DuckDBError) {
+        duckdb_destroy_table_function(&rfn);
+        throw std::runtime_error("gpu_join_rows_resident registration failed");
+    }
+    duckdb_destroy_table_function(&rfn);
+    std::fprintf(stderr,
+        "[gpudb] registered gpu_inner_join + gpu_join_rows_resident\n");
 }
 
 } // namespace gpudb_ext

--- a/src/extension/gpu_join_extension.hpp
+++ b/src/extension/gpu_join_extension.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#if defined(GPUDB_C_STRUCT_ABI)
+#include "duckdb_extension.h"
+#else
+#include "duckdb.h"
+#endif
+
+namespace gpudb_ext {
+
+// Register gpu_inner_join(build_keys LIST(BIGINT), probe_keys LIST(BIGINT))
+// returning (probe_idx BIGINT, build_idx BIGINT).
+void register_gpu_join(duckdb_connection con);
+
+} // namespace gpudb_ext

--- a/src/extension/gpu_join_extension.hpp
+++ b/src/extension/gpu_join_extension.hpp
@@ -6,10 +6,30 @@
 #include "duckdb.h"
 #endif
 
+#include <mutex>
+#include <string>
+
+namespace gpudb {
+class ResidentColumn;
+class HybridAggregator;
+}
+
 namespace gpudb_ext {
 
 // Register gpu_inner_join(build_keys LIST(BIGINT), probe_keys LIST(BIGINT))
-// returning (probe_idx BIGINT, build_idx BIGINT).
+// returning (probe_idx BIGINT, build_idx BIGINT), and
+// gpu_join_rows_resident(probe VARCHAR, build VARCHAR, kind VARCHAR)
+// returning the same shape from resident columns (build_idx NULL for
+// LEFT-unmatched / SEMI / ANTI rows).
 void register_gpu_join(duckdb_connection con);
+
+// Bridge into gpu_resident.cpp's registry (implemented there). All access
+// must hold resident_mutex(). find_resident_column returns nullptr if the
+// name is unknown; the pointer is owned by the registry and is only valid
+// while the mutex is held or the column is not dropped.
+std::mutex& resident_mutex();
+gpudb::ResidentColumn* find_resident_column(const std::string& name);
+gpudb::HybridAggregator& resident_aggregator();
+void resident_set_last_stats(const std::string& s);
 
 } // namespace gpudb_ext

--- a/src/extension/gpu_resident.cpp
+++ b/src/extension/gpu_resident.cpp
@@ -384,6 +384,134 @@ duckdb_aggregate_function make_upload_fn(duckdb_type value_type,
 }
 
 // ---------------------------------------------------------------------------
+// gpu_upload_pair aggregate — upload a (key, payload) column pair in ONE scan.
+//
+// Two separate gpu_upload calls CANNOT be used as a join's probe keys +
+// payload: each upload is an independent aggregate over an independent table
+// scan, and DuckDB's parallel scan/combine order differs between them, so
+// row i of one column need not correspond to row i of the other. (This is
+// invisible to single-column reductions, which are order-insensitive — it
+// only bites operations that pair two columns positionally, like the fused
+// join.) gpu_upload_pair(name, k, v) buffers the pair interleaved in one
+// aggregate state, so whatever order DuckDB delivers, k[i] and v[i] stay
+// together. Finalize registers TWO resident columns: '<name>.k' and
+// '<name>.v'. Rows where either value is NULL are skipped as a pair.
+// ---------------------------------------------------------------------------
+
+void upload_pair_update(duckdb_function_info info, duckdb_data_chunk input,
+                        duckdb_aggregate_state* states) {
+    duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
+    duckdb_vector k_vec    = duckdb_data_chunk_get_vector(input, 1);
+    duckdb_vector v_vec    = duckdb_data_chunk_get_vector(input, 2);
+    auto* names = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(name_vec));
+    const auto* kd = reinterpret_cast<const std::int64_t*>(duckdb_vector_get_data(k_vec));
+    const auto* vd = reinterpret_cast<const std::int64_t*>(duckdb_vector_get_data(v_vec));
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    if (!names || !kd || !vd || n == 0) return;
+
+    uint64_t* name_validity = duckdb_vector_get_validity(name_vec);
+    uint64_t* k_validity    = duckdb_vector_get_validity(k_vec);
+    uint64_t* v_validity    = duckdb_vector_get_validity(v_vec);
+
+    UploadState* s0 = probe_upload_state(states[0]);
+    if (!s0) return;
+    bool per_row = true;
+    if (n > 1) {
+        const idx_t probes[3] = { 1, n / 2, n - 1 };
+        for (idx_t k = 0; k < 3 && per_row; ++k) {
+            const idx_t i = probes[k];
+            if (i == 0) continue;
+            if (probe_upload_state(states[i]) == nullptr) per_row = false;
+        }
+    }
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    auto& G = g();
+    auto append_row = [&](UploadState* s, idx_t i) -> bool {
+        // Either half NULL -> skip the PAIR (keeps k/v aligned).
+        if ((k_validity && !duckdb_validity_row_is_valid(k_validity, i)) ||
+            (v_validity && !duckdb_validity_row_is_valid(v_validity, i))) return true;
+        if (name_validity && !duckdb_validity_row_is_valid(name_validity, i)) {
+            duckdb_aggregate_function_set_error(info,
+                "gpu_upload_pair: name may not be NULL");
+            return false;
+        }
+        UploadBuf& b = state_buf_locked(s, gpudb::Dtype::I64);
+        const char*       nm_data = duckdb_string_t_data(&names[i]);
+        const std::size_t nm_len  = duckdb_string_t_length(names[i]);
+        if (!b.name_set) {
+            b.name.assign(nm_data, nm_len);
+            b.name_set = true;
+        } else if (b.name.size() != nm_len ||
+                   std::memcmp(b.name.data(), nm_data, nm_len) != 0) {
+            duckdb_aggregate_function_set_error(info,
+                ("gpu_upload_pair: one aggregate received two different names ('" +
+                 b.name + "' and '" + std::string(nm_data, nm_len) +
+                 "') — use a constant name").c_str());
+            return false;
+        }
+        if (G.pool_bytes + 2 * sizeof(std::int64_t) > pool_cap_bytes()) {
+            duckdb_aggregate_function_set_error(info,
+                (std::string("gpu_upload_pair: out of buffer memory") + kPoolCapHint).c_str());
+            return false;
+        }
+        G.pool_bytes += 2 * sizeof(std::int64_t);
+        b.i64.push_back(kd[i]);   // interleaved (k, v) — combine() concatenates
+        b.i64.push_back(vd[i]);   // whole buffers, so pairs never split
+        return true;
+    };
+
+    if (n == 1 || !per_row) {
+        for (idx_t i = 0; i < n; ++i) if (!append_row(s0, i)) return;
+    } else {
+        for (idx_t i = 0; i < n; ++i) {
+            UploadState* s = probe_upload_state(states[i]);
+            if (s && !append_row(s, i)) return;
+        }
+    }
+}
+
+void upload_pair_finalize(duckdb_function_info info, duckdb_aggregate_state* source,
+                          duckdb_vector result, idx_t count, idx_t offset) {
+    if (count == 0) return;
+    auto* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(result));
+    duckdb_vector_ensure_validity_writable(result);
+    uint64_t* validity = duckdb_vector_get_validity(result);
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    auto& G = g();
+    for (idx_t i = 0; i < count; ++i) {
+        UploadState* s = probe_upload_state(source[i]);
+        auto it = (s && s->buf_id != 0) ? G.pool.find(s->buf_id) : G.pool.end();
+        if (it == G.pool.end() || it->second.i64.empty()) {
+            out[offset + i] = 0;
+            duckdb_validity_set_row_invalid(validity, offset + i);
+            continue;
+        }
+        UploadBuf& b = it->second;
+        const std::size_t rows = b.i64.size() / 2;
+        try {
+            // De-interleave and upload both columns.
+            std::vector<std::int64_t> keys(rows), vals(rows);
+            for (std::size_t r = 0; r < rows; ++r) {
+                keys[r] = b.i64[2 * r];
+                vals[r] = b.i64[2 * r + 1];
+            }
+            auto& a = agg_locked();
+            auto kcol = a.upload_i64(keys.data(), rows);
+            auto vcol = a.upload_i64(vals.data(), rows);
+            G.registry[b.name + ".k"] = std::move(kcol);
+            G.registry[b.name + ".v"] = std::move(vcol);
+            out[offset + i] = static_cast<std::int64_t>(rows);
+        } catch (const std::exception& e) {
+            duckdb_aggregate_function_set_error(info,
+                (std::string("gpu_upload_pair failed: ") + e.what()).c_str());
+            return;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Resident scalar functions.
 // ---------------------------------------------------------------------------
 
@@ -552,15 +680,99 @@ void drop_resident_exec(duckdb_function_info info, duckdb_data_chunk input,
     }
 }
 
+// ---------------------------------------------------------------------------
+// Fused resident join-aggregate (v0.5).
+//   gpu_join_sum_resident(probe_keys, payload, build_keys) -> BIGINT
+//     SELECT sum(p.payload) FROM probe p JOIN build b ON p.key = b.key,
+//     full build-side multiplicity; NULL when no rows join (SQL SUM semantics).
+//   gpu_join_count_resident(probe_keys, build_keys) -> BIGINT
+//     the same join's COUNT(*); 0 when no rows join.
+// count_only reuses the probe-key column as its own payload — the sum is
+// discarded, only `matched` is read.
+// ---------------------------------------------------------------------------
+
+void record_join_stats_locked(const char* op, const gpudb::JoinAggResult& r) {
+    auto& G = g();
+    const auto& d = G.agg->last_decision();
+    char buf[320];
+    std::snprintf(buf, sizeof(buf),
+        "op=%s backend=%s reason=%s rows_probe=%zu rows_build=%zu matched=%lld "
+        "wall_ms=%.3f kernel_ms=%.3f transfer_ms=%.3f",
+        op, gpudb::to_string(d.chosen), gpudb::to_string(d.reason),
+        r.rows_probe, r.rows_build, static_cast<long long>(r.matched),
+        r.wall_ms, r.kernel_ms, r.transfer_ms);
+    G.last_stats = buf;
+}
+
+template <bool COUNT_ONLY>
+void join_sum_resident_exec(duckdb_function_info info, duckdb_data_chunk input,
+                            duckdb_vector output) {
+    constexpr int kArgs = COUNT_ONLY ? 2 : 3;
+    duckdb_vector    vecs[3] = {};
+    duckdb_string_t* names[3] = {};
+    uint64_t*        valid[3] = {};
+    for (int a = 0; a < kArgs; ++a) {
+        vecs[a]  = duckdb_data_chunk_get_vector(input, a);
+        names[a] = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(vecs[a]));
+        valid[a] = duckdb_vector_get_validity(vecs[a]);
+    }
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    auto* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(output));
+    duckdb_vector_ensure_validity_writable(output);
+    uint64_t* out_validity = duckdb_vector_get_validity(output);
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    for (idx_t i = 0; i < n; ++i) {
+        bool null_arg = false;
+        for (int a = 0; a < kArgs; ++a) {
+            if (valid[a] && !duckdb_validity_row_is_valid(valid[a], i)) { null_arg = true; break; }
+        }
+        if (null_arg) {
+            duckdb_validity_set_row_invalid(out_validity, i);
+            continue;
+        }
+        gpudb::ResidentColumn* cols[3] = {};
+        for (int a = 0; a < kArgs; ++a) {
+            cols[a] = lookup_locked(info, names[a], i);
+            if (!cols[a]) return;
+            if (cols[a]->dtype() != gpudb::Dtype::I64) {
+                duckdb_scalar_function_set_error(info,
+                    "gpu_join_*_resident operates on BIGINT resident columns "
+                    "(f64 keys/payloads are not in the v0.5 join ABI)");
+                return;
+            }
+        }
+        gpudb::ResidentColumn* probe   = cols[0];
+        gpudb::ResidentColumn* payload = COUNT_ONLY ? cols[0] : cols[1];
+        gpudb::ResidentColumn* build   = COUNT_ONLY ? cols[1] : cols[2];
+        try {
+            auto& a = agg_locked();
+            gpudb::JoinAggResult r = a.join_sum_resident_i64(*probe, *payload, *build);
+            record_join_stats_locked(COUNT_ONLY ? "join_count_resident"
+                                                : "join_sum_resident", r);
+            if (COUNT_ONLY) {
+                out[i] = r.matched;
+            } else if (r.matched == 0) {
+                duckdb_validity_set_row_invalid(out_validity, i);  // SUM over ∅ = NULL
+            } else {
+                out[i] = r.sum;
+            }
+        } catch (const std::exception& e) {
+            duckdb_scalar_function_set_error(info, e.what());
+            return;
+        }
+    }
+}
+
 // Build + register one scalar function. All of these are volatile: their
 // result depends on the mutable resident registry, so DuckDB must not
 // constant-fold or cache them across calls.
 void register_scalar(duckdb_connection con, const char* name,
                      duckdb_scalar_function_t exec,
-                     duckdb_type ret, bool takes_name) {
+                     duckdb_type ret, int n_name_params) {
     duckdb_scalar_function fn = duckdb_create_scalar_function();
     duckdb_scalar_function_set_name(fn, name);
-    if (takes_name) {
+    for (int p = 0; p < n_name_params; ++p) {
         duckdb_logical_type t_name = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
         duckdb_scalar_function_add_parameter(fn, t_name);
         duckdb_destroy_logical_type(&t_name);
@@ -600,22 +812,55 @@ void register_gpu_resident(duckdb_connection con) {
         throw std::runtime_error("gpu_upload function set registration failed");
     }
 
+    // gpu_upload_pair(name, k BIGINT, v BIGINT) -> BIGINT, registers
+    // '<name>.k' and '<name>.v' with guaranteed positional alignment.
+    {
+        duckdb_aggregate_function pfn = duckdb_create_aggregate_function();
+        duckdb_aggregate_function_set_name(pfn, "gpu_upload_pair");
+        duckdb_logical_type t_name = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+        duckdb_logical_type t_i64a = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+        duckdb_logical_type t_i64b = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+        duckdb_logical_type t_ret  = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+        duckdb_aggregate_function_add_parameter(pfn, t_name);
+        duckdb_aggregate_function_add_parameter(pfn, t_i64a);
+        duckdb_aggregate_function_add_parameter(pfn, t_i64b);
+        duckdb_aggregate_function_set_return_type(pfn, t_ret);
+        duckdb_destroy_logical_type(&t_name);
+        duckdb_destroy_logical_type(&t_i64a);
+        duckdb_destroy_logical_type(&t_i64b);
+        duckdb_destroy_logical_type(&t_ret);
+        duckdb_aggregate_function_set_functions(pfn,
+            upload_state_size, upload_state_init, upload_pair_update,
+            upload_combine, upload_pair_finalize);
+        duckdb_aggregate_function_set_destructor(pfn, upload_state_destroy);
+        duckdb_aggregate_function_set_special_handling(pfn);
+        duckdb_state pst = duckdb_register_aggregate_function(con, pfn);
+        duckdb_destroy_aggregate_function(&pfn);
+        if (pst == DuckDBError) {
+            throw std::runtime_error("gpu_upload_pair registration failed");
+        }
+    }
+
     register_scalar(con, "gpu_sum_resident",
-        resident_i64_exec<&gpudb::Aggregator::sum_resident_i64>, DUCKDB_TYPE_BIGINT, true);
+        resident_i64_exec<&gpudb::Aggregator::sum_resident_i64>, DUCKDB_TYPE_BIGINT, 1);
     register_scalar(con, "gpu_min_resident",
-        resident_i64_exec<&gpudb::Aggregator::min_resident_i64>, DUCKDB_TYPE_BIGINT, true);
+        resident_i64_exec<&gpudb::Aggregator::min_resident_i64>, DUCKDB_TYPE_BIGINT, 1);
     register_scalar(con, "gpu_max_resident",
-        resident_i64_exec<&gpudb::Aggregator::max_resident_i64>, DUCKDB_TYPE_BIGINT, true);
+        resident_i64_exec<&gpudb::Aggregator::max_resident_i64>, DUCKDB_TYPE_BIGINT, 1);
     register_scalar(con, "gpu_sum_resident_f64",
-        sum_resident_f64_exec, DUCKDB_TYPE_DOUBLE, true);
+        sum_resident_f64_exec, DUCKDB_TYPE_DOUBLE, 1);
     register_scalar(con, "gpu_resident_info",
-        resident_info_exec, DUCKDB_TYPE_VARCHAR, true);
+        resident_info_exec, DUCKDB_TYPE_VARCHAR, 1);
     register_scalar(con, "gpu_drop_resident",
-        drop_resident_exec, DUCKDB_TYPE_BOOLEAN, true);
+        drop_resident_exec, DUCKDB_TYPE_BOOLEAN, 1);
     register_scalar(con, "gpu_last_stats",
-        last_stats_exec, DUCKDB_TYPE_VARCHAR, false);
+        last_stats_exec, DUCKDB_TYPE_VARCHAR, 0);
     register_scalar(con, "gpu_build_info",
-        build_info_exec, DUCKDB_TYPE_VARCHAR, false);
+        build_info_exec, DUCKDB_TYPE_VARCHAR, 0);
+    register_scalar(con, "gpu_join_sum_resident",
+        join_sum_resident_exec</*count_only=*/false>, DUCKDB_TYPE_BIGINT, 3);
+    register_scalar(con, "gpu_join_count_resident",
+        join_sum_resident_exec</*count_only=*/true>, DUCKDB_TYPE_BIGINT, 2);
 }
 
 } // namespace gpudb_ext

--- a/src/extension/gpu_resident.cpp
+++ b/src/extension/gpu_resident.cpp
@@ -398,14 +398,17 @@ duckdb_aggregate_function make_upload_fn(duckdb_type value_type,
 // '<name>.v'. Rows where either value is NULL are skipped as a pair.
 // ---------------------------------------------------------------------------
 
-void upload_pair_update(duckdb_function_info info, duckdb_data_chunk input,
-                        duckdb_aggregate_state* states) {
+// Payload type V is stored bit-cast into the interleaved i64 buffer (identity
+// for BIGINT, raw IEEE-754 bits for DOUBLE); VDT tags which finalize applies.
+template <class V, gpudb::Dtype VDT>
+void upload_pair_update_t(duckdb_function_info info, duckdb_data_chunk input,
+                          duckdb_aggregate_state* states) {
     duckdb_vector name_vec = duckdb_data_chunk_get_vector(input, 0);
     duckdb_vector k_vec    = duckdb_data_chunk_get_vector(input, 1);
     duckdb_vector v_vec    = duckdb_data_chunk_get_vector(input, 2);
     auto* names = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(name_vec));
     const auto* kd = reinterpret_cast<const std::int64_t*>(duckdb_vector_get_data(k_vec));
-    const auto* vd = reinterpret_cast<const std::int64_t*>(duckdb_vector_get_data(v_vec));
+    const auto* vd = reinterpret_cast<const V*>(duckdb_vector_get_data(v_vec));
     const idx_t n = duckdb_data_chunk_get_size(input);
     if (!names || !kd || !vd || n == 0) return;
 
@@ -456,8 +459,11 @@ void upload_pair_update(duckdb_function_info info, duckdb_data_chunk input,
             return false;
         }
         G.pool_bytes += 2 * sizeof(std::int64_t);
+        std::int64_t v_bits;      // bit-cast payload into the i64 lane
+        static_assert(sizeof(V) == sizeof(std::int64_t), "pair payload width");
+        std::memcpy(&v_bits, &vd[i], sizeof(v_bits));
         b.i64.push_back(kd[i]);   // interleaved (k, v) — combine() concatenates
-        b.i64.push_back(vd[i]);   // whole buffers, so pairs never split
+        b.i64.push_back(v_bits);  // whole buffers, so pairs never split
         return true;
     };
 
@@ -471,8 +477,9 @@ void upload_pair_update(duckdb_function_info info, duckdb_data_chunk input,
     }
 }
 
-void upload_pair_finalize(duckdb_function_info info, duckdb_aggregate_state* source,
-                          duckdb_vector result, idx_t count, idx_t offset) {
+template <gpudb::Dtype VDT>
+void upload_pair_finalize_t(duckdb_function_info info, duckdb_aggregate_state* source,
+                            duckdb_vector result, idx_t count, idx_t offset) {
     if (count == 0) return;
     auto* out = reinterpret_cast<std::int64_t*>(duckdb_vector_get_data(result));
     duckdb_vector_ensure_validity_writable(result);
@@ -491,15 +498,27 @@ void upload_pair_finalize(duckdb_function_info info, duckdb_aggregate_state* sou
         UploadBuf& b = it->second;
         const std::size_t rows = b.i64.size() / 2;
         try {
-            // De-interleave and upload both columns.
-            std::vector<std::int64_t> keys(rows), vals(rows);
-            for (std::size_t r = 0; r < rows; ++r) {
-                keys[r] = b.i64[2 * r];
-                vals[r] = b.i64[2 * r + 1];
-            }
+            // De-interleave and upload both columns (payload bits un-cast to
+            // its true type).
+            std::vector<std::int64_t> keys(rows);
             auto& a = agg_locked();
+            std::unique_ptr<gpudb::ResidentColumn> vcol;
+            if (VDT == gpudb::Dtype::I64) {
+                std::vector<std::int64_t> vals(rows);
+                for (std::size_t r = 0; r < rows; ++r) {
+                    keys[r] = b.i64[2 * r];
+                    vals[r] = b.i64[2 * r + 1];
+                }
+                vcol = a.upload_i64(vals.data(), rows);
+            } else {
+                std::vector<double> vals(rows);
+                for (std::size_t r = 0; r < rows; ++r) {
+                    keys[r] = b.i64[2 * r];
+                    std::memcpy(&vals[r], &b.i64[2 * r + 1], sizeof(double));
+                }
+                vcol = a.upload_f64(vals.data(), rows);
+            }
             auto kcol = a.upload_i64(keys.data(), rows);
-            auto vcol = a.upload_i64(vals.data(), rows);
             G.registry[b.name + ".k"] = std::move(kcol);
             G.registry[b.name + ".v"] = std::move(vcol);
             out[offset + i] = static_cast<std::int64_t>(rows);
@@ -704,7 +723,7 @@ void record_join_stats_locked(const char* op, const gpudb::JoinAggResult& r) {
     G.last_stats = buf;
 }
 
-template <bool COUNT_ONLY>
+template <gpudb::JoinKind K, bool COUNT_ONLY>
 void join_sum_resident_exec(duckdb_function_info info, duckdb_data_chunk input,
                             duckdb_vector output) {
     constexpr int kArgs = COUNT_ONLY ? 2 : 3;
@@ -747,7 +766,7 @@ void join_sum_resident_exec(duckdb_function_info info, duckdb_data_chunk input,
         gpudb::ResidentColumn* build   = COUNT_ONLY ? cols[1] : cols[2];
         try {
             auto& a = agg_locked();
-            gpudb::JoinAggResult r = a.join_sum_resident_i64(*probe, *payload, *build);
+            gpudb::JoinAggResult r = a.join_sum_resident_i64(*probe, *payload, *build, K);
             record_join_stats_locked(COUNT_ONLY ? "join_count_resident"
                                                 : "join_sum_resident", r);
             if (COUNT_ONLY) {
@@ -756,6 +775,68 @@ void join_sum_resident_exec(duckdb_function_info info, duckdb_data_chunk input,
                 duckdb_validity_set_row_invalid(out_validity, i);  // SUM over ∅ = NULL
             } else {
                 out[i] = r.sum;
+            }
+        } catch (const std::exception& e) {
+            duckdb_scalar_function_set_error(info, e.what());
+            return;
+        }
+    }
+}
+
+// f64-payload flavor: (probe_keys, payload_f64, build_keys) -> DOUBLE.
+// Keys must be BIGINT resident columns; payload must be DOUBLE.
+template <gpudb::JoinKind K>
+void join_sum_resident_f64_exec(duckdb_function_info info, duckdb_data_chunk input,
+                                duckdb_vector output) {
+    duckdb_vector    vecs[3] = {};
+    duckdb_string_t* names[3] = {};
+    uint64_t*        valid[3] = {};
+    for (int a = 0; a < 3; ++a) {
+        vecs[a]  = duckdb_data_chunk_get_vector(input, a);
+        names[a] = reinterpret_cast<duckdb_string_t*>(duckdb_vector_get_data(vecs[a]));
+        valid[a] = duckdb_vector_get_validity(vecs[a]);
+    }
+    const idx_t n = duckdb_data_chunk_get_size(input);
+    auto* out = reinterpret_cast<double*>(duckdb_vector_get_data(output));
+    duckdb_vector_ensure_validity_writable(output);
+    uint64_t* out_validity = duckdb_vector_get_validity(output);
+
+    std::lock_guard<std::mutex> lock(g().mu);
+    for (idx_t i = 0; i < n; ++i) {
+        bool null_arg = false;
+        for (int a = 0; a < 3; ++a) {
+            if (valid[a] && !duckdb_validity_row_is_valid(valid[a], i)) { null_arg = true; break; }
+        }
+        if (null_arg) {
+            duckdb_validity_set_row_invalid(out_validity, i);
+            continue;
+        }
+        gpudb::ResidentColumn* cols[3] = {};
+        for (int a = 0; a < 3; ++a) {
+            cols[a] = lookup_locked(info, names[a], i);
+            if (!cols[a]) return;
+        }
+        if (cols[0]->dtype() != gpudb::Dtype::I64 ||
+            cols[2]->dtype() != gpudb::Dtype::I64) {
+            duckdb_scalar_function_set_error(info,
+                "gpu_*join_sum_resident_f64: key columns must be BIGINT");
+            return;
+        }
+        if (cols[1]->dtype() != gpudb::Dtype::F64) {
+            duckdb_scalar_function_set_error(info,
+                "gpu_*join_sum_resident_f64: payload must be a DOUBLE resident "
+                "column — for BIGINT payloads use the non-_f64 variant");
+            return;
+        }
+        try {
+            auto& a = agg_locked();
+            gpudb::JoinAggResult r =
+                a.join_sum_resident_f64(*cols[0], *cols[1], *cols[2], K);
+            record_join_stats_locked("join_sum_resident_f64", r);
+            if (r.matched == 0) {
+                duckdb_validity_set_row_invalid(out_validity, i);  // SUM over ∅ = NULL
+            } else {
+                out[i] = r.sum_f64;
             }
         } catch (const std::exception& e) {
             duckdb_scalar_function_set_error(info, e.what());
@@ -812,30 +893,51 @@ void register_gpu_resident(duckdb_connection con) {
         throw std::runtime_error("gpu_upload function set registration failed");
     }
 
-    // gpu_upload_pair(name, k BIGINT, v BIGINT) -> BIGINT, registers
+    // gpu_upload_pair(name, k BIGINT, v BIGINT|DOUBLE) -> BIGINT, registers
     // '<name>.k' and '<name>.v' with guaranteed positional alignment.
     {
-        duckdb_aggregate_function pfn = duckdb_create_aggregate_function();
-        duckdb_aggregate_function_set_name(pfn, "gpu_upload_pair");
-        duckdb_logical_type t_name = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
-        duckdb_logical_type t_i64a = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
-        duckdb_logical_type t_i64b = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
-        duckdb_logical_type t_ret  = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
-        duckdb_aggregate_function_add_parameter(pfn, t_name);
-        duckdb_aggregate_function_add_parameter(pfn, t_i64a);
-        duckdb_aggregate_function_add_parameter(pfn, t_i64b);
-        duckdb_aggregate_function_set_return_type(pfn, t_ret);
-        duckdb_destroy_logical_type(&t_name);
-        duckdb_destroy_logical_type(&t_i64a);
-        duckdb_destroy_logical_type(&t_i64b);
-        duckdb_destroy_logical_type(&t_ret);
-        duckdb_aggregate_function_set_functions(pfn,
-            upload_state_size, upload_state_init, upload_pair_update,
-            upload_combine, upload_pair_finalize);
-        duckdb_aggregate_function_set_destructor(pfn, upload_state_destroy);
-        duckdb_aggregate_function_set_special_handling(pfn);
-        duckdb_state pst = duckdb_register_aggregate_function(con, pfn);
-        duckdb_destroy_aggregate_function(&pfn);
+        auto make_pair_fn = [](duckdb_type v_type,
+                               duckdb_aggregate_update_t update,
+                               duckdb_aggregate_finalize_t finalize) {
+            duckdb_aggregate_function pfn = duckdb_create_aggregate_function();
+            duckdb_aggregate_function_set_name(pfn, "gpu_upload_pair");
+            duckdb_logical_type t_name = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+            duckdb_logical_type t_k    = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+            duckdb_logical_type t_v    = duckdb_create_logical_type(v_type);
+            duckdb_logical_type t_ret  = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
+            duckdb_aggregate_function_add_parameter(pfn, t_name);
+            duckdb_aggregate_function_add_parameter(pfn, t_k);
+            duckdb_aggregate_function_add_parameter(pfn, t_v);
+            duckdb_aggregate_function_set_return_type(pfn, t_ret);
+            duckdb_destroy_logical_type(&t_name);
+            duckdb_destroy_logical_type(&t_k);
+            duckdb_destroy_logical_type(&t_v);
+            duckdb_destroy_logical_type(&t_ret);
+            duckdb_aggregate_function_set_functions(pfn,
+                upload_state_size, upload_state_init, update,
+                upload_combine, finalize);
+            duckdb_aggregate_function_set_destructor(pfn, upload_state_destroy);
+            duckdb_aggregate_function_set_special_handling(pfn);
+            return pfn;
+        };
+        duckdb_aggregate_function_set pset =
+            duckdb_create_aggregate_function_set("gpu_upload_pair");
+        duckdb_aggregate_function p_i64 = make_pair_fn(DUCKDB_TYPE_BIGINT,
+            upload_pair_update_t<std::int64_t, gpudb::Dtype::I64>,
+            upload_pair_finalize_t<gpudb::Dtype::I64>);
+        duckdb_aggregate_function p_f64 = make_pair_fn(DUCKDB_TYPE_DOUBLE,
+            upload_pair_update_t<double, gpudb::Dtype::F64>,
+            upload_pair_finalize_t<gpudb::Dtype::F64>);
+        duckdb_state pa1 = duckdb_add_aggregate_function_to_set(pset, p_i64);
+        duckdb_state pa2 = duckdb_add_aggregate_function_to_set(pset, p_f64);
+        duckdb_destroy_aggregate_function(&p_i64);
+        duckdb_destroy_aggregate_function(&p_f64);
+        if (pa1 == DuckDBError || pa2 == DuckDBError) {
+            duckdb_destroy_aggregate_function_set(&pset);
+            throw std::runtime_error("gpu_upload_pair overload set assembly failed");
+        }
+        duckdb_state pst = duckdb_register_aggregate_function_set(con, pset);
+        duckdb_destroy_aggregate_function_set(&pset);
         if (pst == DuckDBError) {
             throw std::runtime_error("gpu_upload_pair registration failed");
         }
@@ -857,10 +959,34 @@ void register_gpu_resident(duckdb_connection con) {
         last_stats_exec, DUCKDB_TYPE_VARCHAR, 0);
     register_scalar(con, "gpu_build_info",
         build_info_exec, DUCKDB_TYPE_VARCHAR, 0);
+    // Fused resident joins, full kind spectrum. RIGHT/FULL OUTER compose:
+    // probe-payload sum equals INNER/LEFT respectively, and the extra
+    // COUNT(*) term is gpu_anti_join_count_resident with sides swapped.
+    using JK = gpudb::JoinKind;
     register_scalar(con, "gpu_join_sum_resident",
-        join_sum_resident_exec</*count_only=*/false>, DUCKDB_TYPE_BIGINT, 3);
+        join_sum_resident_exec<JK::INNER, false>, DUCKDB_TYPE_BIGINT, 3);
     register_scalar(con, "gpu_join_count_resident",
-        join_sum_resident_exec</*count_only=*/true>, DUCKDB_TYPE_BIGINT, 2);
+        join_sum_resident_exec<JK::INNER, true>, DUCKDB_TYPE_BIGINT, 2);
+    register_scalar(con, "gpu_join_sum_resident_f64",
+        join_sum_resident_f64_exec<JK::INNER>, DUCKDB_TYPE_DOUBLE, 3);
+    register_scalar(con, "gpu_left_join_sum_resident",
+        join_sum_resident_exec<JK::LEFT, false>, DUCKDB_TYPE_BIGINT, 3);
+    register_scalar(con, "gpu_left_join_count_resident",
+        join_sum_resident_exec<JK::LEFT, true>, DUCKDB_TYPE_BIGINT, 2);
+    register_scalar(con, "gpu_left_join_sum_resident_f64",
+        join_sum_resident_f64_exec<JK::LEFT>, DUCKDB_TYPE_DOUBLE, 3);
+    register_scalar(con, "gpu_semi_join_sum_resident",
+        join_sum_resident_exec<JK::SEMI, false>, DUCKDB_TYPE_BIGINT, 3);
+    register_scalar(con, "gpu_semi_join_count_resident",
+        join_sum_resident_exec<JK::SEMI, true>, DUCKDB_TYPE_BIGINT, 2);
+    register_scalar(con, "gpu_semi_join_sum_resident_f64",
+        join_sum_resident_f64_exec<JK::SEMI>, DUCKDB_TYPE_DOUBLE, 3);
+    register_scalar(con, "gpu_anti_join_sum_resident",
+        join_sum_resident_exec<JK::ANTI, false>, DUCKDB_TYPE_BIGINT, 3);
+    register_scalar(con, "gpu_anti_join_count_resident",
+        join_sum_resident_exec<JK::ANTI, true>, DUCKDB_TYPE_BIGINT, 2);
+    register_scalar(con, "gpu_anti_join_sum_resident_f64",
+        join_sum_resident_f64_exec<JK::ANTI>, DUCKDB_TYPE_DOUBLE, 3);
 }
 
 } // namespace gpudb_ext

--- a/src/extension/gpu_resident.cpp
+++ b/src/extension/gpu_resident.cpp
@@ -872,6 +872,20 @@ void register_scalar(duckdb_connection con, const char* name,
 
 } // namespace
 
+// Bridge for gpu_join_extension.cpp (declared in gpu_join_extension.hpp):
+// expose the registry, aggregator, and stats line under the same mutex the
+// scalar functions use.
+std::mutex& resident_mutex() { return g().mu; }
+
+gpudb::ResidentColumn* find_resident_column(const std::string& name) {
+    auto it = g().registry.find(name);
+    return it == g().registry.end() ? nullptr : it->second.get();
+}
+
+gpudb::HybridAggregator& resident_aggregator() { return agg_locked(); }
+
+void resident_set_last_stats(const std::string& s) { g().last_stats = s; }
+
 void register_gpu_resident(duckdb_connection con) {
     // gpu_upload overload set: (VARCHAR, BIGINT) and (VARCHAR, DOUBLE).
     duckdb_aggregate_function_set set = duckdb_create_aggregate_function_set("gpu_upload");

--- a/src/extension/gpu_sum_extension.cpp
+++ b/src/extension/gpu_sum_extension.cpp
@@ -74,6 +74,7 @@
 //   partitions states across threads.
 
 #include "gpu_sum_extension.hpp"
+#include "gpu_join_extension.hpp"
 #include "gpu_backend.hpp"
 
 // gpu_sum_extension.hpp already pulled in the right DuckDB header:
@@ -425,6 +426,7 @@ void register_gpu_sum(duckdb_connection con) {
     register_set<OpMinI64, OpMinF64>(con, "gpu_min");
     register_set<OpMaxI64, OpMaxF64>(con, "gpu_max");
     register_gpu_resident(con);
+    register_gpu_join(con);
     std::fprintf(stderr,
         "[gpudb] registered gpu_sum / gpu_min / gpu_max streaming aggregates "
         "+ resident-column functions (gpu_upload, gpu_*_resident) (backend=%s)\n",

--- a/src/include/gpu_backend.hpp
+++ b/src/include/gpu_backend.hpp
@@ -177,11 +177,9 @@ struct WindowResult {
 //
 // Backend implementation strategy varies:
 //   - CPU:   std::unordered_map<int64,int64> on the build side.
-//   - CUDA:  open-addressing hash table with atomicCAS<int64> (in flight on
-//            feat/cuda-hashjoin).
-//   - Metal: SORT-MERGE join (Apple Silicon GPUs lack 64-bit atomic CAS, so
-//            the CUDA approach cannot be mirrored — see
-//            src/backends/metal/metal_hashjoin.mm header for details).
+//   - CUDA:  open-addressing hash table with atomicCAS<int64>.
+//   - Metal: slot-lock open-addressing hash (32-bit CAS); sort-merge fallback
+//            when build exceeds table capacity (see metal_hashjoin.mm).
 struct JoinResult {
     std::vector<std::int64_t> probe_indices;   // matched probe-side row indices
     std::vector<std::int64_t> build_indices;   // matched build-side row indices
@@ -257,6 +255,9 @@ enum class DispatchReason : std::uint8_t {
     GroupBy_HighCard_GpuWins = 11, // expected_groups >= n / 10 → high cardinality regime
     GroupBy_Borderline_GpuTry= 12, // mid regime: try GPU but flag for tuning
     GroupBy_HugeN_CpuWins    = 13, // n above bitonic O(N log²N) crossover
+    // Hash join reasons
+    Join_SmallN_CpuWins      = 20, // build+probe too small for GPU launch
+    Join_LargeProbe_GpuWins  = 21, // probe-heavy FK join → GPU hash path
 };
 
 [[nodiscard]] const char* to_string(DispatchReason r) noexcept;
@@ -291,9 +292,16 @@ public:
     [[nodiscard]] virtual Backend gpu_backend() const noexcept = 0;
 };
 
+class HybridHashJoinProbe : public HashJoinProbe {
+public:
+    [[nodiscard]] virtual const DispatchDecision& last_decision() const noexcept = 0;
+    [[nodiscard]] virtual Backend gpu_backend() const noexcept = 0;
+};
+
 // Factories. Each internally constructs a CPU aggregator AND a GPU
 // aggregator (GPU = default_backend() if available, else CPU=fallback).
 std::unique_ptr<HybridAggregator>        make_hybrid_aggregator();
 std::unique_ptr<HybridGroupByAggregator> make_hybrid_groupby_aggregator();
+std::unique_ptr<HybridHashJoinProbe>     make_hybrid_hashjoin_probe();
 
 } // namespace gpudb

--- a/src/include/gpu_backend.hpp
+++ b/src/include/gpu_backend.hpp
@@ -96,6 +96,22 @@ struct JoinAggResult {
     double       transfer_ms;   // host<->device transfer time (0 for CPU/Metal-UMA/resident)
 };
 
+// Returned by Aggregator::join_rows_resident — the row-returning join.
+// One entry per OUTPUT ROW of the kind's SQL query, in unspecified order:
+//   INNER: (probe_idx, build_idx) per matching pair (full multiplicity)
+//   LEFT:  matching pairs, plus (probe_idx, -1) for unmatched probe rows
+//   SEMI:  (probe_idx, -1) for each probe row with >= 1 match
+//   ANTI:  (probe_idx, -1) for each probe row with no match
+// build_idx -1 encodes SQL NULL. Indices refer to the ORIGINAL upload order
+// of each resident column.
+struct JoinRowsResult {
+    std::vector<std::int64_t> probe_idx;
+    std::vector<std::int64_t> build_idx;   // -1 = NULL (no build match)
+    std::size_t rows_probe  = 0;
+    std::size_t rows_build  = 0;
+    double wall_ms = 0.0, kernel_ms = 0.0, transfer_ms = 0.0;
+};
+
 // Opaque handle to a column resident in backend memory.
 // Owns the storage; destruction releases device memory.
 // Created by Aggregator::upload_*; must only be used with the SAME aggregator
@@ -178,6 +194,15 @@ public:
                                                 const ResidentColumn& payload,
                                                 const ResidentColumn& build_keys,
                                                 JoinKind kind = JoinKind::INNER);
+
+    // Row-returning resident join (see JoinRowsResult for per-kind output).
+    // max_rows caps the materialized output; exceeding it throws a clean
+    // error naming the actual row count (never silently truncates). Same
+    // default-throwing / default-arg rules as the fused variants above.
+    virtual JoinRowsResult join_rows_resident(const ResidentColumn& probe_keys,
+                                              const ResidentColumn& build_keys,
+                                              JoinKind kind,
+                                              std::size_t max_rows);
 };
 
 // Factory. Throws std::runtime_error if the requested backend wasn't compiled

--- a/src/include/gpu_backend.hpp
+++ b/src/include/gpu_backend.hpp
@@ -52,10 +52,22 @@ struct AggAllResult {
     double       transfer_ms;   // host<->device transfer time (0 for CPU/Metal-UMA/resident)
 };
 
-// Returned by Aggregator::join_sum_resident_i64 — fused inner equi-join +
-// SUM over resident columns. Multiplicity-aware: a probe row matching m
-// build rows contributes payload*m to sum and m to matched (standard SQL
-// inner-join semantics for SELECT sum(p.payload) FROM probe p JOIN build b
+// Join flavor for the fused resident join-aggregates. With a PROBE-SIDE
+// payload, every SQL join type reduces to one formula: each probe row's
+// contribution multiplier c is a function of its build-side match count m —
+//   INNER c = m          (payload repeated per matching build row)
+//   LEFT  c = max(m, 1)  (unmatched probe rows keep their payload once)
+//   SEMI  c = (m > 0)    (EXISTS: payload once if any match)
+//   ANTI  c = (m == 0)   (NOT EXISTS: payload once if no match)
+// sum += c * payload[i]; matched += c. RIGHT and FULL OUTER compose from
+// these: their probe-payload sum equals INNER's / LEFT's respectively
+// (unmatched build rows contribute NULL payload), and the extra COUNT(*)
+// term (# unmatched build rows) is an ANTI count with probe/build swapped.
+enum class JoinKind : std::uint8_t { INNER = 0, LEFT = 1, SEMI = 2, ANTI = 3 };
+
+// Returned by Aggregator::join_sum_resident_* — fused equi-join + SUM over
+// resident columns. Multiplicity-aware per the JoinKind table above
+// (INNER matches SELECT sum(p.payload) FROM probe p JOIN build b
 // ON p.key = b.key).
 // Cross-backend binding rules (CPU is the executable reference):
 //   - matched = TOTAL matched pairs, i.e. the join's COUNT(*) — directly
@@ -66,7 +78,8 @@ struct AggAllResult {
 //   - matched == 0 means "no joined rows": the SQL layer must surface SUM as
 //     NULL in that case (sum is 0 here but carries no meaning).
 struct JoinAggResult {
-    std::int64_t sum;           // Σ payload[i] * multiplicity(probe_keys[i])
+    std::int64_t sum;           // Σ payload[i] * multiplicity(probe_keys[i]) (i64 op)
+    double       sum_f64;       // same, for the f64-payload op (0.0 otherwise)
     std::int64_t matched;       // Σ multiplicity(probe_keys[i]) (= joined COUNT(*))
     std::size_t  rows_probe;    // probe-side row count
     std::size_t  rows_build;    // build-side row count
@@ -140,7 +153,20 @@ public:
     // hybrid planner catches the throw and falls back to CPU.
     virtual JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
                                                 const ResidentColumn& payload,
-                                                const ResidentColumn& build_keys);
+                                                const ResidentColumn& build_keys,
+                                                JoinKind kind = JoinKind::INNER);
+
+    // f64-payload flavor: keys are still I64 (join keys are integers in
+    // practice); payload is an F64 resident column, result in sum_f64.
+    // Multiplicity contributes as m * payload[i] in double arithmetic; the
+    // accumulation order is backend-defined, so cross-engine comparisons use
+    // a relative tolerance, not equality (same caveat as sum_resident_f64).
+    // On Metal this runs as a parallel host pass over UMA buffers (no fp64
+    // in MSL); CUDA can run it natively on device.
+    virtual JoinAggResult join_sum_resident_f64(const ResidentColumn& probe_keys,
+                                                const ResidentColumn& payload,
+                                                const ResidentColumn& build_keys,
+                                                JoinKind kind = JoinKind::INNER);
 };
 
 // Factory. Throws std::runtime_error if the requested backend wasn't compiled

--- a/src/include/gpu_backend.hpp
+++ b/src/include/gpu_backend.hpp
@@ -52,6 +52,29 @@ struct AggAllResult {
     double       transfer_ms;   // host<->device transfer time (0 for CPU/Metal-UMA/resident)
 };
 
+// Returned by Aggregator::join_sum_resident_i64 — fused inner equi-join +
+// SUM over resident columns. Multiplicity-aware: a probe row matching m
+// build rows contributes payload*m to sum and m to matched (standard SQL
+// inner-join semantics for SELECT sum(p.payload) FROM probe p JOIN build b
+// ON p.key = b.key).
+// Cross-backend binding rules (CPU is the executable reference):
+//   - matched = TOTAL matched pairs, i.e. the join's COUNT(*) — directly
+//     checkable against native.
+//   - Both the per-row multiply (m * payload[i]) and the accumulate are
+//     performed in uint64 two's-complement arithmetic (signed overflow is UB;
+//     unsigned wrap is the defined behavior, same rule as sum_i64).
+//   - matched == 0 means "no joined rows": the SQL layer must surface SUM as
+//     NULL in that case (sum is 0 here but carries no meaning).
+struct JoinAggResult {
+    std::int64_t sum;           // Σ payload[i] * multiplicity(probe_keys[i])
+    std::int64_t matched;       // Σ multiplicity(probe_keys[i]) (= joined COUNT(*))
+    std::size_t  rows_probe;    // probe-side row count
+    std::size_t  rows_build;    // build-side row count
+    double       wall_ms;       // total wall time
+    double       kernel_ms;     // GPU kernel time only (0 for CPU)
+    double       transfer_ms;   // host<->device transfer time (0 for CPU/Metal-UMA/resident)
+};
+
 // Opaque handle to a column resident in backend memory.
 // Owns the storage; destruction releases device memory.
 // Created by Aggregator::upload_*; must only be used with the SAME aggregator
@@ -99,6 +122,25 @@ public:
     // when more aggregates are fused.
     virtual AggAllResult agg_all_i64(const std::int64_t* data, std::size_t n) = 0;
     virtual AggAllResult agg_all_resident_i64(const ResidentColumn&) = 0;
+
+    // ---- Fused resident join-aggregate (v0.5) ----
+    // Inner equi-join with full build-side multiplicity, fused with SUM.
+    // payload is probe-side and must have the same row count as probe_keys
+    // (throws std::runtime_error otherwise, as do dtype/backend-tag
+    // mismatches — same error style as the other resident ops). Resident
+    // columns carry no NULLs, so no NULL-key semantics apply here.
+    // Backends may cache derived build-side structures (sorted copy, hash
+    // table) privately on the ResidentColumn; such caches die with the
+    // column (gpu_drop_resident) and do NOT count against the host-side
+    // GPUDB_UPLOAD_POOL_MAX_MB cap; a device-OOM while building one must
+    // surface as a clean std::runtime_error.
+    // Default implementation throws: backends opt in by overriding (CPU and
+    // Metal implement it; CUDA pending — keeping this non-pure means the
+    // CUDA backend builds unchanged until its implementation lands). The
+    // hybrid planner catches the throw and falls back to CPU.
+    virtual JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
+                                                const ResidentColumn& payload,
+                                                const ResidentColumn& build_keys);
 };
 
 // Factory. Throws std::runtime_error if the requested backend wasn't compiled

--- a/src/include/gpu_backend.hpp
+++ b/src/include/gpu_backend.hpp
@@ -77,6 +77,14 @@ enum class JoinKind : std::uint8_t { INNER = 0, LEFT = 1, SEMI = 2, ANTI = 3 };
 //     unsigned wrap is the defined behavior, same rule as sum_i64).
 //   - matched == 0 means "no joined rows": the SQL layer must surface SUM as
 //     NULL in that case (sum is 0 here but carries no meaning).
+//   - `matched` counts the CONTRIBUTING rows/pairs for the given JoinKind —
+//     the result cardinality of that kind's SQL query (for ANTI that is the
+//     number of NON-matching probe rows; do not read it as "pairs").
+//   - f64 sums are tolerance-checked across backends (relative epsilon,
+//     ~1e-9 on warm data), never bit-compared: accumulation order is
+//     backend-defined (CUDA atomic/tree reductions are nondeterministic
+//     run-to-run; Metal streams sequentially). i64 wrap arithmetic is exact
+//     and must bit-match everywhere.
 struct JoinAggResult {
     std::int64_t sum;           // Σ payload[i] * multiplicity(probe_keys[i]) (i64 op)
     double       sum_f64;       // same, for the f64-payload op (0.0 otherwise)
@@ -151,6 +159,9 @@ public:
     // Metal implement it; CUDA pending — keeping this non-pure means the
     // CUDA backend builds unchanged until its implementation lands). The
     // hybrid planner catches the throw and falls back to CPU.
+    // NOTE: the `kind = INNER` default argument binds by STATIC type in C++;
+    // overrides must not declare a different default (callers always go
+    // through this base interface, so the base default is the only one used).
     virtual JoinAggResult join_sum_resident_i64(const ResidentColumn& probe_keys,
                                                 const ResidentColumn& payload,
                                                 const ResidentColumn& build_keys,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(test_gpudb cpp/test_aggregator.cpp)
+add_executable(test_gpudb cpp/test_aggregator.cpp cpp/test_hashjoin.cpp)
 target_link_libraries(test_gpudb PRIVATE gpudb)
 add_test(NAME test_gpudb COMMAND test_gpudb)

--- a/test/cpp/test_aggregator.cpp
+++ b/test/cpp/test_aggregator.cpp
@@ -10,6 +10,10 @@
 #include <random>
 #include <vector>
 
+void test_hashjoin();
+int test_hashjoin_failures();
+int test_hashjoin_total();
+
 namespace {
 
 int failures = 0;
@@ -351,6 +355,10 @@ int main() {
 
     test_hybrid_aggregator();
     test_hybrid_groupby();
+    test_hashjoin();
+
+    failures += test_hashjoin_failures();
+    total += test_hashjoin_total();
 
     std::printf("\n%d / %d checks passed\n", total - failures, total);
     return failures == 0 ? 0 : 1;

--- a/test/cpp/test_hashjoin.cpp
+++ b/test/cpp/test_hashjoin.cpp
@@ -1,0 +1,232 @@
+// Hash join unit tests — every backend verified against CPU reference.
+
+#include "gpu_backend.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+int total = 0;
+
+#define EXPECT(cond)                                                                               \
+    do {                                                                                           \
+        ++total;                                                                                   \
+        if (!(cond)) {                                                                             \
+            ++failures;                                                                            \
+            std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);                   \
+        }                                                                                          \
+    } while (0)
+
+#define EXPECT_EQ(a, b)                                                                            \
+    do {                                                                                           \
+        ++total;                                                                                   \
+        auto _a = (a);                                                                             \
+        auto _b = (b);                                                                             \
+        if (!(_a == _b)) {                                                                         \
+            ++failures;                                                                            \
+            std::fprintf(stderr, "FAIL %s:%d  %s == %s  (got %lld vs %lld)\n", __FILE__, __LINE__, \
+                         #a, #b, static_cast<long long>(_a), static_cast<long long>(_b));        \
+        }                                                                                          \
+    } while (0)
+
+using Pair = std::pair<std::int64_t, std::int64_t>;
+
+std::vector<Pair> canonical_pairs(const gpudb::JoinResult& r) {
+    std::vector<Pair> out;
+    out.reserve(r.matched);
+    for (std::size_t i = 0; i < r.matched; ++i) {
+        out.emplace_back(r.probe_indices[i], r.build_indices[i]);
+    }
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
+bool join_equals(const gpudb::JoinResult& a, const gpudb::JoinResult& b) {
+    if (a.matched != b.matched) return false;
+    return canonical_pairs(a) == canonical_pairs(b);
+}
+
+gpudb::JoinResult cpu_reference(const std::int64_t* build_keys, std::size_t n_build,
+                                const std::int64_t* probe_keys, std::size_t n_probe) {
+    auto cpu = gpudb::make_hashjoin_probe(gpudb::Backend::CPU);
+    return cpu->inner_join_i64(build_keys, n_build, probe_keys, n_probe);
+}
+
+void expect_join_eq(const gpudb::JoinResult& got, const gpudb::JoinResult& ref, const char* label) {
+    if (!join_equals(got, ref)) {
+        ++failures;
+        ++total;
+        std::fprintf(stderr, "FAIL join mismatch: %s (matched %zu vs %zu)\n", label, got.matched,
+                     ref.matched);
+        return;
+    }
+    ++total;
+}
+
+void test_hashjoin_backend(gpudb::Backend b) {
+    std::printf("\n--- testing hash join backend: %s ---\n", gpudb::to_string(b));
+    std::unique_ptr<gpudb::HashJoinProbe> hj;
+    try {
+        hj = gpudb::make_hashjoin_probe(b);
+    } catch (const std::exception& e) {
+        std::printf("  skipped (%s)\n", e.what());
+        return;
+    }
+    std::printf("  device: %s\n", hj->device_name().c_str());
+
+    // Empty build
+    {
+        std::vector<std::int64_t> probe{1, 2, 3};
+        auto ref = cpu_reference(nullptr, 0, probe.data(), probe.size());
+        auto got = hj->inner_join_i64(nullptr, 0, probe.data(), probe.size());
+        expect_join_eq(got, ref, "empty build");
+        EXPECT_EQ(got.matched, std::size_t{0});
+    }
+
+    // Empty probe
+    {
+        std::vector<std::int64_t> build{10, 20};
+        auto ref = cpu_reference(build.data(), build.size(), nullptr, 0);
+        auto got = hj->inner_join_i64(build.data(), build.size(), nullptr, 0);
+        expect_join_eq(got, ref, "empty probe");
+        EXPECT_EQ(got.matched, std::size_t{0});
+    }
+
+    // Single match
+    {
+        std::vector<std::int64_t> build{42};
+        std::vector<std::int64_t> probe{99, 42, 7};
+        auto ref = cpu_reference(build.data(), build.size(), probe.data(), probe.size());
+        auto got = hj->inner_join_i64(build.data(), build.size(), probe.data(), probe.size());
+        expect_join_eq(got, ref, "single match");
+        EXPECT_EQ(got.matched, std::size_t{1});
+        EXPECT_EQ(got.probe_indices[0], std::int64_t{1});
+        EXPECT_EQ(got.build_indices[0], std::int64_t{0});
+    }
+
+    // No matches
+    {
+        std::vector<std::int64_t> build{1, 2, 3};
+        std::vector<std::int64_t> probe{4, 5, 6};
+        auto ref = cpu_reference(build.data(), build.size(), probe.data(), probe.size());
+        auto got = hj->inner_join_i64(build.data(), build.size(), probe.data(), probe.size());
+        expect_join_eq(got, ref, "no match");
+        EXPECT_EQ(got.matched, std::size_t{0});
+    }
+
+    // All probe rows match (FK into build domain)
+    {
+        std::vector<std::int64_t> build{10, 20, 30, 40, 50};
+        std::vector<std::int64_t> probe{10, 20, 30, 40, 50};
+        auto ref = cpu_reference(build.data(), build.size(), probe.data(), probe.size());
+        auto got = hj->inner_join_i64(build.data(), build.size(), probe.data(), probe.size());
+        expect_join_eq(got, ref, "all match");
+        EXPECT_EQ(got.matched, probe.size());
+    }
+
+    // Duplicate build keys: first build row wins (v1 contract)
+    {
+        std::vector<std::int64_t> build{7, 7, 7};
+        std::vector<std::int64_t> probe{7};
+        auto ref = cpu_reference(build.data(), build.size(), probe.data(), probe.size());
+        auto got = hj->inner_join_i64(build.data(), build.size(), probe.data(), probe.size());
+        expect_join_eq(got, ref, "duplicate build keys");
+        EXPECT_EQ(got.matched, std::size_t{1});
+        EXPECT_EQ(got.build_indices[0], std::int64_t{0});
+    }
+
+    // Negative keys
+    {
+        std::vector<std::int64_t> build{-5, 0, 5};
+        std::vector<std::int64_t> probe{-5, 0, 99, 5};
+        auto ref = cpu_reference(build.data(), build.size(), probe.data(), probe.size());
+        auto got = hj->inner_join_i64(build.data(), build.size(), probe.data(), probe.size());
+        expect_join_eq(got, ref, "negative keys");
+        EXPECT_EQ(got.matched, std::size_t{3});
+    }
+
+    // Medium random FK workload
+    {
+        const std::size_t n_build = 50'000;
+        const std::size_t n_probe = 200'000;
+        std::vector<std::int64_t> build(n_build);
+        for (std::size_t j = 0; j < n_build; ++j) {
+            build[j] = static_cast<std::int64_t>(j * 17 + 3);
+        }
+        std::mt19937_64 rng(0x4A01BEEFULL);
+        std::uniform_int_distribution<std::size_t> pick(0, n_build - 1);
+        std::vector<std::int64_t> probe(n_probe);
+        for (auto& p : probe) {
+            p = build[pick(rng)];
+        }
+        // Inject some non-matching probes
+        probe[0] = -999999;
+        probe[1] = 999999999;
+
+        auto ref = cpu_reference(build.data(), n_build, probe.data(), n_probe);
+        auto got = hj->inner_join_i64(build.data(), n_build, probe.data(), n_probe);
+        expect_join_eq(got, ref, "random 50k×200k");
+        EXPECT_EQ(got.matched, ref.matched);
+        std::printf("  random 50k×200k: matched=%zu wall=%.3f ms kernel=%.3f ms\n", got.matched,
+                    got.wall_ms, got.kernel_ms);
+    }
+
+    // GPU backends must execute kernels (not CPU fallback)
+    if (b == gpudb::Backend::METAL || b == gpudb::Backend::CUDA) {
+        const std::size_t n_build = 10'000;
+        const std::size_t n_probe = 50'000;
+        std::vector<std::int64_t> build(n_build);
+        for (std::size_t j = 0; j < n_build; ++j) build[j] = static_cast<std::int64_t>(j);
+        std::vector<std::int64_t> probe(n_probe);
+        for (std::size_t i = 0; i < n_probe; ++i) probe[i] = static_cast<std::int64_t>(i % n_build);
+
+        auto got = hj->inner_join_i64(build.data(), n_build, probe.data(), n_probe);
+        EXPECT(got.kernel_ms > 0.0);
+        std::printf("  gpu kernel check: kernel_ms=%.3f\n", got.kernel_ms);
+    }
+}
+
+void test_hybrid_hashjoin() {
+    std::printf("\n--- testing hybrid hash join ---\n");
+    auto ref_cpu = gpudb::make_hashjoin_probe(gpudb::Backend::CPU);
+    auto hybrid = gpudb::make_hybrid_hashjoin_probe();
+    std::printf("  device: %s\n", hybrid->device_name().c_str());
+
+    const std::size_t n_build = 100'000;
+    const std::size_t n_probe = 500'000;
+    std::vector<std::int64_t> build(n_build);
+    for (std::size_t j = 0; j < n_build; ++j) build[j] = static_cast<std::int64_t>(j * 17 + 3);
+    std::vector<std::int64_t> probe(n_probe);
+    for (std::size_t i = 0; i < n_probe; ++i) probe[i] = build[i % n_build];
+
+    auto ref = ref_cpu->inner_join_i64(build.data(), n_build, probe.data(), n_probe);
+    auto got = hybrid->inner_join_i64(build.data(), n_build, probe.data(), n_probe);
+    expect_join_eq(got, ref, "hybrid 100k×500k");
+    EXPECT(got.kernel_ms > 0.0);
+    std::printf("  hybrid 100k×500k: matched=%zu dispatch=%s wall=%.3f ms\n",
+                got.matched, gpudb::to_string(hybrid->last_decision().chosen), got.wall_ms);
+}
+
+} // namespace
+
+void test_hashjoin() {
+    test_hashjoin_backend(gpudb::Backend::CPU);
+
+#if GPUDB_HAVE_CUDA
+    test_hashjoin_backend(gpudb::Backend::CUDA);
+#endif
+#if GPUDB_HAVE_METAL
+    test_hashjoin_backend(gpudb::Backend::METAL);
+#endif
+
+    test_hybrid_hashjoin();
+}
+
+int test_hashjoin_failures() { return failures; }
+int test_hashjoin_total() { return total; }

--- a/test/cpp/test_hashjoin.cpp
+++ b/test/cpp/test_hashjoin.cpp
@@ -177,6 +177,38 @@ void test_hashjoin_backend(gpudb::Backend b) {
                     got.wall_ms, got.kernel_ms);
     }
 
+    // Duplicate-heavy build (97 distinct keys x ~2k rows each): every probe
+    // must map to the SMALLEST build index of its key (first build row wins),
+    // whatever order GPU threads inserted in. Regression for the lost-insert /
+    // wrong-index races in the slot-lock tables (CI paravirtual GPU, 2026-08).
+    {
+        const std::size_t n_build = 200'000;
+        const std::size_t n_probe = 100'000;
+        std::vector<std::int64_t> build(n_build);
+        for (std::size_t j = 0; j < n_build; ++j) build[j] = static_cast<std::int64_t>((j * 7919) % 97);
+        std::vector<std::int64_t> probe(n_probe);
+        for (std::size_t i = 0; i < n_probe; ++i) probe[i] = static_cast<std::int64_t>(i % 120); // 97..119 miss
+        auto ref = cpu_reference(build.data(), n_build, probe.data(), n_probe);
+        auto got = hj->inner_join_i64(build.data(), n_build, probe.data(), n_probe);
+        expect_join_eq(got, ref, "dup-heavy 97 keys x 200k build");
+        EXPECT_EQ(got.matched, ref.matched);
+    }
+
+    // Large build (above the global/partitioned switch) with few distinct keys:
+    // the per-partition table must collapse duplicates instead of overflowing.
+    {
+        const std::size_t n_build = 700'000;
+        const std::size_t n_probe = 50'000;
+        std::vector<std::int64_t> build(n_build);
+        for (std::size_t j = 0; j < n_build; ++j) build[j] = static_cast<std::int64_t>(j % 5);
+        std::vector<std::int64_t> probe(n_probe);
+        for (std::size_t i = 0; i < n_probe; ++i) probe[i] = static_cast<std::int64_t>(i % 8);
+        auto ref = cpu_reference(build.data(), n_build, probe.data(), n_probe);
+        auto got = hj->inner_join_i64(build.data(), n_build, probe.data(), n_probe);
+        expect_join_eq(got, ref, "5 keys x 700k build (partitioned path)");
+        EXPECT_EQ(got.matched, ref.matched);
+    }
+
     // GPU backends must execute kernels (not CPU fallback)
     if (b == gpudb::Backend::METAL || b == gpudb::Backend::CUDA) {
         const std::size_t n_build = 10'000;
@@ -208,7 +240,11 @@ void test_hybrid_hashjoin() {
     auto ref = ref_cpu->inner_join_i64(build.data(), n_build, probe.data(), n_probe);
     auto got = hybrid->inner_join_i64(build.data(), n_build, probe.data(), n_probe);
     expect_join_eq(got, ref, "hybrid 100k×500k");
-    EXPECT(got.kernel_ms > 0.0);
+    // kernel_ms is only meaningful when the planner dispatched to a GPU; on a
+    // CPU-only build (CI linux job) the hybrid probe runs the CPU path (0.0).
+    if (hybrid->last_decision().chosen != gpudb::Backend::CPU) {
+        EXPECT(got.kernel_ms > 0.0);
+    }
     std::printf("  hybrid 100k×500k: matched=%zu dispatch=%s wall=%.3f ms\n",
                 got.matched, gpudb::to_string(hybrid->last_decision().chosen), got.wall_ms);
 }

--- a/test/sql/gpu_join.test
+++ b/test/sql/gpu_join.test
@@ -1,0 +1,19 @@
+# gpu_inner_join SQL test — inner equi-join via extension table function.
+#
+# Requires the loadable extension (LOAD gpudb). Run via scripts/run_sql_tests.sh
+# when GPUDB_BUILD_EXT=ON.
+
+-- Simple list join
+SELECT probe_idx, build_idx
+FROM gpu_inner_join([10, 20, 30], [20, 40, 99])
+ORDER BY probe_idx;
+-- expect: 0  1
+-- expect: 1  2
+
+-- No matches
+SELECT count(*)::BIGINT FROM gpu_inner_join([1, 2], [3, 4]);
+-- expect: 0
+
+-- All match
+SELECT count(*)::BIGINT FROM gpu_inner_join([5, 6, 7], [5, 6, 7]);
+-- expect: 3

--- a/test/sql/gpu_join.test
+++ b/test/sql/gpu_join.test
@@ -3,12 +3,18 @@
 # Requires the loadable extension (LOAD gpudb). Run via scripts/run_sql_tests.sh
 # when GPUDB_BUILD_EXT=ON.
 
--- Simple list join
+-- Simple list join: build=[10,20,30], probe=[20,40,99] — only probe[0]=20
+-- matches (build index 1).
 SELECT probe_idx, build_idx
 FROM gpu_inner_join([10, 20, 30], [20, 40, 99])
 ORDER BY probe_idx;
 -- expect: 0  1
--- expect: 1  2
+
+-- Duplicate build keys: first-match semantics (v1 interface contract) —
+-- probe[0]=7 matches build index 0, not both duplicates.
+SELECT probe_idx, build_idx
+FROM gpu_inner_join([7, 7], [7]);
+-- expect: 0  0
 
 -- No matches
 SELECT count(*)::BIGINT FROM gpu_inner_join([1, 2], [3, 4]);

--- a/test/sql/gpu_join_resident.test
+++ b/test/sql/gpu_join_resident.test
@@ -1,0 +1,102 @@
+# gpu_join_resident SQL test — fused resident joins (v0.5.0):
+#   gpu_join_sum_resident / gpu_join_count_resident / gpu_join_sum_resident_f64
+#   and the left / semi / anti variants, all over gpu_upload_pair'd columns.
+#
+# Same one-statement pattern as gpu_resident.test: the suite runs every query
+# in a fresh gpudb-sql process, so uploads and the join read happen in ONE
+# statement. Every outer query references each upload's count column (u1.n1,
+# u2.n2) — an unreferenced upload subquery is pruned and never runs.
+#
+# Fixture (used by tests 1-8):
+#   probe (k, v) = (1,10) (2,20) (3,30) (2,25)      build (k) = 2, 2, 5
+#   Key 2 appears twice on the build side, so INNER/LEFT carry multiplicity 2.
+#
+# Row-returning gpu_join_rows_resident needs sequential statements (--multi)
+# and is covered by scripts/join_parity_check.sh instead.
+#
+# Run via: ./scripts/run_sql_tests.sh gpu_join_resident
+
+-- 1. INNER sum: matched rows (20+25) x build multiplicity 2 = 90
+SELECT gpu_join_sum_resident('p1.k', 'p1.v', 'b1') AS s, u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p1', k, v) AS n1 FROM (VALUES (1,10),(2,20),(3,30),(2,25)) t(k,v)) u1,
+     (SELECT gpu_upload('b1', k) AS n2 FROM (VALUES (2),(2),(5)) t(k)) u2;
+-- expect: 90  4  3
+
+-- 2. INNER count: 2 probe rows x 2 build rows = 4 joined pairs
+SELECT gpu_join_count_resident('p2.k', 'b2') AS c, u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p2', k, v) AS n1 FROM (VALUES (1,10),(2,20),(3,30),(2,25)) t(k,v)) u1,
+     (SELECT gpu_upload('b2', k) AS n2 FROM (VALUES (2),(2),(5)) t(k)) u2;
+-- expect: 4  4  3
+
+-- 3. LEFT sum: unmatched rows once (10+30) + matched with multiplicity (90) = 130
+SELECT gpu_left_join_sum_resident('p3.k', 'p3.v', 'b3') AS s, u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p3', k, v) AS n1 FROM (VALUES (1,10),(2,20),(3,30),(2,25)) t(k,v)) u1,
+     (SELECT gpu_upload('b3', k) AS n2 FROM (VALUES (2),(2),(5)) t(k)) u2;
+-- expect: 130  4  3
+
+-- 4. LEFT count: 1 + 2 + 1 + 2 = 6 output rows
+SELECT gpu_left_join_count_resident('p4.k', 'b4') AS c, u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p4', k, v) AS n1 FROM (VALUES (1,10),(2,20),(3,30),(2,25)) t(k,v)) u1,
+     (SELECT gpu_upload('b4', k) AS n2 FROM (VALUES (2),(2),(5)) t(k)) u2;
+-- expect: 6  4  3
+
+-- 5. SEMI sum / count: each matching probe row once, regardless of build dups
+SELECT gpu_semi_join_sum_resident('p5.k', 'p5.v', 'b5') AS s,
+       gpu_semi_join_count_resident('p5.k', 'b5') AS c, u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p5', k, v) AS n1 FROM (VALUES (1,10),(2,20),(3,30),(2,25)) t(k,v)) u1,
+     (SELECT gpu_upload('b5', k) AS n2 FROM (VALUES (2),(2),(5)) t(k)) u2;
+-- expect: 45  2  4  3
+
+-- 6. ANTI sum / count: probe rows with no build match (10+30)
+SELECT gpu_anti_join_sum_resident('p6.k', 'p6.v', 'b6') AS s,
+       gpu_anti_join_count_resident('p6.k', 'b6') AS c, u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p6', k, v) AS n1 FROM (VALUES (1,10),(2,20),(3,30),(2,25)) t(k,v)) u1,
+     (SELECT gpu_upload('b6', k) AS n2 FROM (VALUES (2),(2),(5)) t(k)) u2;
+-- expect: 40  2  4  3
+
+-- 7. DOUBLE payload: INNER f64 sum = 90 / 4 = 22.5 (payload uploaded as v/4.0)
+SELECT gpu_join_sum_resident_f64('p7.k', 'p7.v', 'b7') AS s, u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p7', k, (v / 4.0)::DOUBLE) AS n1 FROM (VALUES (1,10),(2,20),(3,30),(2,25)) t(k,v)) u1,
+     (SELECT gpu_upload('b7', k) AS n2 FROM (VALUES (2),(2),(5)) t(k)) u2;
+-- expect: 22.5  4  3
+
+-- 8. No rows join: sum is SQL NULL (like native sum over an empty join), count is 0
+SELECT gpu_join_sum_resident('p8.k', 'p8.v', 'b8') IS NULL AS sum_is_null,
+       gpu_join_count_resident('p8.k', 'b8') AS c, u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p8', k, v) AS n1 FROM (VALUES (1,10),(2,20),(3,30),(2,25)) t(k,v)) u1,
+     (SELECT gpu_upload('b8', k) AS n2 FROM (VALUES (9),(11)) t(k)) u2;
+-- expect: true  0  4  2
+
+-- 9. Parity with native DuckDB, dup keys both sides (100k probe, build keys 0..2 x3)
+SELECT gpu_join_sum_resident('p9.k', 'p9.v', 'b9')
+         IS NOT DISTINCT FROM (SELECT sum(p.v) FROM (SELECT (range % 5)::BIGINT AS k, range::BIGINT AS v FROM range(100000)) p
+                                                  JOIN (SELECT (range % 3)::BIGINT AS k FROM range(9)) b ON p.k = b.k) AS sum_matches,
+       gpu_join_count_resident('p9.k', 'b9')
+         IS NOT DISTINCT FROM (SELECT count(*) FROM (SELECT (range % 5)::BIGINT AS k FROM range(100000)) p
+                                                   JOIN (SELECT (range % 3)::BIGINT AS k FROM range(9)) b ON p.k = b.k) AS count_matches,
+       u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p9', (range % 5)::BIGINT, range::BIGINT) AS n1 FROM range(100000)) u1,
+     (SELECT gpu_upload('b9', (range % 3)::BIGINT) AS n2 FROM range(9)) u2;
+-- expect: true  true  100000  9
+
+-- 10. All four kinds vs native in one statement, negative keys, ~50% match
+SELECT gpu_left_join_sum_resident('p10.k', 'p10.v', 'b10')
+         IS NOT DISTINCT FROM (SELECT sum(p.v) FROM (SELECT (range % 1000 - 500)::BIGINT AS k, (range % 33 - 16)::BIGINT AS v FROM range(20000)) p
+                                                  LEFT JOIN (SELECT (range % 800 - 400)::BIGINT AS k FROM range(5000)) b ON p.k = b.k) AS left_ok,
+       gpu_semi_join_sum_resident('p10.k', 'p10.v', 'b10')
+         IS NOT DISTINCT FROM (SELECT sum(v) FROM (SELECT (range % 1000 - 500)::BIGINT AS k, (range % 33 - 16)::BIGINT AS v FROM range(20000)) p
+                               WHERE EXISTS (SELECT 1 FROM (SELECT (range % 800 - 400)::BIGINT AS k FROM range(5000)) b WHERE b.k = p.k)) AS semi_ok,
+       gpu_anti_join_count_resident('p10.k', 'b10')
+         IS NOT DISTINCT FROM (SELECT count(*) FROM (SELECT (range % 1000 - 500)::BIGINT AS k FROM range(20000)) p
+                               WHERE NOT EXISTS (SELECT 1 FROM (SELECT (range % 800 - 400)::BIGINT AS k FROM range(5000)) b WHERE b.k = p.k)) AS anti_ok,
+       u1.n1, u2.n2
+FROM (SELECT gpu_upload_pair('p10', (range % 1000 - 500)::BIGINT, (range % 33 - 16)::BIGINT) AS n1 FROM range(20000)) u1,
+     (SELECT gpu_upload('b10', (range % 800 - 400)::BIGINT) AS n2 FROM range(5000)) u2;
+-- expect: true  true  true  20000  5000
+
+-- 11. Guardrail: f64 keys are rejected with a clear error (keys must be BIGINT)
+-- expected_fail: gpu_join_*_resident operates on BIGINT resident columns
+SELECT gpu_join_count_resident('p11', 'b11') AS c, u1.n1, u2.n2
+FROM (SELECT gpu_upload('p11', (range / 2.0)::DOUBLE) AS n1 FROM range(10)) u1,
+     (SELECT gpu_upload('b11', range::BIGINT) AS n2 FROM range(10)) u2;
+-- expect: (error)


### PR DESCRIPTION
## v0.5.0 — GPU joins from SQL, on both backends

Fused resident joins: upload key+payload pairs once (`gpu_upload_pair`), then join and reduce in a single GPU pass against a device-cached sorted build side — no join output materialised, `transfer_ms=0.000`. Verified against native DuckDB's hash join end-to-end on TPC-H SF10/SF50, both backends, correctness-gated before any timing counted.

### SQL surface
- `gpu_upload_pair(name, key BIGINT, payload BIGINT|DOUBLE)` → registers `name.k`, `name.v`
- `gpu_join_sum_resident`, `gpu_join_count_resident`, `gpu_join_sum_resident_f64` and the `gpu_left_join_*`, `gpu_semi_join_*`, `gpu_anti_join_*` variants (RIGHT/FULL as documented compositions)
- `gpu_join_rows_resident(probe, build, kind)` table function → `(probe_idx, build_idx)`
- `gpudb-sql --multi` (sequential statements on one connection)

### Results (warm, vs native on the same machine; full tables + methodology in BENCHMARK.md)

| measurement | Metal · M4 Max (native v1.5.2) | CUDA · RTX 4090 Laptop (native v1.5.5; v1.5.2 agrees ±10%) |
|---|---:|---:|
| inner join-sum BIGINT, SF50 (300M ⋈ 75M) | 429 → 36.8 ms, **11.7×** | 998 → 27–37 ms, **27–37×** |
| inner join-sum DOUBLE, SF50 | 363 → 60–72 ms, **5.1–6.0×** | 1090 → 34–38 ms, **~30×** |
| multiplicity direction (orders ⋈ lineitem), SF10 | 84 → 10.4 ms, **8.1×** | 246 → 1.7 ms, **~140×** |
| Q3-style filtered join DOUBLE, SF10 | 68 → 13.7 ms, **5.0×** | 141 → 4.8–5.7 ms, **25–29×** |
| EXISTS semi-join DOUBLE, SF10 | 182 → 8.2 ms, **22.2×** | 640 → 1.70 ms, **~376×** |
| row-returning, 60M pairs, end-to-end | 76 → 65 ms, 1.16× | 232 → 453–481 ms, **native wins** (PCIe device→host copy) |

BIGINT sums bit-equal to native on both backends; DOUBLE within ~1e-11 (1e-9 contract); `matched` equals native `COUNT(*)`. The losing row is kept and explained in BENCHMARK.md and KNOWN_ISSUES.md.

### Implementation
- Metal (`src/backends/metal/`): radix-sorted build with cached permutation, binary-search probe kernel with a JoinKind multiplier (INNER `m`, LEFT `max(m,1)`, SEMI `m>0`, ANTI `m==0`); DOUBLE payloads use "GPU searches, host streams" (no doubles in MSL); row-returning path = lookup kernel + host prefix-sum/fill.
- CUDA (`src/backends/cuda/`): same sorted-build design, `kernels/join_kernel.cu`, fully on-device for both BIGINT and DOUBLE; rows path = count → scan → cap → fill. Also fixes the pre-existing v1 `HashJoinProbe` duplicate-key divergence (first-build-row-wins per the header contract).
- Shared: `gpu_backend.hpp` join entries with the cross-backend contract documented (f64 tolerance, `matched` semantics); hybrid planner pass-through; extension registration; `scripts/join_parity_check.sh`.

### Tests
- Unit: 137/137 (Metal), 118/118 (CUDA), incl. new `test/cpp/test_hashjoin.cpp`.
- `test/sql/gpu_join_resident.test`: 10 deterministic checks across all kinds + DOUBLE + NULL semantics + native parity, 1 asserted guardrail. Full SQL suite 87 pass / 0 fail / 4 expected-fail.
- `scripts/join_parity_check.sh`: 11 adversarial scenarios × 12 checks, native and gpudb in the same statement — 11/11 on both machines.

### Also in this PR
- Colab notebook: requests a T4 runtime automatically, builds with the new `GPUDB_REQUIRE_CUDA=1` (configure fails loudly instead of silently falling back to CPU), asserts the CUDA backend actually ran. Verified on a free T4: 77/77 unit checks on CUDA, `gpudb-groupby-bench` 50M×10M at 458 ms.
- Docs: BENCHMARK.md v0.5.0 section (both backends, honest losing row, reproduction), KNOWN_ISSUES.md join design notes, README.

### Credit
The base of this join stack — the Metal hash join, the hybrid join planner, and the on-device segment reduce — is @lmangani's work from #43, landed here as the first commit (c826058). Thank you, Lorenzo; this release closes #43 via merge.
