### PR TITLE
feat(cuda): resident GROUP BY sum/count and top-k over the cached sort

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -162,6 +162,87 @@ build cache for such key sets — see KNOWN_ISSUES); every row above is from
 the fixed build, and the shape is now a regression scenario in both parity
 harnesses.
 
+### NVIDIA RTX 4090 Laptop (CUDA) — sm_89, 16 GB, driver 580.178.04, CUDA 13.0.88, CUB 3.0.1; native DuckDB CLI v1.5.5
+
+Branch `feat/cuda-groupby-resident`, clean rebuild. Native: DuckDB CLI
+v1.5.5 (d8cdaa33fd) `-readonly`, 20 threads, `.timer on`, each query 5× in
+one process, run 1 discarded, min–max of the rest. gpudb: `gpudb-sql
+--multi`, uploads as earlier statements, `gpu_last_stats()` `wall_ms` of the
+warm calls (min–max of 2–4 calls; the cold first call, which includes the
+one-time key sort, listed separately). The statement time DuckDB itself
+measures is in brackets — it is higher than `wall_ms` because the table
+function's rows still stream through DuckDB's pipeline. Every row
+`backend=CUDA reason=Hot_GpuAlwaysWins`. SF50 used
+`GPUDB_UPLOAD_POOL_MAX_MB=12288`.
+
+| measurement | SF | native (ms) | gpudb warm `wall_ms` [stmt] | `kernel_ms` | `transfer_ms` | cold first call | end-to-end / on-device | result check |
+|---|---|---:|---:|---:|---:|---:|---:|---|
+| (A) sum i64, 15M groups | 10 | 130–137 | 73.4–75.5 [95–99] | 4.5–4.6 | 68.8–71.0 | 117 [139] | **1.8× / 29×** | 15,000,000 groups == native |
+| (A) sum i64, 75M groups | 50 | 631–646 | 362–368 [457–459] | 21.3 | 341–347 | 544 [636] | **1.75× / 30×** | 75,000,000 == native |
+| (B) HAVING sum > 300 | 10 | 195–200 | 74.6–74.8 [102] | 4.5 | 70.0–70.3 | — | **2.6× / 43×** | 624 groups == native |
+| (B) HAVING sum > 300 | 50 | 959–988 | 365–368 [495–498] | 21.3 | 343–346 | — | **2.65× / 45×** | 3,182 == native |
+| (C) sum f64 | 10 | 189–199 | 72.9–74.5 [102] | 4.6 | 68.3–70.0 | 117 | **2.6× / 42×** | sum-of-sums rel-diff 9e-14 |
+| (C) sum f64 | 50 | 942–955 | 364–371 [491–500] | 21.3–21.4 | 342–350 | 553 | **2.6× / 44×** | rel-diff 1.1e-13 |
+| (D) count | 10 | 130–132 | 48.3–50.0 [63–64] | 2.5–2.6 | 45.8–47.4 | — | **2.7× / 51×** | 15,000,000 == native |
+| (D) count | 50 | 635–654 | 235–244 [298–308] | 11.6–11.7 | 223–232 | — | **2.7× / 55×** | 75,000,000 == native |
+| (E) top-10 DESC | 10 | 25–29 | 0.022–0.028 [0.2] | 0.002 | 0.015 | 33.9 (the sort) | cold **0.8× — native wins**; warm ~1000× | values == native |
+| (E) top-10 DESC | 50 | 121–127 | 0.022–0.027 [0.2] | 0.002 | 0.015 | 170.5 (the sort) | cold **0.7× — native wins**; warm ~5000× | values == native |
+| (F) 4 groups, hashed key | 10 | 167–172 | 4.5 [4.8] | 4.4 | 0.02 | 44.4 | **37× / 38×** (see note) | 4 groups, 1,529,738,036 == native |
+| (F) 4 groups, hashed key | 50 | 731–759 | 26.6 [28] | 26.6 | 0.02 | 200 | **28× / 28×** (see note) | 4 groups, 7,650,052,980 == native |
+| (F′) 7 groups, plain BIGINT key (`l_linenumber`) | 10 | 31–32 | 5.9 | 5.9 | 0.02 | 47 | **5.3× / 5.3×** | 1,529,738,036 == native |
+| (F′) 7 groups, plain BIGINT key | 50 | 151–158 | 28.8 | 28.8 | 0.02 | 208 | **5.3× / 5.3×** | 7,650,052,980 == native |
+
+One-time costs, stated plainly: the upload statement is 4.6–4.7 s for a
+pair at SF10 (3.5 s for a single column) and 19.7–24.4 s at SF50 (15.6 s
+single); the first call on a key column pays its sort (≈35 ms at SF10,
+≈170 ms at SF50) once, after which every GROUP BY / top-k on that key skips
+it. Break-even for (A) is ≈80 repeated calls at either scale (≈57 ms saved per call at SF10, ≈275 ms at SF50).
+
+**Where the wall time goes (A–D).** The kernel is 4–5% of the end-to-end
+number; the rest is the result crossing device→host: 15M × 24 B = 360 MB
+at SF10, 1.8 GB at SF50. Measured on this box for a 120 MB result array:
+the PCIe copy itself is ≈12 ms (≈10 GB/s), but first-touch page-faulting of
+the freshly allocated `std::vector` was ≈27 ms — more than the copy.
+Reserving the vector, advising transparent huge pages on the untouched
+range, then resizing brings the fault cost to ≈11 ms (in this branch;
+Linux-only, no-op where THP is disabled). A pinned, double-buffered staging
+path was implemented, measured (no change: the copy was never the
+bottleneck) and dropped. On a unified-memory machine the transfer column is
+what disappears — see the Metal rows. Whether a result this size should
+leave the device at all is the question v0.7's GROUP BY-over-join work will
+answer (the Q18 filter in (B) keeps 624 of 15M groups).
+
+**(E), honestly.** Native DuckDB's top-k is a zonemap-pruned heap; it beats
+the cold call (a full sort of the column) on both scales. Every subsequent
+top-k on that column is a 10-row slice of the cached sort. Sort the column
+once only if you will ask for it more than once.
+
+**(F) is not the losing row it was expected to be.** The hashed key
+expression is evaluated once, at upload; native re-evaluates
+`hash(l_returnflag||l_linestatus)` per row on every query (167 ms at SF10).
+(F′) is the true low-cardinality reference: a plain `BIGINT` key,
+`sum(l_quantity::BIGINT) GROUP BY l_linenumber` (7 groups, measured with the
+standalone driver, columns resident). Still a win with the data resident,
+but 5×, not 30×: with few groups the value gather through the permutation
+is fully random, and there is no result to save. This is where the two
+backends differ — on Metal the same shape loses to native (see the Metal
+rows): the sorted gather of 60M values costs more than DuckDB's hash
+aggregate there. The real losing rows on this machine are the cold (E) call
+and the upload itself.
+
+**Memory budget (SF50).** A resident pair is 4.8 GB; each sorted key column
+adds 16 B/row (4.8 GB) plus ≈16 B/row of transient radix scratch during the
+sort. Two pairs plus one cache fit in 16 GB; the second cache build fails
+with a clean `cudaMalloc join cache (sorted keys) failed: out of memory`
+error (no partial results). The (C) and (F) runs above therefore ran in
+separate processes from (A)/(B)/(D).
+
+**v0.5 (f) revisited.** The same page-fault fix applies to the
+row-returning join: `gpu_join_rows_resident` over 60M pairs at SF10 now
+measures wall 195–215 ms = kernel 13–14 + transfer 182–189 ms (was 356.6 =
+14.8 + 341.8) against the same native 232–272 ms — ≈1.1× instead of 0.5×;
+the v0.5 table above is left as measured on that branch.
+
 ### Reproduce
 
 ```bash
@@ -189,6 +270,8 @@ SELECT count(*) FROM gpu_groupby_sum_resident_f64_having('lf', '>', 400000); -- 
 "
 # native bars, same engine: SELECT count(*) FROM (SELECT l_orderkey, sum(l_quantity::BIGINT) FROM lineitem GROUP BY 1);  etc.
 # SF50: export GPUDB_UPLOAD_POOL_MAX_MB=12288
+# CUDA (build-linux): same statements; (C)/(F) at SF50 in separate processes (memory budget)
+# GPUDB_UPLOAD_POOL_MAX_MB=12288 ./build-linux/bin/gpudb-sql --db data/tpch_bench/tpch_sf50.duckdb --multi < shapes.sql
 ```
 
 ## 2026-08-22 (v0.5.0) — fused resident joins: the GPU beats DuckDB's native hash join end-to-end, on both backends

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -212,10 +212,17 @@ LIMIT 10` over the same GROUP BY.
 With the filter on the device the transfer column is 20–60 µs and the
 statement is the kernel plus DuckDB's fixed per-statement cost: the on-device
 number has become the end-to-end number, which is the point of the feature.
-(B′) and (G) at SF50 are bimodal (42 ↔ 78 ms and 86 ↔ 123 ms; the SM clock
-was sampled between 1665 and 2400 MHz across the runs — laptop boost, same
-pattern as the v0.5 joins); the ranges above span both modes, from a second
-clean-rebuild pass on 07706c4. (G) pays a full radix sort of the aggregates
+(B′) and (G) at SF50 are bimodal (42 ↔ 78 ms and 86 ↔ 123 ms). Clock note
+from the second, clean-rebuild pass on 07706c4 (`nvidia-smi` sampled
+between sets): SM clock 1815 MHz idle, 1665–2400 MHz across the sets
+(laptop boost, not pinned), memory clock 9001 MHz throughout, GPU
+temperature 42 → 51 °C over the pass — the same pattern as the v0.5 joins.
+The ranges above span both modes. Raw lines for (G) SF50 from that pass
+(statement ms, then `gpu_last_stats`): native 1023.1 / 1037.7 / 1025.9;
+gpudb 86.0 / 122.9 / 115.1 with `wall_ms` 78.3 / 115.2 / 107.4, `kernel_ms`
+78.3 / 115.2 / 107.4, `transfer_ms` 0.044 / 0.026 / 0.030, `rows_out=10`,
+`groups=75000000`; SF10: native 221.6 / 215.6 / 211.1, gpudb 22.5 / 24.6 /
+25.7 (`kernel_ms` 18.0 / 20.2 / 21.4). (G) pays a full radix sort of the aggregates
 (15M ≈ 17 ms, 75M ≈ 80–115 ms) before taking the first 10 — a radix-select
 would cut that; measured and shipped as is.
 

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -181,7 +181,7 @@ statement / gpudb statement; on-device = native statement / `kernel_ms`.**
 | measurement | SF | native stmt (ms) | gpudb stmt (ms) | `wall_ms` | `kernel_ms` | `transfer_ms` | cold first stmt | end-to-end / on-device | result check |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
 | (A) sum i64, 15M groups | 10 | 135–138 | 96.4–97.4 | 75–76 | 4.5–4.7 | 70.5–71.7 | 141 | **1.4× / 29×** | 15,000,000 groups == native |
-| (A) sum i64, 75M groups | 50 | 684–693 | 458–464 | 362–368 | 21.4 | 340–347 | 651 | **1.5× / 32×** | 75,000,000 == native |
+| (A) sum i64, 75M groups | 50 | 681–718 | 458–471 | 362–372 | 21.4 | 340–351 | 651–928 | **1.45–1.53× / 32×** | 75,000,000 == native |
 | (B) HAVING sum > 300 | 10 | 204–209 | 105–106 | 76.5–76.8 | 4.5–4.7 | 72.0–72.2 | — | **2.0× / 45×** | 624 groups == native |
 | (B) HAVING sum > 300 | 50 | 991–1013 | 491–505 | 364–371 | 21.3–21.4 | 343–349 | — | **2.0× / 47×** | 3,182 == native |
 | (C) sum f64 | 10 | 206–213 | 104–106 | 76–77 | 4.6 | 71.5–72.4 | 149 | **2.0× / 45×** | sum-of-sums rel-diff 9e-14 |
@@ -204,18 +204,20 @@ LIMIT 10` over the same GROUP BY.
 
 | measurement | SF | native stmt (ms) | gpudb stmt (ms) | `wall_ms` | `kernel_ms` | `transfer_ms` | cold first stmt | end-to-end / on-device | result check |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
-| (B′) HAVING sum > 300 on the device | 10 | 209 | 11.8–12.0 | 8.3–8.4 | 8.2–8.4 | 0.02 | 59 | **17× / 25×** | 624 rows == native |
-| (B′) HAVING sum > 300 on the device | 50 | 1012–1022 | 42–78 | 37–72 | 37–72 | 0.04–0.06 | 228 | **13–24× / 14–27×** | 3,182 rows == native |
+| (B′) HAVING sum > 300 on the device | 10 | 208–210 | 11.7–12.9 | 8.3–10.4 | 8.2–10.4 | 0.02 | 57–59 | **16–18× / 20–25×** | 624 rows == native |
+| (B′) HAVING sum > 300 on the device | 50 | 1012–1039 | 42–78 | 37–72 | 37–72 | 0.04–0.06 | 223–228 | **13–24× / 14–28×** | 3,182 rows == native |
 | (G) top-10 groups by sum | 10 | 211–213 | 26.6–26.8 | 21.1–21.3 | 21.1–21.3 | 0.02 | 23 | **8× / 10×** | rows == native |
-| (G) top-10 groups by sum | 50 | 1018–1042 | 95–97 | 88 | 88 | 0.03 | 94 | **10.6× / 11.6×** | rows == native |
+| (G) top-10 groups by sum | 50 | 1018–1042 | 86–123 | 78–115 | 78–115 | 0.03–0.04 | 86–94 | **8.3–12× / 8.9–13×** | sums == native (tie keys differ) |
 
 With the filter on the device the transfer column is 20–60 µs and the
 statement is the kernel plus DuckDB's fixed per-statement cost: the on-device
 number has become the end-to-end number, which is the point of the feature.
-(B′) at SF50 is bimodal (42 ↔ 78 ms, laptop clocks, same pattern as the v0.5
-joins); both values are in the range. (G) pays a full radix sort of the
-aggregates (15M ≈ 17 ms, 75M ≈ 85 ms) before taking the first 10 — a
-radix-select would cut that; measured and shipped as is.
+(B′) and (G) at SF50 are bimodal (42 ↔ 78 ms and 86 ↔ 123 ms; the SM clock
+was sampled between 1665 and 2400 MHz across the runs — laptop boost, same
+pattern as the v0.5 joins); the ranges above span both modes, from a second
+clean-rebuild pass on 07706c4. (G) pays a full radix sort of the aggregates
+(15M ≈ 17 ms, 75M ≈ 80–115 ms) before taking the first 10 — a radix-select
+would cut that; measured and shipped as is.
 
 Headline for this machine: **≈1.5–2.2× end-to-end, ≈30–58× on-device** for
 the high-cardinality shapes (A)–(D) when the whole result comes back, and

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -195,8 +195,32 @@ statement / gpudb statement; on-device = native statement / `kernel_ms`.**
 | (F′) 7 groups, `l_linenumber` | 10 | 34.4–35.8 | 6.3–9.2 | 6.0–8.8 | 6.0–8.8 | 0.016 | 48.7 | **3.7–5.6× / 3.9–6×** | 7 groups, 1,529,738,036 == native |
 | (F′) 7 groups, `l_linenumber` | 50 | 185–186 | 34.1–38.2 | 33.4–36.9 | 33.3–36.8 | 0.017 | 209 | **4.9–5.4× / 5–5.6×** | 7 groups, 7,650,052,980 == native |
 
+Device-side filter (`GroupByFilter`, same harness, branch @ 04896b3): the
+HAVING / top-k is applied on the device and only the survivors are copied —
+(B′) is (B) with the filter inside `gpu_groupby_sum_resident_having('l',
+'>', 300)`, (G) is "top 10 groups by sum" via
+`gpu_groupby_sum_resident_topk('l', 10, 'desc')` vs native `ORDER BY s DESC
+LIMIT 10` over the same GROUP BY.
+
+| measurement | SF | native stmt (ms) | gpudb stmt (ms) | `wall_ms` | `kernel_ms` | `transfer_ms` | cold first stmt | end-to-end / on-device | result check |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| (B′) HAVING sum > 300 on the device | 10 | 209 | 11.8–12.0 | 8.3–8.4 | 8.2–8.4 | 0.02 | 59 | **17× / 25×** | 624 rows == native |
+| (B′) HAVING sum > 300 on the device | 50 | 1012–1022 | 42–78 | 37–72 | 37–72 | 0.04–0.06 | 228 | **13–24× / 14–27×** | 3,182 rows == native |
+| (G) top-10 groups by sum | 10 | 211–213 | 26.6–26.8 | 21.1–21.3 | 21.1–21.3 | 0.02 | 23 | **8× / 10×** | rows == native |
+| (G) top-10 groups by sum | 50 | 1018–1042 | 95–97 | 88 | 88 | 0.03 | 94 | **10.6× / 11.6×** | rows == native |
+
+With the filter on the device the transfer column is 20–60 µs and the
+statement is the kernel plus DuckDB's fixed per-statement cost: the on-device
+number has become the end-to-end number, which is the point of the feature.
+(B′) at SF50 is bimodal (42 ↔ 78 ms, laptop clocks, same pattern as the v0.5
+joins); both values are in the range. (G) pays a full radix sort of the
+aggregates (15M ≈ 17 ms, 75M ≈ 85 ms) before taking the first 10 — a
+radix-select would cut that; measured and shipped as is.
+
 Headline for this machine: **≈1.5–2.2× end-to-end, ≈30–58× on-device** for
-the high-cardinality shapes (A)–(D) — both numbers, always together. The
+the high-cardinality shapes (A)–(D) when the whole result comes back, and
+**13–24× end-to-end** once the HAVING runs on the device ((B′) below) — both
+numbers, always together. The
 earlier draft of this subsection compared native statement time against
 the operator's `wall_ms`, which omits the ≈20–30 % of the statement DuckDB
 spends streaming 15M–75M result rows out of the table function; the

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -162,51 +162,64 @@ build cache for such key sets — see KNOWN_ISSUES); every row above is from
 the fixed build, and the shape is now a regression scenario in both parity
 harnesses.
 
-### NVIDIA RTX 4090 Laptop (CUDA) — sm_89, 16 GB, driver 580.178.04, CUDA 13.0.88, CUB 3.0.1; native DuckDB CLI v1.5.5
+### NVIDIA RTX 4090 Laptop (CUDA) — sm_89, 16 GB, driver 580.178.04, CUDA 13.0.88, CUB 3.0.1; native and embedded engine both DuckDB v1.5.2
 
-Branch `feat/cuda-groupby-resident`, clean rebuild. Native: DuckDB CLI
-v1.5.5 (d8cdaa33fd) `-readonly`, 20 threads, `.timer on`, each query 5× in
-one process, run 1 discarded, min–max of the rest. gpudb: `gpudb-sql
---multi`, uploads as earlier statements, `gpu_last_stats()` `wall_ms` of the
-warm calls (min–max of 2–4 calls; the cold first call, which includes the
-one-time key sort, listed separately). The statement time DuckDB itself
-measures is in brackets — it is higher than `wall_ms` because the table
-function's rows still stream through DuckDB's pipeline. Every row
-`backend=CUDA reason=Hot_GpuAlwaysWins`. SF50 used
-`GPUDB_UPLOAD_POOL_MAX_MB=12288`.
+Branch `feat/cuda-groupby-resident` @ 71d9321, clean rebuild. Native and
+gpudb timed by the **same clock in the same process**: `gpudb-sql --multi`
+(embedded libduckdb v1.5.2) runs each native shape 3× as plain SQL, then
+the upload, then the gpudb shape 3×; the per-statement time gpudb-sql prints
+is the number in both columns (first run of each discarded, min–max of the
+other two). So "end-to-end" is statement-vs-statement and includes streaming
+the table function's rows through DuckDB's pipeline; `wall_ms` /
+`kernel_ms` / `transfer_ms` from `gpu_last_stats()` are the breakdown of the
+operator inside that statement. Every row `backend=CUDA
+reason=Hot_GpuAlwaysWins`. SF50 used `GPUDB_UPLOAD_POOL_MAX_MB=12288`, with
+(C), (E), (F), (F′) in separate processes from (A)/(B)/(D) (memory budget,
+below). Both ratios are always printed together: **end-to-end = native
+statement / gpudb statement; on-device = native statement / `kernel_ms`.**
 
-| measurement | SF | native (ms) | gpudb warm `wall_ms` [stmt] | `kernel_ms` | `transfer_ms` | cold first call | end-to-end / on-device | result check |
-|---|---|---:|---:|---:|---:|---:|---:|---|
-| (A) sum i64, 15M groups | 10 | 130–137 | 73.4–75.5 [95–99] | 4.5–4.6 | 68.8–71.0 | 117 [139] | **1.8× / 29×** | 15,000,000 groups == native |
-| (A) sum i64, 75M groups | 50 | 631–646 | 362–368 [457–459] | 21.3 | 341–347 | 544 [636] | **1.75× / 30×** | 75,000,000 == native |
-| (B) HAVING sum > 300 | 10 | 195–200 | 74.6–74.8 [102] | 4.5 | 70.0–70.3 | — | **2.6× / 43×** | 624 groups == native |
-| (B) HAVING sum > 300 | 50 | 959–988 | 365–368 [495–498] | 21.3 | 343–346 | — | **2.65× / 45×** | 3,182 == native |
-| (C) sum f64 | 10 | 189–199 | 72.9–74.5 [102] | 4.6 | 68.3–70.0 | 117 | **2.6× / 42×** | sum-of-sums rel-diff 9e-14 |
-| (C) sum f64 | 50 | 942–955 | 364–371 [491–500] | 21.3–21.4 | 342–350 | 553 | **2.6× / 44×** | rel-diff 1.1e-13 |
-| (D) count | 10 | 130–132 | 48.3–50.0 [63–64] | 2.5–2.6 | 45.8–47.4 | — | **2.7× / 51×** | 15,000,000 == native |
-| (D) count | 50 | 635–654 | 235–244 [298–308] | 11.6–11.7 | 223–232 | — | **2.7× / 55×** | 75,000,000 == native |
-| (E) top-10 DESC | 10 | 25–29 | 0.022–0.028 [0.2] | 0.002 | 0.015 | 33.9 (the sort) | cold **0.8× — native wins**; warm ~1000× | values == native |
-| (E) top-10 DESC | 50 | 121–127 | 0.022–0.027 [0.2] | 0.002 | 0.015 | 170.5 (the sort) | cold **0.7× — native wins**; warm ~5000× | values == native |
-| (F) 4 groups, hashed key | 10 | 167–172 | 4.5 [4.8] | 4.4 | 0.02 | 44.4 | **37× / 38×** (see note) | 4 groups, 1,529,738,036 == native |
-| (F) 4 groups, hashed key | 50 | 731–759 | 26.6 [28] | 26.6 | 0.02 | 200 | **28× / 28×** (see note) | 4 groups, 7,650,052,980 == native |
-| (F′) 7 groups, plain BIGINT key (`l_linenumber`) | 10 | 31–32 | 5.9 | 5.9 | 0.02 | 47 | **5.3× / 5.3×** | 1,529,738,036 == native |
-| (F′) 7 groups, plain BIGINT key | 50 | 151–158 | 28.8 | 28.8 | 0.02 | 208 | **5.3× / 5.3×** | 7,650,052,980 == native |
+| measurement | SF | native stmt (ms) | gpudb stmt (ms) | `wall_ms` | `kernel_ms` | `transfer_ms` | cold first stmt | end-to-end / on-device | result check |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| (A) sum i64, 15M groups | 10 | 135–138 | 96.4–97.4 | 75–76 | 4.5–4.7 | 70.5–71.7 | 141 | **1.4× / 29×** | 15,000,000 groups == native |
+| (A) sum i64, 75M groups | 50 | 684–693 | 458–464 | 362–368 | 21.4 | 340–347 | 651 | **1.5× / 32×** | 75,000,000 == native |
+| (B) HAVING sum > 300 | 10 | 204–209 | 105–106 | 76.5–76.8 | 4.5–4.7 | 72.0–72.2 | — | **2.0× / 45×** | 624 groups == native |
+| (B) HAVING sum > 300 | 50 | 991–1013 | 491–505 | 364–371 | 21.3–21.4 | 343–349 | — | **2.0× / 47×** | 3,182 == native |
+| (C) sum f64 | 10 | 206–213 | 104–106 | 76–77 | 4.6 | 71.5–72.4 | 149 | **2.0× / 45×** | sum-of-sums rel-diff 9e-14 |
+| (C) sum f64 | 50 | 982–994 | 498–503 | 368–369 | 21.4 | 347 | 674 | **2.0× / 46×** | rel-diff 1.1e-13 |
+| (D) count | 10 | 135–140 | 64.5–66.0 | 49–50 | 2.5–2.7 | 46.7–47.4 | — | **2.1× / 52×** | 15,000,000 == native |
+| (D) count | 50 | 672–687 | 309–314 | 246–248 | 11.6–11.7 | 234–236 | — | **2.2× / 58×** | 75,000,000 == native |
+| (E) top-10 DESC | 10 | 31.0–31.5 | 0.14–0.27 | 0.03 | 0.002 | 0.015 | 34.6 (the sort) | cold **0.9× — native wins**; warm ≈120–220× | values == native |
+| (E) top-10 DESC | 50 | 145–146 | 0.16–0.28 | 0.03 | 0.002 | 0.02 | 169 (the sort) | cold **0.85× — native wins**; warm ≈500–900× | values == native |
+| (F) 4 groups, packed-ascii key | 10 | 106–110 | 4.7–7.5 | 4.4–7.1 | 4.4–7.1 | 0.015 | 46.6 | **14–23× / 15–25×** | 4 groups, 1,529,738,036 == native |
+| (F) 4 groups, packed-ascii key | 50 | 433–439 | 28.0–28.2 | 26.7–26.9 | 26.6–26.9 | 0.017 | 197 | **15.5× / 16×** | 4 groups, 7,650,052,980 == native |
+| (F′) 7 groups, `l_linenumber` | 10 | 34.4–35.8 | 6.3–9.2 | 6.0–8.8 | 6.0–8.8 | 0.016 | 48.7 | **3.7–5.6× / 3.9–6×** | 7 groups, 1,529,738,036 == native |
+| (F′) 7 groups, `l_linenumber` | 50 | 185–186 | 34.1–38.2 | 33.4–36.9 | 33.3–36.8 | 0.017 | 209 | **4.9–5.4× / 5–5.6×** | 7 groups, 7,650,052,980 == native |
 
-One-time costs, stated plainly: the upload statement is 4.6–4.7 s for a
-pair at SF10 (3.5 s for a single column) and 19.7–24.4 s at SF50 (15.6 s
+Headline for this machine: **≈1.5–2.2× end-to-end, ≈30–58× on-device** for
+the high-cardinality shapes (A)–(D) — both numbers, always together. The
+earlier draft of this subsection compared native statement time against
+the operator's `wall_ms`, which omits the ≈20–30 % of the statement DuckDB
+spends streaming 15M–75M result rows out of the table function; the
+corrected column is the statement time. (F) uses the same packed-ascii key
+as the Metal rows, `(ascii(l_returnflag)*256+ascii(l_linestatus))::BIGINT`.
+
+One-time costs, stated plainly: the upload statement is 3.4–3.9 s for a
+pair at SF10 (2.1 s for a single column) and 15.9–18.4 s at SF50 (7.6 s
 single); the first call on a key column pays its sort (≈35 ms at SF10,
 ≈170 ms at SF50) once, after which every GROUP BY / top-k on that key skips
-it. Break-even for (A) is ≈80 repeated calls at either scale (≈57 ms saved per call at SF10, ≈275 ms at SF50).
+it. Break-even for (A) is ≈95 repeated statements at SF10 (≈40 ms saved
+each), ≈80 at SF50 (≈230 ms each).
 
-**Where the wall time goes (A–D).** The kernel is 4–5% of the end-to-end
-number; the rest is the result crossing device→host: 15M × 24 B = 360 MB
-at SF10, 1.8 GB at SF50. Measured on this box for a 120 MB result array:
-the PCIe copy itself is ≈12 ms (≈10 GB/s), but first-touch page-faulting of
-the freshly allocated `std::vector` was ≈27 ms — more than the copy.
-Reserving the vector, advising transparent huge pages on the untouched
-range, then resizing brings the fault cost to ≈11 ms (in this branch;
-Linux-only, no-op where THP is disabled). A pinned, double-buffered staging
-path was implemented, measured (no change: the copy was never the
+**Where the statement time goes (A–D).** The kernel is 3–5 % of the
+statement; ≈75 % is the result crossing device→host (15M × 24 B = 360 MB at
+SF10, 1.8 GB at SF50) and ≈20–25 % is DuckDB streaming those rows out of
+the table function. Measured on this box for a 120 MB result array: the
+PCIe copy itself is ≈12 ms (≈10 GB/s), but first-touch page-faulting of the
+freshly allocated `std::vector` was ≈27 ms — more than the copy. Reserving
+the vector, advising transparent huge pages on the untouched range, then
+resizing brings the fault cost to ≈11 ms (in this branch; Linux-only,
+page-size-aware, no-op where THP is disabled). A pinned, double-buffered
+staging path was implemented, measured (no change: the copy was never the
 bottleneck) and dropped. On a unified-memory machine the transfer column is
 what disappears — see the Metal rows. Whether a result this size should
 leave the device at all is the question v0.7's GROUP BY-over-join work will
@@ -217,31 +230,27 @@ the cold call (a full sort of the column) on both scales. Every subsequent
 top-k on that column is a 10-row slice of the cached sort. Sort the column
 once only if you will ask for it more than once.
 
-**(F) is not the losing row it was expected to be.** The hashed key
-expression is evaluated once, at upload; native re-evaluates
-`hash(l_returnflag||l_linestatus)` per row on every query (167 ms at SF10).
-(F′) is the true low-cardinality reference: a plain `BIGINT` key,
-`sum(l_quantity::BIGINT) GROUP BY l_linenumber` (7 groups, measured with the
-standalone driver, columns resident). Still a win with the data resident,
-but 5×, not 30×: with few groups the value gather through the permutation
-is fully random, and there is no result to save. This is where the two
-backends differ — on Metal the same shape loses to native (see the Metal
-rows): the sorted gather of 60M values costs more than DuckDB's hash
-aggregate there. The real losing rows on this machine are the cold (E) call
-and the upload itself.
+**(F) and (F′).** With few groups there is no result to move, so the gap is
+the kernel alone: the value gather through the permutation is fully random
+when the sort has scattered the rows (15–23× on the packed key, whose native
+side still evaluates two `ascii()` calls per row; 4–5.6× on the plain
+`BIGINT` `l_linenumber` key, the true low-cardinality reference). This is
+where the two backends differ — on Metal the same shape loses to native
+(see the Metal rows). The real losing rows on this machine are the cold (E)
+call and the upload itself.
 
 **Memory budget (SF50).** A resident pair is 4.8 GB; each sorted key column
 adds 16 B/row (4.8 GB) plus ≈16 B/row of transient radix scratch during the
 sort. Two pairs plus one cache fit in 16 GB; the second cache build fails
 with a clean `cudaMalloc join cache (sorted keys) failed: out of memory`
-error (no partial results). The (C) and (F) runs above therefore ran in
-separate processes from (A)/(B)/(D).
+error (no partial results).
 
 **v0.5 (f) revisited.** The same page-fault fix applies to the
 row-returning join: `gpu_join_rows_resident` over 60M pairs at SF10 now
-measures wall 195–215 ms = kernel 13–14 + transfer 182–189 ms (was 356.6 =
-14.8 + 341.8) against the same native 232–272 ms — ≈1.1× instead of 0.5×;
-the v0.5 table above is left as measured on that branch.
+measures operator wall 195–215 ms = kernel 13–14 + transfer 182–189 ms
+(was 356.6 = 14.8 + 341.8), statement 255–275 ms, against the v0.5 native
+232–272 ms — roughly a tie instead of 0.5×; the v0.5 table above is left as
+measured on that branch.
 
 ### Reproduce
 

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -243,6 +243,28 @@ single); the first call on a key column pays its sort (≈35 ms at SF10,
 it. Break-even for (A) is ≈95 repeated statements at SF10 (≈40 ms saved
 each), ≈80 at SF50 (≈230 ms each).
 
+**Follow-up on this branch — radix-select for (G), CUB on explicit temp
+storage.** Top-k of groups now finds the k-th aggregate with eight 256-bin
+histogram passes over order keys and compacts the winners (the full sort is
+kept for k ≥ groups/8); every resident step also moved from Thrust's
+self-allocating algorithms to CUB primitives on buffers we own, so a device
+fault returns its `cudaError_t` (→ SQL error) instead of aborting the
+process (unit-tested in a child process). Same harness as above, same day:
+
+| measurement | SF | native stmt (ms) | gpudb stmt (ms) | `kernel_ms` | before (sort-based) | end-to-end / on-device |
+|---|---|---:|---:|---:|---:|---:|
+| (G) top-10 groups by sum | 10 | 211–215 | 16.1–16.3 | 11.6–11.8 | 26.6–26.8 (kernel 21) | **13× / 18×** |
+| (G) top-10 groups by sum | 50 | 1009–1023 | 60–64 | 52–56 | 86–123 (kernel 78–115) | **16–17× / 18–19×** |
+| (B′) HAVING sum > 300 (unchanged path, CUB build) | 10 | 204–206 | 12.0–12.3 | 9.6–9.8 | 11.7–12.9 | 17× / 21× |
+| (B′) HAVING sum > 300 (unchanged path, CUB build) | 50 | 1019–1023 | 50–57 | 45–52 | 42–78 | 18–20× / 20–23× |
+
+(G) is now the reduce-by-key itself (the (B′) floor, 45–52 ms at SF50) plus
+≈8 ms of select — the 75M-key aggregate sort it replaced was 40–70 ms. Raw
+(G) lines: SF10 native 215.0 / 211.3 / 215.3, gpudb 16.06 / 16.33 / 16.17
+(`kernel_ms` 11.57 / 11.84 / 11.71); SF50 native 1009.2 / 1013.5 / 1009.6,
+gpudb 64.2 / 60.2 / 61.2 (`kernel_ms` 56.3 / 52.5 / 53.2); sums == native
+in every run.
+
 **Where the statement time goes (A–D).** The kernel is 3–5 % of the
 statement; ≈75 % is the result crossing device→host (15M × 24 B = 360 MB at
 SF10, 1.8 GB at SF50) and ≈20–25 % is DuckDB streaming those rows out of

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ if(GPUDB_HAS_CUDA)
         backends/cuda/kernels/groupby_kernel.cu
         backends/cuda/kernels/hashjoin_kernel.cu
         backends/cuda/kernels/join_kernel.cu
+        backends/cuda/kernels/groupby_resident_kernel.cu
     )
 endif()
 

--- a/src/backends/cuda/cuda_aggregator.cpp
+++ b/src/backends/cuda/cuda_aggregator.cpp
@@ -8,6 +8,10 @@
 
 #include <cuda_runtime.h>
 
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
+
 #include <algorithm>
 #include <chrono>
 #include <string>
@@ -462,8 +466,8 @@ public:
             cudaEventElapsedTime(&kernel_ms, ev_start_, ev_stop_);
 
             const auto t_xfer0 = std::chrono::steady_clock::now();
-            r.probe_idx.resize(total);
-            r.build_idx.resize(total);
+            prepare_host(r.probe_idx, total);
+            prepare_host(r.build_idx, total);
             e = cudaMemcpyAsync(r.probe_idx.data(), d_p, out_bytes,
                                 cudaMemcpyDeviceToHost, stream_);
             if (e == cudaSuccess)
@@ -617,16 +621,16 @@ public:
 
         const std::size_t off = descending ? n - k : 0;
         const auto tx = std::chrono::steady_clock::now();
-        r.idx.resize(k);
+        prepare_host(r.idx, k);
         GPUDB_CUDA_CHECK(cudaMemcpyAsync(r.idx.data(), c.perm() + off, k * sizeof(std::int64_t),
                                          cudaMemcpyDeviceToHost, stream_), "topk idx D2H");
         if (c.dtype() == Dtype::I64) {
-            r.values_i64.resize(k);
+            prepare_host(r.values_i64, k);
             GPUDB_CUDA_CHECK(cudaMemcpyAsync(r.values_i64.data(), c.sorted_keys() + off,
                                              k * sizeof(std::int64_t),
                                              cudaMemcpyDeviceToHost, stream_), "topk values D2H");
         } else {
-            r.values_f64.resize(k);
+            prepare_host(r.values_f64, k);
             GPUDB_CUDA_CHECK(cudaMemcpyAsync(r.values_f64.data(), c.sorted_f64() + off,
                                              k * sizeof(double),
                                              cudaMemcpyDeviceToHost, stream_), "topk values D2H");
@@ -657,9 +661,33 @@ private:
         DeviceOut& operator=(const DeviceOut&) = delete;
     };
 
+    // Size a host result vector for a large device->host copy. Measured on the
+    // RTX 4090 Laptop box: for a 120 MB result the PCIe copy is ~12 ms but
+    // first-touch faulting of the fresh pages (4 KB at a time) costs ~27 ms —
+    // more than the copy. Advising transparent huge pages on the reserved,
+    // not-yet-touched range before the value-initialising resize cuts that
+    // to ~11 ms. No-op where THP is unavailable or disabled; std::vector
+    // semantics are unchanged (reserve then resize, same capacity).
+    template <typename T>
+    static void prepare_host(std::vector<T>& v, std::size_t n) {
+        v.clear();
+        v.reserve(n);
+#if defined(__linux__) && defined(MADV_HUGEPAGE)
+        if (n * sizeof(T) >= (8u << 20)) {
+            constexpr std::uintptr_t kPage = 4096;
+            auto lo = reinterpret_cast<std::uintptr_t>(v.data());
+            auto hi = lo + n * sizeof(T);
+            lo = (lo + kPage - 1) & ~(kPage - 1);
+            hi &= ~(kPage - 1);
+            if (hi > lo) (void)madvise(reinterpret_cast<void*>(lo), hi - lo, MADV_HUGEPAGE);
+        }
+#endif
+        v.resize(n);
+    }
+
     template <typename T>
     void d2h(std::vector<T>& dst, const DeviceOut<T>& src, std::size_t n, const char* what) {
-        dst.resize(n);
+        prepare_host(dst, n);
         GPUDB_CUDA_CHECK(cudaMemcpyAsync(dst.data(), src.p, n * sizeof(T),
                                          cudaMemcpyDeviceToHost, stream_), what);
     }

--- a/src/backends/cuda/cuda_aggregator.cpp
+++ b/src/backends/cuda/cuda_aggregator.cpp
@@ -8,7 +8,10 @@
 
 #include <cuda_runtime.h>
 
+#include <algorithm>
 #include <chrono>
+#include <string>
+#include <vector>
 #include <cstring>
 #include <limits>
 #include <sstream>
@@ -56,6 +59,23 @@ cudaError_t gpudb_cuda_join_rows_fill(const std::int64_t* d_probe,
                                       int kind, const unsigned long long* d_offs,
                                       std::int64_t* d_out_pidx, std::int64_t* d_out_bidx,
                                       int grid, cudaStream_t s);
+cudaError_t gpudb_cuda_sorted_run_count(const std::int64_t* d_sorted, std::size_t n,
+                                        std::size_t* h_runs, cudaStream_t s);
+cudaError_t gpudb_cuda_groupby_sum_i64(const std::int64_t* d_sorted, const std::int64_t* d_perm,
+                                       const std::int64_t* d_vals, std::size_t n,
+                                       std::int64_t* out_keys, std::int64_t* out_sums,
+                                       std::int64_t* out_counts,
+                                       std::size_t* h_runs, cudaStream_t s);
+cudaError_t gpudb_cuda_groupby_sum_f64(const std::int64_t* d_sorted, const std::int64_t* d_perm,
+                                       const double* d_vals, std::size_t n,
+                                       std::int64_t* out_keys, double* out_sums,
+                                       std::int64_t* out_counts,
+                                       std::size_t* h_runs, cudaStream_t s);
+cudaError_t gpudb_cuda_groupby_count(const std::int64_t* d_sorted, std::size_t n,
+                                     std::int64_t* out_keys, std::int64_t* out_counts,
+                                     std::size_t* h_runs, cudaStream_t s);
+cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
+                                     std::int64_t* d_perm, std::size_t n, cudaStream_t s);
 }
 
 namespace {
@@ -113,8 +133,32 @@ public:
         d_sorted_ = sorted;
         d_perm_   = perm;
     }
+    // Sort cache for any dtype (v0.6 top-k): I64 shares the join cache above;
+    // F64 sorts through order-preserving u64 keys (NaN greatest) and stores
+    // the sorted doubles in the same slot.
+    void ensure_sort_cache(cudaStream_t s) const {
+        if (dtype_ == Dtype::I64) { ensure_join_cache(s); return; }
+        if (d_sorted_ || rows_ == 0) return;
+        void* sorted = nullptr;
+        void* perm   = nullptr;
+        GPUDB_CUDA_CHECK(cudaMalloc(&sorted, bytes_), "cudaMalloc sort cache (sorted f64)");
+        cudaError_t e = cudaMalloc(&perm, rows_ * sizeof(std::int64_t));
+        if (e != cudaSuccess) { cudaFree(sorted); cuda_throw(e, "cudaMalloc sort cache (perm)"); }
+        e = gpudb_cuda_sort_f64_perm(static_cast<const double*>(dptr_),
+                                     static_cast<double*>(sorted),
+                                     static_cast<std::int64_t*>(perm), rows_, s);
+        if (e != cudaSuccess) {
+            cudaFree(sorted); cudaFree(perm);
+            cuda_throw(e, "sort cache build (f64 sort_by_key)");
+        }
+        d_sorted_ = sorted;
+        d_perm_   = perm;
+    }
     const std::int64_t* sorted_keys() const noexcept {
         return static_cast<const std::int64_t*>(d_sorted_);
+    }
+    const double* sorted_f64() const noexcept {
+        return static_cast<const double*>(d_sorted_);
     }
     const std::int64_t* perm() const noexcept {
         return static_cast<const std::int64_t*>(d_perm_);
@@ -442,8 +486,212 @@ public:
         return r;
     }
 
+    // ---- resident GROUP BY / top-k (v0.6) ----
+    // Keys reuse the v0.5 sort cache (sorted keys + permutation); values are
+    // read through the permutation and reduced per key run. The group count
+    // comes from a cheap run-count pass first, so the cap is checked before
+    // any output is allocated or transferred.
+    GroupByResidentResult groupby_sum_resident_i64(const ResidentColumn& keys,
+                                                   const ResidentColumn& vals,
+                                                   std::size_t max_groups) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& k = check_i64(keys);
+        const auto& v = check_i64(vals);
+        if (k.rows() != v.rows())
+            throw std::runtime_error(
+                "groupby_sum_resident_i64: keys and vals row counts differ");
+        GroupByResidentResult r{};
+        r.rows_in = k.rows();
+        if (k.rows() == 0) { r.wall_ms = elapsed_ms(t0); return r; }
+
+        k.ensure_join_cache(stream_);
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
+        const std::size_t groups = checked_group_count("groupby_sum_resident_i64", k, max_groups);
+        DeviceOut<std::int64_t> d_keys(groups, "groupby out keys");
+        DeviceOut<std::int64_t> d_sums(groups, "groupby out sums");
+        DeviceOut<std::int64_t> d_cnts(groups, "groupby out counts");
+        std::size_t runs = 0;
+        GPUDB_CUDA_CHECK(gpudb_cuda_groupby_sum_i64(
+                             k.sorted_keys(), k.perm(),
+                             static_cast<const std::int64_t*>(v.device_ptr()), k.rows(),
+                             d_keys.p, d_sums.p, d_cnts.p, &runs, stream_),
+                         "groupby_sum_i64 reduce_by_key");
+        r.kernel_ms = stop_kernel_timer();
+        check_runs("groupby_sum_resident_i64", runs, groups);
+
+        const auto tx = std::chrono::steady_clock::now();
+        d2h(r.keys,   d_keys, groups, "groupby keys D2H");
+        d2h(r.sums,   d_sums, groups, "groupby sums D2H");
+        d2h(r.counts, d_cnts, groups, "groupby counts D2H");
+        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
+        r.transfer_ms = elapsed_ms(tx);
+        r.wall_ms     = elapsed_ms(t0);
+        return r;
+    }
+
+    GroupByResidentResult groupby_sum_resident_f64(const ResidentColumn& keys,
+                                                   const ResidentColumn& vals,
+                                                   std::size_t max_groups) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& k = check_i64(keys);
+        const auto& v = check_f64(vals);
+        if (k.rows() != v.rows())
+            throw std::runtime_error(
+                "groupby_sum_resident_f64: keys and vals row counts differ");
+        GroupByResidentResult r{};
+        r.rows_in = k.rows();
+        if (k.rows() == 0) { r.wall_ms = elapsed_ms(t0); return r; }
+
+        k.ensure_join_cache(stream_);
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
+        const std::size_t groups = checked_group_count("groupby_sum_resident_f64", k, max_groups);
+        DeviceOut<std::int64_t> d_keys(groups, "groupby out keys");
+        DeviceOut<double>       d_sums(groups, "groupby out sums (f64)");
+        DeviceOut<std::int64_t> d_cnts(groups, "groupby out counts");
+        std::size_t runs = 0;
+        GPUDB_CUDA_CHECK(gpudb_cuda_groupby_sum_f64(
+                             k.sorted_keys(), k.perm(),
+                             static_cast<const double*>(v.device_ptr()), k.rows(),
+                             d_keys.p, d_sums.p, d_cnts.p, &runs, stream_),
+                         "groupby_sum_f64 reduce_by_key");
+        r.kernel_ms = stop_kernel_timer();
+        check_runs("groupby_sum_resident_f64", runs, groups);
+
+        const auto tx = std::chrono::steady_clock::now();
+        d2h(r.keys,     d_keys, groups, "groupby keys D2H");
+        d2h(r.sums_f64, d_sums, groups, "groupby sums D2H");
+        d2h(r.counts,   d_cnts, groups, "groupby counts D2H");
+        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
+        r.transfer_ms = elapsed_ms(tx);
+        r.wall_ms     = elapsed_ms(t0);
+        return r;
+    }
+
+    GroupByResidentResult groupby_count_resident(const ResidentColumn& keys,
+                                                 std::size_t max_groups) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        const auto& k = check_i64(keys);
+        GroupByResidentResult r{};
+        r.rows_in = k.rows();
+        if (k.rows() == 0) { r.wall_ms = elapsed_ms(t0); return r; }
+
+        k.ensure_join_cache(stream_);
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
+        const std::size_t groups = checked_group_count("groupby_count_resident", k, max_groups);
+        DeviceOut<std::int64_t> d_keys(groups, "groupby out keys");
+        DeviceOut<std::int64_t> d_cnts(groups, "groupby out counts");
+        std::size_t runs = 0;
+        GPUDB_CUDA_CHECK(gpudb_cuda_groupby_count(k.sorted_keys(), k.rows(),
+                                                  d_keys.p, d_cnts.p, &runs, stream_),
+                         "groupby_count reduce_by_key");
+        r.kernel_ms = stop_kernel_timer();
+        check_runs("groupby_count_resident", runs, groups);
+
+        const auto tx = std::chrono::steady_clock::now();
+        d2h(r.keys,   d_keys, groups, "groupby keys D2H");
+        d2h(r.counts, d_cnts, groups, "groupby counts D2H");
+        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
+        r.transfer_ms = elapsed_ms(tx);
+        r.wall_ms     = elapsed_ms(t0);
+        return r;
+    }
+
+    // top-k = a slice of the cached sort. kernel_ms covers the sort on the
+    // first call for a column and is ~0 on later calls (cache hit); the
+    // descending order is the tail of the ascending run, reversed on the host.
+    TopKResult topk_resident(const ResidentColumn& col, std::size_t k,
+                             bool descending) override {
+        const auto t0 = std::chrono::steady_clock::now();
+        if (col.backend_tag() != Backend::CUDA)
+            throw std::runtime_error("ResidentColumn from wrong backend");
+        const auto& c = static_cast<const CudaResidentColumn&>(col);
+        TopKResult r{};
+        r.rows_in = c.rows();
+        const std::size_t n = c.rows();
+        if (k > n) k = n;
+        if (k == 0) { r.wall_ms = elapsed_ms(t0); return r; }
+
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
+        c.ensure_sort_cache(stream_);
+        r.kernel_ms = stop_kernel_timer();
+
+        const std::size_t off = descending ? n - k : 0;
+        const auto tx = std::chrono::steady_clock::now();
+        r.idx.resize(k);
+        GPUDB_CUDA_CHECK(cudaMemcpyAsync(r.idx.data(), c.perm() + off, k * sizeof(std::int64_t),
+                                         cudaMemcpyDeviceToHost, stream_), "topk idx D2H");
+        if (c.dtype() == Dtype::I64) {
+            r.values_i64.resize(k);
+            GPUDB_CUDA_CHECK(cudaMemcpyAsync(r.values_i64.data(), c.sorted_keys() + off,
+                                             k * sizeof(std::int64_t),
+                                             cudaMemcpyDeviceToHost, stream_), "topk values D2H");
+        } else {
+            r.values_f64.resize(k);
+            GPUDB_CUDA_CHECK(cudaMemcpyAsync(r.values_f64.data(), c.sorted_f64() + off,
+                                             k * sizeof(double),
+                                             cudaMemcpyDeviceToHost, stream_), "topk values D2H");
+        }
+        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
+        r.transfer_ms = elapsed_ms(tx);
+        if (descending) {
+            std::reverse(r.idx.begin(), r.idx.end());
+            std::reverse(r.values_i64.begin(), r.values_i64.end());
+            std::reverse(r.values_f64.begin(), r.values_f64.end());
+        }
+        r.wall_ms = elapsed_ms(t0);
+        return r;
+    }
+
 private:
     enum class ReduceKind { Sum, Min, Max };
+
+    // Per-call device output buffer (freed on scope exit, including throws).
+    template <typename T>
+    struct DeviceOut {
+        T* p = nullptr;
+        DeviceOut(std::size_t n, const char* what) {
+            if (n) GPUDB_CUDA_CHECK(cudaMalloc(&p, n * sizeof(T)), what);
+        }
+        ~DeviceOut() { if (p) cudaFree(p); }
+        DeviceOut(const DeviceOut&) = delete;
+        DeviceOut& operator=(const DeviceOut&) = delete;
+    };
+
+    template <typename T>
+    void d2h(std::vector<T>& dst, const DeviceOut<T>& src, std::size_t n, const char* what) {
+        dst.resize(n);
+        GPUDB_CUDA_CHECK(cudaMemcpyAsync(dst.data(), src.p, n * sizeof(T),
+                                         cudaMemcpyDeviceToHost, stream_), what);
+    }
+
+    double stop_kernel_timer() {
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_stop_, stream_), "ev_stop");
+        GPUDB_CUDA_CHECK(cudaEventSynchronize(ev_stop_), "ev_sync");
+        float ms = 0.0f;
+        GPUDB_CUDA_CHECK(cudaEventElapsedTime(&ms, ev_start_, ev_stop_), "elapsed");
+        return static_cast<double>(ms);
+    }
+
+    // Distinct-key count over the cached sorted keys, checked against the cap
+    // before any output allocation or transfer.
+    std::size_t checked_group_count(const char* op, const CudaResidentColumn& k,
+                                    std::size_t max_groups) {
+        std::size_t groups = 0;
+        GPUDB_CUDA_CHECK(gpudb_cuda_sorted_run_count(k.sorted_keys(), k.rows(), &groups, stream_),
+                         "groupby run count");
+        if (groups > max_groups)
+            throw std::runtime_error(
+                std::string(op) + ": result has " + std::to_string(groups) +
+                " groups, above the cap of " + std::to_string(max_groups) +
+                " (raise GPUDB_GROUPBY_ROWS_MAX_M if intentional)");
+        return groups;
+    }
+    static void check_runs(const char* op, std::size_t runs, std::size_t groups) {
+        if (runs != groups)
+            throw std::runtime_error(std::string(op) + ": reduce produced " +
+                                     std::to_string(runs) + " runs, expected " +
+                                     std::to_string(groups));
+    }
 
     static double elapsed_ms(std::chrono::steady_clock::time_point t0) {
         return std::chrono::duration<double, std::milli>(

--- a/src/backends/cuda/cuda_aggregator.cpp
+++ b/src/backends/cuda/cuda_aggregator.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <chrono>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include <cstring>
 #include <limits>
@@ -81,6 +82,20 @@ cudaError_t gpudb_cuda_groupby_count(const std::int64_t* d_sorted, std::size_t n
                                      std::size_t* h_runs, cudaStream_t s);
 cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
                                      std::int64_t* d_perm, std::size_t n, cudaStream_t s);
+cudaError_t gpudb_cuda_groupby_survivors_i64(const std::int64_t* agg, std::size_t n, int cmp,
+                                             std::int64_t t, std::size_t* h_out, cudaStream_t s);
+cudaError_t gpudb_cuda_groupby_survivors_f64(const double* agg, std::size_t n, int cmp,
+                                             double t, std::size_t* h_out, cudaStream_t s);
+cudaError_t gpudb_cuda_groupby_filter_i64(const std::int64_t* keys, const std::int64_t* agg,
+                                          const std::int64_t* cnt, std::size_t n, int cmp,
+                                          std::int64_t t, std::size_t topk, int desc, std::size_t n_out,
+                                          std::int64_t* out_keys, std::int64_t* out_agg,
+                                          std::int64_t* out_cnt, cudaStream_t s);
+cudaError_t gpudb_cuda_groupby_filter_f64(const std::int64_t* keys, const double* agg,
+                                          const std::int64_t* cnt, std::size_t n, int cmp,
+                                          double t, std::size_t topk, int desc, std::size_t n_out,
+                                          std::int64_t* out_keys, double* out_agg,
+                                          std::int64_t* out_cnt, cudaStream_t s);
 }
 
 namespace {
@@ -494,111 +509,47 @@ public:
     // ---- resident GROUP BY / top-k (v0.6) ----
     // Keys reuse the v0.5 sort cache (sorted keys + permutation); values are
     // read through the permutation and reduced per key run. The group count
-    // comes from a cheap run-count pass first, so the cap is checked before
+    // comes from a cheap run-count pass first. With a GroupByFilter the
+    // survivors are selected (and top-k'd) on the device and only they are
+    // copied back; the cap bounds the rows returned and is checked before
     // any output is allocated or transferred.
     GroupByResidentResult groupby_sum_resident_i64(const ResidentColumn& keys,
                                                    const ResidentColumn& vals,
-                                                   std::size_t max_groups) override {
+                                                   std::size_t max_groups,
+                                                   const GroupByFilter& filter) override {
         const auto t0 = std::chrono::steady_clock::now();
         const auto& k = check_i64(keys);
         const auto& v = check_i64(vals);
         if (k.rows() != v.rows())
             throw std::runtime_error(
                 "groupby_sum_resident_i64: keys and vals row counts differ");
-        GroupByResidentResult r{};
-        r.rows_in = k.rows();
-        if (k.rows() == 0) { r.wall_ms = elapsed_ms(t0); return r; }
-
-        k.ensure_join_cache(stream_);
-        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
-        const std::size_t groups = checked_group_count("groupby_sum_resident_i64", k, max_groups);
-        DeviceOut<std::int64_t> d_keys(groups, "groupby out keys");
-        DeviceOut<std::int64_t> d_sums(groups, "groupby out sums");
-        DeviceOut<std::int64_t> d_cnts(groups, "groupby out counts");
-        std::size_t runs = 0;
-        GPUDB_CUDA_CHECK(gpudb_cuda_groupby_sum_i64(
-                             k.sorted_keys(), k.perm(),
-                             static_cast<const std::int64_t*>(v.device_ptr()), k.rows(),
-                             d_keys.p, d_sums.p, d_cnts.p, &runs, stream_),
-                         "groupby_sum_i64 reduce_by_key");
-        r.kernel_ms = stop_kernel_timer();
-        check_runs("groupby_sum_resident_i64", runs, groups);
-
-        const auto tx = std::chrono::steady_clock::now();
-        d2h(r.keys,   d_keys, groups, "groupby keys D2H");
-        d2h(r.sums,   d_sums, groups, "groupby sums D2H");
-        d2h(r.counts, d_cnts, groups, "groupby counts D2H");
-        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
-        r.transfer_ms = elapsed_ms(tx);
-        r.wall_ms     = elapsed_ms(t0);
-        return r;
+        return groupby_common<std::int64_t>("groupby_sum_resident_i64", k,
+                                            static_cast<const std::int64_t*>(v.device_ptr()),
+                                            max_groups, filter, t0);
     }
 
     GroupByResidentResult groupby_sum_resident_f64(const ResidentColumn& keys,
                                                    const ResidentColumn& vals,
-                                                   std::size_t max_groups) override {
+                                                   std::size_t max_groups,
+                                                   const GroupByFilter& filter) override {
         const auto t0 = std::chrono::steady_clock::now();
         const auto& k = check_i64(keys);
         const auto& v = check_f64(vals);
         if (k.rows() != v.rows())
             throw std::runtime_error(
                 "groupby_sum_resident_f64: keys and vals row counts differ");
-        GroupByResidentResult r{};
-        r.rows_in = k.rows();
-        if (k.rows() == 0) { r.wall_ms = elapsed_ms(t0); return r; }
-
-        k.ensure_join_cache(stream_);
-        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
-        const std::size_t groups = checked_group_count("groupby_sum_resident_f64", k, max_groups);
-        DeviceOut<std::int64_t> d_keys(groups, "groupby out keys");
-        DeviceOut<double>       d_sums(groups, "groupby out sums (f64)");
-        DeviceOut<std::int64_t> d_cnts(groups, "groupby out counts");
-        std::size_t runs = 0;
-        GPUDB_CUDA_CHECK(gpudb_cuda_groupby_sum_f64(
-                             k.sorted_keys(), k.perm(),
-                             static_cast<const double*>(v.device_ptr()), k.rows(),
-                             d_keys.p, d_sums.p, d_cnts.p, &runs, stream_),
-                         "groupby_sum_f64 reduce_by_key");
-        r.kernel_ms = stop_kernel_timer();
-        check_runs("groupby_sum_resident_f64", runs, groups);
-
-        const auto tx = std::chrono::steady_clock::now();
-        d2h(r.keys,     d_keys, groups, "groupby keys D2H");
-        d2h(r.sums_f64, d_sums, groups, "groupby sums D2H");
-        d2h(r.counts,   d_cnts, groups, "groupby counts D2H");
-        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
-        r.transfer_ms = elapsed_ms(tx);
-        r.wall_ms     = elapsed_ms(t0);
-        return r;
+        return groupby_common<double>("groupby_sum_resident_f64", k,
+                                      static_cast<const double*>(v.device_ptr()),
+                                      max_groups, filter, t0);
     }
 
     GroupByResidentResult groupby_count_resident(const ResidentColumn& keys,
-                                                 std::size_t max_groups) override {
+                                                 std::size_t max_groups,
+                                                 const GroupByFilter& filter) override {
         const auto t0 = std::chrono::steady_clock::now();
         const auto& k = check_i64(keys);
-        GroupByResidentResult r{};
-        r.rows_in = k.rows();
-        if (k.rows() == 0) { r.wall_ms = elapsed_ms(t0); return r; }
-
-        k.ensure_join_cache(stream_);
-        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
-        const std::size_t groups = checked_group_count("groupby_count_resident", k, max_groups);
-        DeviceOut<std::int64_t> d_keys(groups, "groupby out keys");
-        DeviceOut<std::int64_t> d_cnts(groups, "groupby out counts");
-        std::size_t runs = 0;
-        GPUDB_CUDA_CHECK(gpudb_cuda_groupby_count(k.sorted_keys(), k.rows(),
-                                                  d_keys.p, d_cnts.p, &runs, stream_),
-                         "groupby_count reduce_by_key");
-        r.kernel_ms = stop_kernel_timer();
-        check_runs("groupby_count_resident", runs, groups);
-
-        const auto tx = std::chrono::steady_clock::now();
-        d2h(r.keys,   d_keys, groups, "groupby keys D2H");
-        d2h(r.counts, d_cnts, groups, "groupby counts D2H");
-        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
-        r.transfer_ms = elapsed_ms(tx);
-        r.wall_ms     = elapsed_ms(t0);
-        return r;
+        return groupby_common<std::int64_t>("groupby_count_resident", k, nullptr,
+                                            max_groups, filter, t0);
     }
 
     // top-k = a slice of the cached sort. kernel_ms covers the sort on the
@@ -658,6 +609,10 @@ private:
             if (n) GPUDB_CUDA_CHECK(cudaMalloc(&p, n * sizeof(T)), what);
         }
         ~DeviceOut() { if (p) cudaFree(p); }
+        void reset(std::size_t n, const char* what) {
+            if (p) { cudaFree(p); p = nullptr; }
+            if (n) GPUDB_CUDA_CHECK(cudaMalloc(&p, n * sizeof(T)), what);
+        }
         DeviceOut(const DeviceOut&) = delete;
         DeviceOut& operator=(const DeviceOut&) = delete;
     };
@@ -725,6 +680,116 @@ private:
             throw std::runtime_error(std::string(op) + ": reduce produced " +
                                      std::to_string(runs) + " runs, expected " +
                                      std::to_string(groups));
+    }
+
+    // Shared body of the three GROUP BY ops. A = aggregate type (i64 sum or
+    // count, or double sum); vals == nullptr means the count op (the
+    // aggregate is the count, no separate count vector).
+    template <typename A>
+    GroupByResidentResult groupby_common(const char* op, const CudaResidentColumn& k,
+                                         const A* vals, std::size_t max_groups,
+                                         const GroupByFilter& f,
+                                         std::chrono::steady_clock::time_point t0) {
+        constexpr bool kIsF64 = std::is_same<A, double>::value;
+        const bool is_count = (vals == nullptr);
+        GroupByResidentResult r{};
+        r.rows_in = k.rows();
+        if (k.rows() == 0) { r.wall_ms = elapsed_ms(t0); return r; }
+
+        k.ensure_join_cache(stream_);
+        GPUDB_CUDA_CHECK(cudaEventRecord(ev_start_, stream_), "ev_start");
+        std::size_t groups = 0;
+        GPUDB_CUDA_CHECK(gpudb_cuda_sorted_run_count(k.sorted_keys(), k.rows(), &groups, stream_),
+                         "groupby run count");
+        r.groups_total = groups;
+        if (!f.active() && groups > max_groups) throw_cap(op, groups, max_groups, false);
+
+        // Full aggregate on the device.
+        DeviceOut<std::int64_t> d_keys(groups, "groupby out keys");
+        DeviceOut<A>            d_agg(groups, "groupby out aggregate");
+        DeviceOut<std::int64_t> d_cnt(is_count ? 0 : groups, "groupby out counts");
+        std::size_t runs = 0;
+        if (is_count) {
+            GPUDB_CUDA_CHECK(gpudb_cuda_groupby_count(k.sorted_keys(), k.rows(), d_keys.p,
+                                                      reinterpret_cast<std::int64_t*>(d_agg.p),
+                                                      &runs, stream_),
+                             "groupby_count reduce_by_key");
+        } else if constexpr (kIsF64) {
+            GPUDB_CUDA_CHECK(gpudb_cuda_groupby_sum_f64(k.sorted_keys(), k.perm(), vals, k.rows(),
+                                                        d_keys.p, d_agg.p, d_cnt.p, &runs, stream_),
+                             "groupby_sum_f64 reduce_by_key");
+        } else {
+            GPUDB_CUDA_CHECK(gpudb_cuda_groupby_sum_i64(k.sorted_keys(), k.perm(), vals, k.rows(),
+                                                        d_keys.p, d_agg.p, d_cnt.p, &runs, stream_),
+                             "groupby_sum_i64 reduce_by_key");
+        }
+        check_runs(op, runs, groups);
+
+        // Filter on the device: survivors count -> cap -> select (+ top-k).
+        const std::int64_t* src_keys = d_keys.p;
+        const A*            src_agg  = d_agg.p;
+        const std::int64_t* src_cnt  = is_count ? nullptr : d_cnt.p;
+        std::size_t n_out = groups;
+        DeviceOut<std::int64_t> f_keys(0, ""); DeviceOut<A> f_agg(0, ""); DeviceOut<std::int64_t> f_cnt(0, "");
+        if (f.active()) {
+            const int cmp = static_cast<int>(f.cmp);
+            std::size_t surv = groups;
+            if (cmp != 0) {
+                if constexpr (kIsF64)
+                    GPUDB_CUDA_CHECK(gpudb_cuda_groupby_survivors_f64(d_agg.p, groups, cmp, f.threshold_f64,
+                                                                      &surv, stream_), "groupby filter count");
+                else
+                    GPUDB_CUDA_CHECK(gpudb_cuda_groupby_survivors_i64(d_agg.p, groups, cmp, f.threshold_i64,
+                                                                      &surv, stream_), "groupby filter count");
+            }
+            n_out = (f.topk != 0 && f.topk < surv) ? f.topk : surv;
+            if (n_out > max_groups) throw_cap(op, n_out, max_groups, true);
+            f_keys.reset(n_out, "groupby filtered keys");
+            f_agg.reset(n_out, "groupby filtered aggregate");
+            if (!is_count) f_cnt.reset(n_out, "groupby filtered counts");
+            if (n_out > 0) {
+                if constexpr (kIsF64)
+                    GPUDB_CUDA_CHECK(gpudb_cuda_groupby_filter_f64(d_keys.p, d_agg.p, src_cnt, groups, cmp,
+                                                                   f.threshold_f64, f.topk, f.topk_desc ? 1 : 0,
+                                                                   n_out, f_keys.p, f_agg.p, f_cnt.p, stream_),
+                                     "groupby filter select");
+                else
+                    GPUDB_CUDA_CHECK(gpudb_cuda_groupby_filter_i64(d_keys.p, d_agg.p, src_cnt, groups, cmp,
+                                                                   f.threshold_i64, f.topk, f.topk_desc ? 1 : 0,
+                                                                   n_out, f_keys.p, f_agg.p, f_cnt.p, stream_),
+                                     "groupby filter select");
+            }
+            src_keys = f_keys.p; src_agg = f_agg.p; src_cnt = is_count ? nullptr : f_cnt.p;
+        }
+        r.kernel_ms = stop_kernel_timer();
+
+        const auto tx = std::chrono::steady_clock::now();
+        d2h_raw(r.keys, src_keys, n_out, "groupby keys D2H");
+        if (is_count) {
+            d2h_raw(r.counts, reinterpret_cast<const std::int64_t*>(src_agg), n_out, "groupby counts D2H");
+        } else {
+            if constexpr (kIsF64) d2h_raw(r.sums_f64, src_agg, n_out, "groupby sums D2H");
+            else                  d2h_raw(r.sums, src_agg, n_out, "groupby sums D2H");
+            d2h_raw(r.counts, src_cnt, n_out, "groupby counts D2H");
+        }
+        GPUDB_CUDA_CHECK(cudaStreamSynchronize(stream_), "sync D2H");
+        r.transfer_ms = elapsed_ms(tx);
+        r.wall_ms     = elapsed_ms(t0);
+        return r;
+    }
+
+    [[noreturn]] static void throw_cap(const char* op, std::size_t n, std::size_t cap, bool filtered) {
+        throw std::runtime_error(
+            std::string(op) + ": result has " + std::to_string(n) +
+            (filtered ? " rows after the filter, above the cap of " : " groups, above the cap of ") +
+            std::to_string(cap) + " (raise GPUDB_GROUPBY_ROWS_MAX_M if intentional)");
+    }
+
+    template <typename T>
+    void d2h_raw(std::vector<T>& dst, const T* src, std::size_t n, const char* what) {
+        prepare_host(dst, n);
+        if (n) GPUDB_CUDA_CHECK(cudaMemcpyAsync(dst.data(), src, n * sizeof(T),
+                                                cudaMemcpyDeviceToHost, stream_), what);
     }
 
     static double elapsed_ms(std::chrono::steady_clock::time_point t0) {

--- a/src/backends/cuda/cuda_aggregator.cpp
+++ b/src/backends/cuda/cuda_aggregator.cpp
@@ -10,6 +10,7 @@
 
 #if defined(__linux__)
 #include <sys/mman.h>
+#include <unistd.h>
 #endif
 
 #include <algorithm>
@@ -674,12 +675,17 @@ private:
         v.reserve(n);
 #if defined(__linux__) && defined(MADV_HUGEPAGE)
         if (n * sizeof(T) >= (8u << 20)) {
-            constexpr std::uintptr_t kPage = 4096;
-            auto lo = reinterpret_cast<std::uintptr_t>(v.data());
-            auto hi = lo + n * sizeof(T);
-            lo = (lo + kPage - 1) & ~(kPage - 1);
-            hi &= ~(kPage - 1);
-            if (hi > lo) (void)madvise(reinterpret_cast<void*>(lo), hi - lo, MADV_HUGEPAGE);
+            // Best-effort: align to the system page size (4 KiB on x86-64,
+            // 64 KiB on some aarch64 kernels), advise the interior pages.
+            const long ps = sysconf(_SC_PAGESIZE);
+            if (ps > 0 && (ps & (ps - 1)) == 0) {
+                const auto page = static_cast<std::uintptr_t>(ps);
+                auto lo = reinterpret_cast<std::uintptr_t>(v.data());
+                auto hi = lo + n * sizeof(T);
+                lo = (lo + page - 1) & ~(page - 1);
+                hi &= ~(page - 1);
+                if (hi > lo) (void)madvise(reinterpret_cast<void*>(lo), hi - lo, MADV_HUGEPAGE);
+            }
         }
 #endif
         v.resize(n);

--- a/src/backends/cuda/kernels/cub_ops.cuh
+++ b/src/backends/cuda/kernels/cub_ops.cuh
@@ -1,0 +1,121 @@
+// cub_ops.cuh — CUB device primitives on EXPLICIT temp storage, plus the tiny
+// element-wise kernels the resident paths need. Nothing here allocates
+// behind our back: every buffer is a cudaMalloc we own and free ourselves,
+// and a free that fails (sticky device fault) is ignored rather than thrown
+// from a destructor — so a fault surfaces to the host wrapper as the real
+// cudaError_t instead of std::terminate.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <cub/cub.cuh>
+
+namespace gpudb_cuda_ops {
+
+using u64 = unsigned long long;
+using i64 = std::int64_t;
+
+struct DevBuf {
+    void* p = nullptr;
+    std::size_t bytes = 0;
+    cudaError_t alloc(std::size_t b) {
+        release();
+        bytes = b;
+        return b ? cudaMalloc(&p, b) : cudaSuccess;
+    }
+    void release() { if (p) { (void)cudaFree(p); p = nullptr; } bytes = 0; }
+    ~DevBuf() { release(); }
+    DevBuf() = default;
+    DevBuf(const DevBuf&) = delete;
+    DevBuf& operator=(const DevBuf&) = delete;
+};
+
+// Run a CUB call twice: size query, then for real on temp storage we own.
+template <typename F>
+cudaError_t with_temp(F&& call) {
+    std::size_t bytes = 0;
+    cudaError_t e = call(static_cast<void*>(nullptr), bytes);
+    if (e != cudaSuccess) return e;
+    DevBuf tmp;
+    if ((e = tmp.alloc(bytes ? bytes : 1)) != cudaSuccess) return e;
+    return call(tmp.p, bytes);
+}
+
+constexpr int kBlock = 256;
+inline unsigned grid_for(std::size_t n) {
+    const std::size_t g = (n + kBlock - 1) / kBlock;
+    return static_cast<unsigned>(g > 65535u * 16u ? 65535u * 16u : (g ? g : 1));
+}
+
+template <typename T, typename F>
+__global__ void transform_kernel(const T* __restrict__ in, u64* __restrict__ out,
+                                 std::size_t n, F f) {
+    const std::size_t stride = static_cast<std::size_t>(gridDim.x) * blockDim.x;
+    for (std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         i < n; i += stride) out[i] = f(in[i]);
+}
+template <typename T, typename F>
+cudaError_t transform(const T* in, u64* out, std::size_t n, F f, cudaStream_t s) {
+    if (n) transform_kernel<T, F><<<grid_for(n), kBlock, 0, s>>>(in, out, n, f);
+    return cudaGetLastError();
+}
+
+__global__ inline void sequence_kernel(i64* __restrict__ out, std::size_t n) {
+    const std::size_t stride = static_cast<std::size_t>(gridDim.x) * blockDim.x;
+    for (std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         i < n; i += stride) out[i] = static_cast<i64>(i);
+}
+inline cudaError_t sequence(i64* out, std::size_t n, cudaStream_t s) {
+    if (n) sequence_kernel<<<grid_for(n), kBlock, 0, s>>>(out, n);
+    return cudaGetLastError();
+}
+
+template <typename T>
+__global__ void gather_kernel(const i64* __restrict__ idx, std::size_t n,
+                              const T* __restrict__ src, T* __restrict__ dst) {
+    const std::size_t stride = static_cast<std::size_t>(gridDim.x) * blockDim.x;
+    for (std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         i < n; i += stride) dst[i] = src[idx[i]];
+}
+template <typename T>
+cudaError_t gather(const i64* idx, std::size_t n, const T* src, T* dst, cudaStream_t s) {
+    if (n) gather_kernel<T><<<grid_for(n), kBlock, 0, s>>>(idx, n, src, dst);
+    return cudaGetLastError();
+}
+
+// Sum of a transform over [0, n) (used for run counts and survivor counts).
+template <typename It>
+cudaError_t sum_u64(It first, std::size_t n, u64* d_out, cudaStream_t s) {
+    return with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceReduce::Sum(tmp, b, first, d_out, n, s);
+    });
+}
+
+// Ascending radix sort of (u64 key, i64 value) pairs, in place on the
+// caller's buffers (an alternate buffer pair is allocated here).
+inline cudaError_t sort_pairs_u64(u64* keys, i64* vals, std::size_t n, cudaStream_t s) {
+    if (n < 2) return cudaSuccess;
+    DevBuf ka, va;
+    cudaError_t e;
+    if ((e = ka.alloc(n * sizeof(u64))) != cudaSuccess) return e;
+    if ((e = va.alloc(n * sizeof(i64))) != cudaSuccess) return e;
+    cub::DoubleBuffer<u64> dk(keys, static_cast<u64*>(ka.p));
+    cub::DoubleBuffer<i64> dv(vals, static_cast<i64*>(va.p));
+    e = with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceRadixSort::SortPairs(tmp, b, dk, dv, n, 0, 64, s);
+    });
+    if (e != cudaSuccess) return e;
+    // Results may be in the alternate buffers: copy back if so.
+    if (dk.Current() != keys) {
+        if ((e = cudaMemcpyAsync(keys, dk.Current(), n * sizeof(u64),
+                                 cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+    }
+    if (dv.Current() != vals) {
+        if ((e = cudaMemcpyAsync(vals, dv.Current(), n * sizeof(i64),
+                                 cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+    }
+    return cudaStreamSynchronize(s);   // the alternates are freed on return
+}
+
+} // namespace gpudb_cuda_ops

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -27,6 +27,8 @@
 #include <thrust/tuple.h>
 #include <thrust/unique.h>
 
+#include "thrust_errors.cuh"
+
 namespace {
 
 using u64 = unsigned long long;
@@ -84,7 +86,7 @@ cudaError_t gpudb_cuda_sorted_run_count(const i64* d_sorted, std::size_t n,
         *h_runs = static_cast<std::size_t>(
             thrust::unique_count(thrust::cuda::par.on(s), d_sorted, d_sorted + n));
     } catch (...) {
-        return cudaErrorMemoryAllocation;
+        return gpudb_cuda_detail::map_exception();
     }
     return cudaGetLastError();
 }
@@ -106,7 +108,7 @@ cudaError_t gpudb_cuda_groupby_sum_i64(const i64* d_sorted, const i64* d_perm,
                                           thrust::equal_to<i64>(), AddU64Pair());
         *h_runs = static_cast<std::size_t>(ends.first - out_keys);
     } catch (...) {
-        return cudaErrorMemoryAllocation;
+        return gpudb_cuda_detail::map_exception();
     }
     return cudaGetLastError();
 }
@@ -126,7 +128,7 @@ cudaError_t gpudb_cuda_groupby_sum_f64(const i64* d_sorted, const i64* d_perm,
                                           thrust::equal_to<i64>(), AddF64Pair());
         *h_runs = static_cast<std::size_t>(ends.first - out_keys);
     } catch (...) {
-        return cudaErrorMemoryAllocation;
+        return gpudb_cuda_detail::map_exception();
     }
     return cudaGetLastError();
 }
@@ -142,7 +144,7 @@ cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
                                           out_keys, reinterpret_cast<u64*>(out_counts));
         *h_runs = static_cast<std::size_t>(ends.first - out_keys);
     } catch (...) {
-        return cudaErrorMemoryAllocation;
+        return gpudb_cuda_detail::map_exception();
     }
     return cudaGetLastError();
 }
@@ -161,7 +163,7 @@ cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
         thrust::sort_by_key(thrust::cuda::par.on(s), k, k + n, d_perm);
         thrust::gather(thrust::cuda::par.on(s), d_perm, d_perm + n, d_vals, d_sorted);
     } catch (...) {
-        return cudaErrorMemoryAllocation;
+        return gpudb_cuda_detail::map_exception();
     }
     return cudaStreamSynchronize(s);
 }

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -71,14 +71,6 @@ struct F64OrderKey {
     }
 };
 
-// Whole-buffer RAII for Thrust's own temp needs is internal to Thrust; this
-// is for the explicit key buffer of the f64 sort.
-struct DevBuf {
-    void* p = nullptr;
-    cudaError_t alloc(std::size_t bytes) { return cudaMalloc(&p, bytes); }
-    ~DevBuf() { if (p) cudaFree(p); }
-};
-
 } // namespace
 
 extern "C" {
@@ -156,14 +148,14 @@ cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
 }
 
 // f64 sort cache: d_sorted <- vals sorted ascending (NaN last), d_perm <- the
-// original indices in that order. Radix sort on order-preserving u64 keys.
+// original indices in that order. Radix sort on order-preserving u64 keys
+// built in d_sorted itself; the sorted doubles are then gathered over the
+// (no longer needed) keys in place, so no extra n-sized buffer is required —
+// peak extra memory is the sort's own scratch.
 cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
                                      i64* d_perm, std::size_t n, cudaStream_t s) {
-    DevBuf keys;
-    cudaError_t e = keys.alloc(n * sizeof(u64));
-    if (e != cudaSuccess) return e;
     try {
-        auto* k = static_cast<u64*>(keys.p);
+        auto* k = reinterpret_cast<u64*>(d_sorted);
         thrust::transform(thrust::cuda::par.on(s), d_vals, d_vals + n, k, F64OrderKey());
         thrust::sequence(thrust::cuda::par.on(s), d_perm, d_perm + n);
         thrust::sort_by_key(thrust::cuda::par.on(s), k, k + n, d_perm);

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -12,7 +12,7 @@
 // order-preserving uint64 keys (NaN greatest, matching DuckDB's total order)
 // so the radix path is used, then the sorted values are gathered back.
 
-#include <cmath>
+#include <algorithm>
 #include <cstdint>
 #include <cuda_runtime.h>
 
@@ -196,26 +196,6 @@ struct Keep {
         }
     }
 };
-// f64: DuckDB's total order for HAVING — NaN is greater than everything (so
-// NaN groups pass '>' and '>=', fail '<' and '<='), -0.0 == 0.0. Mirrors
-// apply_group_filter_host exactly; NOT the order-key mapping (which would
-// separate -0.0 from 0.0).
-template <>
-struct Keep<double> {
-    int cmp; double t;
-    __host__ __device__ static bool lt(double x, double y) {
-        return !isnan(x) && (isnan(y) || x < y);
-    }
-    __host__ __device__ bool operator()(double a) const {
-        switch (cmp) {
-            case 1:  return lt(t, a);     // a >  t
-            case 2:  return !lt(a, t);    // a >= t
-            case 3:  return lt(a, t);     // a <  t
-            case 4:  return !lt(t, a);    // a <= t
-            default: return true;
-        }
-    }
-};
 
 struct DevBuf {
     void* p = nullptr;
@@ -227,6 +207,16 @@ struct DevBuf {
 // folds sign-magnitude with EVERY NaN greatest (DuckDB ORDER BY order) and
 // -0.0 == 0.0 handled by the tie rule. Inverted keys turn "largest k" into
 // "smallest k" so one ascending radix sort serves both directions.
+// ---- radix-select for top-k of groups ----
+//
+// Aggregates are mapped to order-preserving u64 keys (i64: flip the sign
+// bit; f64: sign-magnitude fold with NaN greatest, as in F64OrderKey). For
+// "largest k" the keys are inverted so the problem is always "smallest k".
+// Eight MSB->LSB passes of a 256-bin histogram over the elements matching
+// the prefix so far locate the k-th key T; the output is every element
+// with key < T plus enough key == T elements to reach k (tie choice
+// unspecified, per the contract), finally sorted by key.
+
 template <typename A> struct OrderKey;
 template <> struct OrderKey<i64> {
     __host__ __device__ u64 operator()(i64 v) const { return static_cast<u64>(v) ^ (1ULL << 63); }
@@ -237,6 +227,76 @@ template <> struct OrderKey<double> {
 template <typename A> struct InvOrderKey {
     __host__ __device__ u64 operator()(A v) const { return ~OrderKey<A>{}(v); }
 };
+
+__global__ void radix_hist_kernel(const u64* __restrict__ keys, std::size_t n,
+                                  u64 prefix, int shift, u64* __restrict__ hist) {
+    __shared__ unsigned int sh[256];
+    for (int i = threadIdx.x; i < 256; i += blockDim.x) sh[i] = 0u;
+    __syncthreads();
+    const std::size_t stride = static_cast<std::size_t>(gridDim.x) * blockDim.x;
+    for (std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         i < n; i += stride) {
+        const u64 k = keys[i];
+        if (shift == 56 || (k >> (shift + 8)) == prefix)
+            atomicAdd(&sh[(k >> shift) & 0xFFu], 1u);
+    }
+    __syncthreads();
+    for (int i = threadIdx.x; i < 256; i += blockDim.x)
+        if (sh[i]) atomicAdd(&hist[i], static_cast<u64>(sh[i]));
+}
+
+struct KeyLess  { u64 t; __host__ __device__ bool operator()(u64 k) const { return k <  t; } };
+struct KeyEqual { u64 t; __host__ __device__ bool operator()(u64 k) const { return k == t; } };
+
+// Selects the k smallest of `keys` (u64 order keys, n of them) into idx[0..k)
+// sorted ascending by key. Requires 0 < k <= n. Uses only its own scratch.
+inline cudaError_t radix_select_k(const u64* keys, std::size_t n, std::size_t k,
+                                  i64* out_idx, cudaStream_t s) {
+    auto pol = thrust::cuda::par.on(s);
+    DevBuf hb; cudaError_t e = hb.alloc(256 * sizeof(u64));
+    if (e != cudaSuccess) return e;
+    auto* d_hist = static_cast<u64*>(hb.p);
+    u64 h[256];
+    u64 prefix = 0; std::size_t want = k;              // want-th smallest among prefix matches
+    const int grid = static_cast<int>(std::min<std::size_t>((n + 255) / 256, 4096));
+    for (int pass = 0; pass < 8; ++pass) {
+        const int shift = 56 - 8 * pass;
+        if ((e = cudaMemsetAsync(d_hist, 0, 256 * sizeof(u64), s)) != cudaSuccess) return e;
+        radix_hist_kernel<<<grid, 256, 0, s>>>(keys, n, prefix, shift, d_hist);
+        if ((e = cudaMemcpyAsync(h, d_hist, sizeof(h), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
+        if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
+        std::size_t acc = 0; int bin = 255;
+        for (int b = 0; b < 256; ++b) { if (acc + h[b] >= want) { bin = b; break; } acc += h[b]; }
+        want -= acc;
+        prefix = (prefix << 8) | static_cast<u64>(bin);
+    }
+    const u64 T = prefix;
+    try {
+        auto cnt = thrust::make_counting_iterator<i64>(0);
+        // strictly smaller than T: all of them
+        auto end_lt = thrust::copy_if(pol, cnt, cnt + static_cast<i64>(n), keys, out_idx, KeyLess{T});
+        const std::size_t n_lt = static_cast<std::size_t>(end_lt - out_idx);
+        if (n_lt < k) {
+            // ties at T: take the first (k - n_lt) in index order
+            const std::size_t need = k - n_lt;
+            const std::size_t n_eq = static_cast<std::size_t>(
+                thrust::count_if(pol, keys, keys + n, KeyEqual{T}));
+            DevBuf eb; if ((e = eb.alloc(n_eq * sizeof(i64))) != cudaSuccess) return e;
+            auto* d_eq = static_cast<i64*>(eb.p);
+            thrust::copy_if(pol, cnt, cnt + static_cast<i64>(n), keys, d_eq, KeyEqual{T});
+            if ((e = cudaMemcpyAsync(out_idx + n_lt, d_eq, need * sizeof(i64),
+                                     cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+        }
+        // order the k winners by key (ties by index, unspecified anyway)
+        DevBuf kb; if ((e = kb.alloc(k * sizeof(u64))) != cudaSuccess) return e;
+        auto* d_k = static_cast<u64*>(kb.p);
+        thrust::gather(pol, out_idx, out_idx + k, keys, d_k);
+        thrust::sort_by_key(pol, d_k, d_k + k, out_idx);
+    } catch (...) {
+        return gpudb_cuda_detail::map_exception();
+    }
+    return cudaGetLastError();
+}
 
 template <typename A>
 std::size_t count_survivors(const A* agg, std::size_t n, int cmp, A t, cudaStream_t s) {
@@ -291,11 +351,26 @@ cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::siz
             if (has_cnt) cudaMemcpyAsync(out_cnt, cnt, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
             return cudaGetLastError();
         }
-        // top-k over n_surv survivors: radix sort of (order key, index) — the
-        // order keys give one total order (NaN greatest) for both directions.
-        DevBuf kb, ix;
+        // top-k over n_surv survivors. Small k: radix-select on order keys
+        // (8 histogram passes + one compaction). Large k: full radix sort of
+        // (aggregate copy, index) pairs.
         cudaError_t e;
-        if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
+        if (n_out * 8 <= n_surv) {
+            DevBuf kb, ix;
+            if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
+            if ((e = ix.alloc(n_out * sizeof(i64)))  != cudaSuccess) return e;
+            auto* okeys = static_cast<u64*>(kb.p);
+            i64*  idx   = static_cast<i64*>(ix.p);
+            if (desc) thrust::transform(pol, a_in, a_in + n_surv, okeys, InvOrderKey<A>{});
+            else      thrust::transform(pol, a_in, a_in + n_surv, okeys, OrderKey<A>{});
+            if ((e = radix_select_k(okeys, n_surv, n_out, idx, s)) != cudaSuccess) return e;
+            thrust::gather(pol, idx, idx + n_out, k_in, out_keys);
+            thrust::gather(pol, idx, idx + n_out, a_in, out_agg);
+            if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
+            return cudaGetLastError();
+        }
+        DevBuf ak, ix;
+        if ((e = ak.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
         if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
         auto* okeys = static_cast<u64*>(kb.p);
         i64*  idx   = static_cast<i64*>(ix.p);

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -202,6 +202,21 @@ struct DevBuf {
     ~DevBuf() { if (p) cudaFree(p); }
 };
 
+// Order-preserving u64 keys for the aggregate: i64 flips the sign bit; f64
+// folds sign-magnitude with EVERY NaN greatest (DuckDB ORDER BY order) and
+// -0.0 == 0.0 handled by the tie rule. Inverted keys turn "largest k" into
+// "smallest k" so one ascending radix sort serves both directions.
+template <typename A> struct OrderKey;
+template <> struct OrderKey<i64> {
+    __host__ __device__ u64 operator()(i64 v) const { return static_cast<u64>(v) ^ (1ULL << 63); }
+};
+template <> struct OrderKey<double> {
+    __host__ __device__ u64 operator()(double d) const { return F64OrderKey{}(d); }
+};
+template <typename A> struct InvOrderKey {
+    __host__ __device__ u64 operator()(A v) const { return ~OrderKey<A>{}(v); }
+};
+
 template <typename A>
 std::size_t count_survivors(const A* agg, std::size_t n, int cmp, A t, cudaStream_t s) {
     if (cmp == 0) return n;
@@ -255,20 +270,21 @@ cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::siz
             if (has_cnt) cudaMemcpyAsync(out_cnt, cnt, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
             return cudaGetLastError();
         }
-        // top-k over n_surv survivors: radix sort (aggregate copy, index).
-        DevBuf ak, ix;
+        // top-k over n_surv survivors: radix sort of (order key, index) — the
+        // order keys give one total order (NaN greatest) for both directions.
+        DevBuf kb, ix;
         cudaError_t e;
-        if ((e = ak.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
+        if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
         if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
-        A*   a_sorted = static_cast<A*>(ak.p);
-        i64* idx      = static_cast<i64*>(ix.p);
-        cudaMemcpyAsync(a_sorted, a_in, n_surv * sizeof(A), cudaMemcpyDeviceToDevice, s);
+        auto* okeys = static_cast<u64*>(kb.p);
+        i64*  idx   = static_cast<i64*>(ix.p);
+        if (desc) thrust::transform(pol, a_in, a_in + n_surv, okeys, InvOrderKey<A>{});
+        else      thrust::transform(pol, a_in, a_in + n_surv, okeys, OrderKey<A>{});
         thrust::sequence(pol, idx, idx + n_surv);
-        if (desc) thrust::sort_by_key(pol, a_sorted, a_sorted + n_surv, idx, thrust::greater<A>());
-        else      thrust::sort_by_key(pol, a_sorted, a_sorted + n_surv, idx, thrust::less<A>());
+        thrust::sort_by_key(pol, okeys, okeys + n_surv, idx);
         thrust::gather(pol, idx, idx + n_out, k_in, out_keys);
+        thrust::gather(pol, idx, idx + n_out, a_in, out_agg);
         if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
-        cudaMemcpyAsync(out_agg, a_sorted, n_out * sizeof(A), cudaMemcpyDeviceToDevice, s);
     } catch (...) {
         return gpudb_cuda_detail::map_exception();
     }

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -210,7 +210,9 @@ struct DevBuf {
 // ---- radix-select for top-k of groups ----
 //
 // Aggregates are mapped to order-preserving u64 keys (i64: flip the sign
-// bit; f64: sign-magnitude fold with NaN greatest, as in F64OrderKey). For
+// bit; f64: sign-magnitude fold with every NaN greatest — DuckDB's ORDER BY
+// places NaN above +inf — and -0.0 < 0.0, as in F64OrderKey). Both top-k
+// paths (select and full sort) use these keys, so the order is one. For
 // "largest k" the keys are inverted so the problem is always "smallest k".
 // Eight MSB->LSB passes of a 256-bin histogram over the elements matching
 // the prefix so far locate the k-th key T; the output is every element
@@ -369,8 +371,10 @@ cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::siz
             if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
             return cudaGetLastError();
         }
-        DevBuf ak, ix;
-        if ((e = ak.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
+        // Full sort on the same order keys as the select path, so NaN placement
+        // (greatest) and -0.0/0.0 handling are identical whichever path runs.
+        DevBuf kb, ix;
+        if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
         if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
         auto* okeys = static_cast<u64*>(kb.p);
         i64*  idx   = static_cast<i64*>(ix.p);

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -1,0 +1,177 @@
+// groupby_resident_kernel.cu — resident GROUP BY / top-k device paths (v0.6).
+//
+// GROUP BY reuses the v0.5 build-side sort cache on the key column (keys
+// sorted ascending + original-index permutation). Values are read through
+// the permutation and reduced per key run with reduce_by_key (Thrust over
+// CUB DeviceReduce::ReduceByKey), so output rows come out sorted by key —
+// the cross-backend contract in gpu_backend.hpp. i64 sums accumulate in
+// uint64 (wrap-add commutes -> bit-exact regardless of reduction order);
+// f64 sums are backend-ordered under the tolerance contract.
+//
+// top-k on an f64 column needs its own sort: doubles are mapped to
+// order-preserving uint64 keys (NaN greatest, matching DuckDB's total order)
+// so the radix path is used, then the sorted values are gathered back.
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+#include <thrust/execution_policy.h>
+#include <thrust/gather.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/reduce.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+#include <thrust/tuple.h>
+#include <thrust/unique.h>
+
+namespace {
+
+using u64 = unsigned long long;
+using i64 = std::int64_t;
+
+// (value, 1) through the permutation: sorted position i -> original row perm[i].
+struct PermValI64 {
+    const i64* vals; const i64* perm;
+    __host__ __device__ thrust::tuple<u64, u64> operator()(i64 i) const {
+        return thrust::make_tuple(static_cast<u64>(vals[perm[i]]), 1ULL);
+    }
+};
+struct PermValF64 {
+    const double* vals; const i64* perm;
+    __host__ __device__ thrust::tuple<double, u64> operator()(i64 i) const {
+        return thrust::make_tuple(vals[perm[i]], 1ULL);
+    }
+};
+struct AddU64Pair {
+    __host__ __device__ thrust::tuple<u64, u64> operator()(const thrust::tuple<u64, u64>& a,
+                                                           const thrust::tuple<u64, u64>& b) const {
+        return thrust::make_tuple(thrust::get<0>(a) + thrust::get<0>(b),
+                                  thrust::get<1>(a) + thrust::get<1>(b));
+    }
+};
+struct AddF64Pair {
+    __host__ __device__ thrust::tuple<double, u64> operator()(const thrust::tuple<double, u64>& a,
+                                                              const thrust::tuple<double, u64>& b) const {
+        return thrust::make_tuple(thrust::get<0>(a) + thrust::get<0>(b),
+                                  thrust::get<1>(a) + thrust::get<1>(b));
+    }
+};
+
+// Order-preserving map double -> uint64: negatives reversed, positives get the
+// top bit, NaN (any sign) maps to the maximum so it sorts last.
+struct F64OrderKey {
+    __host__ __device__ u64 operator()(double d) const {
+        if (d != d) return ~0ULL;
+        u64 b;
+        memcpy(&b, &d, sizeof(b));
+        return (b >> 63) ? ~b : (b | (1ULL << 63));
+    }
+};
+
+// Whole-buffer RAII for Thrust's own temp needs is internal to Thrust; this
+// is for the explicit key buffer of the f64 sort.
+struct DevBuf {
+    void* p = nullptr;
+    cudaError_t alloc(std::size_t bytes) { return cudaMalloc(&p, bytes); }
+    ~DevBuf() { if (p) cudaFree(p); }
+};
+
+} // namespace
+
+extern "C" {
+
+// Number of distinct runs in an ascending-sorted i64 array (0 for n == 0).
+// Synchronizes the stream; the count lands on the host.
+cudaError_t gpudb_cuda_sorted_run_count(const i64* d_sorted, std::size_t n,
+                                        std::size_t* h_runs, cudaStream_t s) {
+    if (n == 0) { *h_runs = 0; return cudaSuccess; }
+    try {
+        *h_runs = static_cast<std::size_t>(
+            thrust::unique_count(thrust::cuda::par.on(s), d_sorted, d_sorted + n));
+    } catch (...) {
+        return cudaErrorMemoryAllocation;
+    }
+    return cudaGetLastError();
+}
+
+// SUM(vals) + COUNT(*) per run of d_sorted; outputs sized n_groups exactly.
+// Writes the run count actually produced to *h_runs (sanity-checked by host).
+cudaError_t gpudb_cuda_groupby_sum_i64(const i64* d_sorted, const i64* d_perm,
+                                       const i64* d_vals, std::size_t n,
+                                       i64* out_keys, i64* out_sums, i64* out_counts,
+                                       std::size_t* h_runs, cudaStream_t s) {
+    try {
+        auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
+                                                     PermValI64{d_vals, d_perm});
+        auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(
+            reinterpret_cast<u64*>(out_sums), reinterpret_cast<u64*>(out_counts)));
+        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
+                                          d_sorted, d_sorted + n, first,
+                                          out_keys, out_vals,
+                                          thrust::equal_to<i64>(), AddU64Pair());
+        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
+    } catch (...) {
+        return cudaErrorMemoryAllocation;
+    }
+    return cudaGetLastError();
+}
+
+cudaError_t gpudb_cuda_groupby_sum_f64(const i64* d_sorted, const i64* d_perm,
+                                       const double* d_vals, std::size_t n,
+                                       i64* out_keys, double* out_sums, i64* out_counts,
+                                       std::size_t* h_runs, cudaStream_t s) {
+    try {
+        auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
+                                                     PermValF64{d_vals, d_perm});
+        auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(
+            out_sums, reinterpret_cast<u64*>(out_counts)));
+        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
+                                          d_sorted, d_sorted + n, first,
+                                          out_keys, out_vals,
+                                          thrust::equal_to<i64>(), AddF64Pair());
+        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
+    } catch (...) {
+        return cudaErrorMemoryAllocation;
+    }
+    return cudaGetLastError();
+}
+
+// COUNT(*) per run of d_sorted (keys only; no permutation needed).
+cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
+                                     i64* out_keys, i64* out_counts,
+                                     std::size_t* h_runs, cudaStream_t s) {
+    try {
+        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
+                                          d_sorted, d_sorted + n,
+                                          thrust::constant_iterator<u64>(1ULL),
+                                          out_keys, reinterpret_cast<u64*>(out_counts));
+        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
+    } catch (...) {
+        return cudaErrorMemoryAllocation;
+    }
+    return cudaGetLastError();
+}
+
+// f64 sort cache: d_sorted <- vals sorted ascending (NaN last), d_perm <- the
+// original indices in that order. Radix sort on order-preserving u64 keys.
+cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
+                                     i64* d_perm, std::size_t n, cudaStream_t s) {
+    DevBuf keys;
+    cudaError_t e = keys.alloc(n * sizeof(u64));
+    if (e != cudaSuccess) return e;
+    try {
+        auto* k = static_cast<u64*>(keys.p);
+        thrust::transform(thrust::cuda::par.on(s), d_vals, d_vals + n, k, F64OrderKey());
+        thrust::sequence(thrust::cuda::par.on(s), d_perm, d_perm + n);
+        thrust::sort_by_key(thrust::cuda::par.on(s), k, k + n, d_perm);
+        thrust::gather(thrust::cuda::par.on(s), d_perm, d_perm + n, d_vals, d_sorted);
+    } catch (...) {
+        return cudaErrorMemoryAllocation;
+    }
+    return cudaStreamSynchronize(s);
+}
+
+} // extern "C"

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -414,4 +414,17 @@ cudaError_t gpudb_cuda_groupby_filter_f64(const i64* keys, const double* agg, co
     return apply_filter<double>(keys, agg, cnt, n, cmp, t, topk, desc != 0, n_out, out_keys, out_agg, out_cnt, s);
 }
 
+
+// Test hook: poison the context with an out-of-bounds device read so the
+// next resident op sees a sticky cudaErrorIllegalAddress. Only for the
+// fault-injection unit test (run in a forked child — the context is dead
+// afterwards). Returns the error the poisoning itself produced.
+cudaError_t gpudb_cuda_debug_fault_inject(cudaStream_t s) {
+    DevBuf b; cudaError_t e = b.alloc(64);
+    if (e != cudaSuccess) return e;
+    if ((e = cudaMemsetAsync(b.p, 0, 64, s)) != cudaSuccess) return e;
+    std::size_t runs = 0;
+    return gpudb_cuda_sorted_run_count(static_cast<const i64*>(b.p), std::size_t(1) << 28, &runs, s);
+}
+
 } // extern "C"

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -19,6 +19,7 @@
 // so the radix path is used, then the sorted values are gathered back.
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cuda_runtime.h>
 
@@ -110,6 +111,7 @@ cudaError_t reduce_runs(const i64* d_sorted, std::size_t n, Val vals_first, Add 
                         std::size_t* h_runs, cudaStream_t s) {
     DevBuf nr; cudaError_t e = nr.alloc(sizeof(u64));
     if (e != cudaSuccess) return e;
+    if ((e = cudaMemsetAsync(nr.p, 0, sizeof(u64), s)) != cudaSuccess) return e;   // CUB 2.x writes 32 bits
     auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(out_agg, reinterpret_cast<u64*>(out_counts)));
     e = with_temp([&](void* tmp, std::size_t& b) {
         return cub::DeviceReduce::ReduceByKey(tmp, b, d_sorted, out_keys, vals_first, out_vals,
@@ -142,6 +144,7 @@ template <typename In, typename Flags, typename Out>
 cudaError_t select_flagged(In in, Flags flags, Out out, std::size_t n, cudaStream_t s) {
     DevBuf ns; cudaError_t e = ns.alloc(sizeof(u64));
     if (e != cudaSuccess) return e;
+    if ((e = cudaMemsetAsync(ns.p, 0, sizeof(u64), s)) != cudaSuccess) return e;   // CUB 2.x writes 32 bits
     return with_temp([&](void* tmp, std::size_t& b) {
         return cub::DeviceSelect::Flagged(tmp, b, in, flags, out, static_cast<u64*>(ns.p), n, s);
     });
@@ -159,6 +162,26 @@ struct Keep {
             case 2:  return a >= t;
             case 3:  return a <  t;
             case 4:  return a <= t;
+            default: return true;
+        }
+    }
+};
+// f64: DuckDB's total order for HAVING — NaN is greater than everything (so
+// NaN groups pass '>' and '>=', fail '<' and '<='), -0.0 == 0.0. Mirrors
+// apply_group_filter_host exactly; NOT the order-key mapping (which would
+// separate -0.0 from 0.0).
+template <>
+struct Keep<double> {
+    int cmp; double t;
+    __host__ __device__ static bool lt(double x, double y) {
+        return !isnan(x) && (isnan(y) || x < y);
+    }
+    __host__ __device__ bool operator()(double a) const {
+        switch (cmp) {
+            case 1:  return lt(t, a);     // a >  t
+            case 2:  return !lt(a, t);    // a >= t
+            case 3:  return lt(a, t);     // a <  t
+            case 4:  return !lt(t, a);    // a <= t
             default: return true;
         }
     }
@@ -365,6 +388,7 @@ cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
                                      std::size_t* h_runs, cudaStream_t s) {
     DevBuf nr; cudaError_t e = nr.alloc(sizeof(u64));
     if (e != cudaSuccess) return e;
+    if ((e = cudaMemsetAsync(nr.p, 0, sizeof(u64), s)) != cudaSuccess) return e;   // CUB 2.x writes 32 bits
     e = with_temp([&](void* tmp, std::size_t& b) {
         return cub::DeviceReduce::ReduceByKey(tmp, b, d_sorted, out_keys,
                                               thrust::constant_iterator<u64>(1ULL),

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -2,11 +2,17 @@
 //
 // GROUP BY reuses the v0.5 build-side sort cache on the key column (keys
 // sorted ascending + original-index permutation). Values are read through
-// the permutation and reduced per key run with reduce_by_key (Thrust over
-// CUB DeviceReduce::ReduceByKey), so output rows come out sorted by key —
-// the cross-backend contract in gpu_backend.hpp. i64 sums accumulate in
-// uint64 (wrap-add commutes -> bit-exact regardless of reduction order);
-// f64 sums are backend-ordered under the tolerance contract.
+// the permutation and reduced per key run with CUB DeviceReduce::ReduceByKey,
+// so output rows come out sorted by key — the cross-backend contract in
+// gpu_backend.hpp. i64 sums accumulate in uint64 (wrap-add commutes ->
+// bit-exact regardless of reduction order); f64 sums are backend-ordered
+// under the tolerance contract.
+//
+// Every CUB call here runs on EXPLICIT temp storage we allocate and free
+// (cub_ops.cuh); Thrust is used only for its allocation-free iterators. So a
+// device fault inside any step comes back to the host wrapper as its real
+// cudaError_t (-> std::runtime_error -> SQL error) instead of a Thrust
+// temporary's destructor throwing on cudaFree and aborting the process.
 //
 // top-k on an f64 column needs its own sort: doubles are mapped to
 // order-preserving uint64 keys (NaN greatest, matching DuckDB's total order)
@@ -16,27 +22,20 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-#include <thrust/execution_policy.h>
-#include <thrust/gather.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/copy.h>
-#include <thrust/count.h>
-#include <thrust/functional.h>
-#include <thrust/reduce.h>
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
 #include <thrust/tuple.h>
-#include <thrust/unique.h>
 
-#include "thrust_errors.cuh"
+#include "cub_ops.cuh"
 
 namespace {
 
 using u64 = unsigned long long;
 using i64 = std::int64_t;
+using gpudb_cuda_ops::DevBuf;
+using gpudb_cuda_ops::with_temp;
 
 // (value, 1) through the permutation: sorted position i -> original row perm[i].
 struct PermValI64 {
@@ -65,6 +64,17 @@ struct AddF64Pair {
                                   thrust::get<1>(a) + thrust::get<1>(b));
     }
 };
+struct AddU64 {
+    __host__ __device__ u64 operator()(u64 a, u64 b) const { return a + b; }
+};
+
+// 1 at every run start of an ascending-sorted key array.
+struct RunStart {
+    const i64* keys;
+    __host__ __device__ u64 operator()(i64 i) const {
+        return (i == 0 || keys[i] != keys[i - 1]) ? 1ULL : 0ULL;
+    }
+};
 
 // Order-preserving map double -> uint64: negatives reversed, positives get the
 // top bit, NaN (any sign) maps to the maximum so it sorts last.
@@ -77,111 +87,68 @@ struct F64OrderKey {
     }
 };
 
-} // namespace
+// Order-preserving u64 keys for the aggregate: i64 flips the sign bit; f64
+// folds sign-magnitude with EVERY NaN greatest (DuckDB ORDER BY order) and
+// -0.0 == 0.0 handled by the tie rule. Inverted keys turn "largest k" into
+// "smallest k" so one ascending radix sort serves both directions.
+template <typename A> struct OrderKey;
+template <> struct OrderKey<i64> {
+    __host__ __device__ u64 operator()(i64 v) const { return static_cast<u64>(v) ^ (1ULL << 63); }
+};
+template <> struct OrderKey<double> {
+    __host__ __device__ u64 operator()(double d) const { return F64OrderKey{}(d); }
+};
+template <typename A> struct InvOrderKey {
+    __host__ __device__ u64 operator()(A v) const { return ~OrderKey<A>{}(v); }
+};
 
-extern "C" {
-
-// Number of distinct runs in an ascending-sorted i64 array (0 for n == 0).
-// Synchronizes the stream; the count lands on the host.
-cudaError_t gpudb_cuda_sorted_run_count(const i64* d_sorted, std::size_t n,
-                                        std::size_t* h_runs, cudaStream_t s) {
-    if (n == 0) { *h_runs = 0; return cudaSuccess; }
-    try {
-        *h_runs = static_cast<std::size_t>(
-            thrust::unique_count(thrust::cuda::par.on(s), d_sorted, d_sorted + n));
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaGetLastError();
+// Reduce the permuted values per key run. Outputs sized to the run count;
+// the run count actually produced lands in *h_runs.
+template <typename A, typename Val, typename Add>
+cudaError_t reduce_runs(const i64* d_sorted, std::size_t n, Val vals_first, Add add,
+                        i64* out_keys, A* out_agg, i64* out_counts,
+                        std::size_t* h_runs, cudaStream_t s) {
+    DevBuf nr; cudaError_t e = nr.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(out_agg, reinterpret_cast<u64*>(out_counts)));
+    e = with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceReduce::ReduceByKey(tmp, b, d_sorted, out_keys, vals_first, out_vals,
+                                              static_cast<u64*>(nr.p), add, n, s);
+    });
+    if (e != cudaSuccess) return e;
+    u64 runs = 0;
+    if ((e = cudaMemcpyAsync(&runs, nr.p, sizeof(u64), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
+    if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
+    *h_runs = static_cast<std::size_t>(runs);
+    return cudaSuccess;
 }
 
-// SUM(vals) + COUNT(*) per run of d_sorted; outputs sized n_groups exactly.
-// Writes the run count actually produced to *h_runs (sanity-checked by host).
-cudaError_t gpudb_cuda_groupby_sum_i64(const i64* d_sorted, const i64* d_perm,
-                                       const i64* d_vals, std::size_t n,
-                                       i64* out_keys, i64* out_sums, i64* out_counts,
-                                       std::size_t* h_runs, cudaStream_t s) {
-    try {
-        auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
-                                                     PermValI64{d_vals, d_perm});
-        auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(
-            reinterpret_cast<u64*>(out_sums), reinterpret_cast<u64*>(out_counts)));
-        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
-                                          d_sorted, d_sorted + n, first,
-                                          out_keys, out_vals,
-                                          thrust::equal_to<i64>(), AddU64Pair());
-        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaGetLastError();
+// Sum of a device-side transform, returned to the host.
+template <typename It>
+cudaError_t host_sum(It first, std::size_t n, std::size_t* h_out, cudaStream_t s) {
+    if (n == 0) { *h_out = 0; return cudaSuccess; }
+    DevBuf o; cudaError_t e = o.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sum_u64(first, n, static_cast<u64*>(o.p), s)) != cudaSuccess) return e;
+    u64 v = 0;
+    if ((e = cudaMemcpyAsync(&v, o.p, sizeof(u64), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
+    if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
+    *h_out = static_cast<std::size_t>(v);
+    return cudaSuccess;
 }
 
-cudaError_t gpudb_cuda_groupby_sum_f64(const i64* d_sorted, const i64* d_perm,
-                                       const double* d_vals, std::size_t n,
-                                       i64* out_keys, double* out_sums, i64* out_counts,
-                                       std::size_t* h_runs, cudaStream_t s) {
-    try {
-        auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
-                                                     PermValF64{d_vals, d_perm});
-        auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(
-            out_sums, reinterpret_cast<u64*>(out_counts)));
-        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
-                                          d_sorted, d_sorted + n, first,
-                                          out_keys, out_vals,
-                                          thrust::equal_to<i64>(), AddF64Pair());
-        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaGetLastError();
+// Compact `in` (any random-access iterator) where flag(i) into `out`.
+template <typename In, typename Flags, typename Out>
+cudaError_t select_flagged(In in, Flags flags, Out out, std::size_t n, cudaStream_t s) {
+    DevBuf ns; cudaError_t e = ns.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    return with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceSelect::Flagged(tmp, b, in, flags, out, static_cast<u64*>(ns.p), n, s);
+    });
 }
-
-// COUNT(*) per run of d_sorted (keys only; no permutation needed).
-cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
-                                     i64* out_keys, i64* out_counts,
-                                     std::size_t* h_runs, cudaStream_t s) {
-    try {
-        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
-                                          d_sorted, d_sorted + n,
-                                          thrust::constant_iterator<u64>(1ULL),
-                                          out_keys, reinterpret_cast<u64*>(out_counts));
-        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaGetLastError();
-}
-
-// f64 sort cache: d_sorted <- vals sorted ascending (NaN last), d_perm <- the
-// original indices in that order. Radix sort on order-preserving u64 keys
-// built in d_sorted itself; the sorted doubles are then gathered over the
-// (no longer needed) keys in place, so no extra n-sized buffer is required —
-// peak extra memory is the sort's own scratch.
-cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
-                                     i64* d_perm, std::size_t n, cudaStream_t s) {
-    try {
-        auto* k = reinterpret_cast<u64*>(d_sorted);
-        thrust::transform(thrust::cuda::par.on(s), d_vals, d_vals + n, k, F64OrderKey());
-        thrust::sequence(thrust::cuda::par.on(s), d_perm, d_perm + n);
-        thrust::sort_by_key(thrust::cuda::par.on(s), k, k + n, d_perm);
-        thrust::gather(thrust::cuda::par.on(s), d_perm, d_perm + n, d_vals, d_sorted);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaStreamSynchronize(s);
-}
-
-} // extern "C"
 
 // ---- GroupByFilter on the device (v0.6): cmp on the aggregate, then top-k ----
-//
-// Survivors are selected with copy_if (order preserved, so the key-sorted
-// order survives); top-k radix-sorts (aggregate, index) pairs — primitive
-// keys and values, so Thrust takes the radix path — and gathers the first k.
 // cmp codes mirror GroupByFilter::Cmp: 0 None, 1 GT, 2 GE, 3 LT, 4 LE.
-
-namespace {
 
 template <typename A>
 struct Keep {
@@ -196,40 +163,28 @@ struct Keep {
         }
     }
 };
-
-struct DevBuf {
-    void* p = nullptr;
-    cudaError_t alloc(std::size_t bytes) { return bytes ? cudaMalloc(&p, bytes) : cudaSuccess; }
-    ~DevBuf() { if (p) cudaFree(p); }
+template <typename A>
+struct KeepU64 {          // Keep as a 0/1 count over element indices
+    const A* agg; Keep<A> k;
+    __host__ __device__ u64 operator()(i64 i) const { return k(agg[i]) ? 1ULL : 0ULL; }
+};
+template <typename A>
+struct KeepFlag {         // Keep as a bool flag over element indices
+    const A* agg; Keep<A> k;
+    __host__ __device__ bool operator()(i64 i) const { return k(agg[i]); }
 };
 
-// Order-preserving u64 keys for the aggregate: i64 flips the sign bit; f64
-// folds sign-magnitude with EVERY NaN greatest (DuckDB ORDER BY order) and
-// -0.0 == 0.0 handled by the tie rule. Inverted keys turn "largest k" into
-// "smallest k" so one ascending radix sort serves both directions.
+struct KeyLessU64  { const u64* keys; u64 t; __host__ __device__ u64  operator()(i64 i) const { return keys[i] <  t ? 1ULL : 0ULL; } };
+struct KeyLessFlag { const u64* keys; u64 t; __host__ __device__ bool operator()(i64 i) const { return keys[i] <  t; } };
+struct KeyEqU64    { const u64* keys; u64 t; __host__ __device__ u64  operator()(i64 i) const { return keys[i] == t ? 1ULL : 0ULL; } };
+struct KeyEqFlag   { const u64* keys; u64 t; __host__ __device__ bool operator()(i64 i) const { return keys[i] == t; } };
+
 // ---- radix-select for top-k of groups ----
 //
-// Aggregates are mapped to order-preserving u64 keys (i64: flip the sign
-// bit; f64: sign-magnitude fold with every NaN greatest — DuckDB's ORDER BY
-// places NaN above +inf — and -0.0 < 0.0, as in F64OrderKey). Both top-k
-// paths (select and full sort) use these keys, so the order is one. For
-// "largest k" the keys are inverted so the problem is always "smallest k".
 // Eight MSB->LSB passes of a 256-bin histogram over the elements matching
-// the prefix so far locate the k-th key T; the output is every element
-// with key < T plus enough key == T elements to reach k (tie choice
+// the prefix so far locate the k-th smallest key T; the output is every
+// element with key < T plus enough key == T elements to reach k (tie choice
 // unspecified, per the contract), finally sorted by key.
-
-template <typename A> struct OrderKey;
-template <> struct OrderKey<i64> {
-    __host__ __device__ u64 operator()(i64 v) const { return static_cast<u64>(v) ^ (1ULL << 63); }
-};
-template <> struct OrderKey<double> {
-    __host__ __device__ u64 operator()(double d) const { return F64OrderKey{}(d); }
-};
-template <typename A> struct InvOrderKey {
-    __host__ __device__ u64 operator()(A v) const { return ~OrderKey<A>{}(v); }
-};
-
 __global__ void radix_hist_kernel(const u64* __restrict__ keys, std::size_t n,
                                   u64 prefix, int shift, u64* __restrict__ hist) {
     __shared__ unsigned int sh[256];
@@ -247,14 +202,10 @@ __global__ void radix_hist_kernel(const u64* __restrict__ keys, std::size_t n,
         if (sh[i]) atomicAdd(&hist[i], static_cast<u64>(sh[i]));
 }
 
-struct KeyLess  { u64 t; __host__ __device__ bool operator()(u64 k) const { return k <  t; } };
-struct KeyEqual { u64 t; __host__ __device__ bool operator()(u64 k) const { return k == t; } };
-
 // Selects the k smallest of `keys` (u64 order keys, n of them) into idx[0..k)
 // sorted ascending by key. Requires 0 < k <= n. Uses only its own scratch.
 inline cudaError_t radix_select_k(const u64* keys, std::size_t n, std::size_t k,
                                   i64* out_idx, cudaStream_t s) {
-    auto pol = thrust::cuda::par.on(s);
     DevBuf hb; cudaError_t e = hb.alloc(256 * sizeof(u64));
     if (e != cudaSuccess) return e;
     auto* d_hist = static_cast<u64*>(hb.p);
@@ -265,6 +216,7 @@ inline cudaError_t radix_select_k(const u64* keys, std::size_t n, std::size_t k,
         const int shift = 56 - 8 * pass;
         if ((e = cudaMemsetAsync(d_hist, 0, 256 * sizeof(u64), s)) != cudaSuccess) return e;
         radix_hist_kernel<<<grid, 256, 0, s>>>(keys, n, prefix, shift, d_hist);
+        if ((e = cudaGetLastError()) != cudaSuccess) return e;
         if ((e = cudaMemcpyAsync(h, d_hist, sizeof(h), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
         if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
         std::size_t acc = 0; int bin = 255;
@@ -273,38 +225,34 @@ inline cudaError_t radix_select_k(const u64* keys, std::size_t n, std::size_t k,
         prefix = (prefix << 8) | static_cast<u64>(bin);
     }
     const u64 T = prefix;
-    try {
-        auto cnt = thrust::make_counting_iterator<i64>(0);
-        // strictly smaller than T: all of them
-        auto end_lt = thrust::copy_if(pol, cnt, cnt + static_cast<i64>(n), keys, out_idx, KeyLess{T});
-        const std::size_t n_lt = static_cast<std::size_t>(end_lt - out_idx);
-        if (n_lt < k) {
-            // ties at T: take the first (k - n_lt) in index order
-            const std::size_t need = k - n_lt;
-            const std::size_t n_eq = static_cast<std::size_t>(
-                thrust::count_if(pol, keys, keys + n, KeyEqual{T}));
-            DevBuf eb; if ((e = eb.alloc(n_eq * sizeof(i64))) != cudaSuccess) return e;
-            auto* d_eq = static_cast<i64*>(eb.p);
-            thrust::copy_if(pol, cnt, cnt + static_cast<i64>(n), keys, d_eq, KeyEqual{T});
-            if ((e = cudaMemcpyAsync(out_idx + n_lt, d_eq, need * sizeof(i64),
-                                     cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
-        }
-        // order the k winners by key (ties by index, unspecified anyway)
-        DevBuf kb; if ((e = kb.alloc(k * sizeof(u64))) != cudaSuccess) return e;
-        auto* d_k = static_cast<u64*>(kb.p);
-        thrust::gather(pol, out_idx, out_idx + k, keys, d_k);
-        thrust::sort_by_key(pol, d_k, d_k + k, out_idx);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
+    auto cnt = thrust::make_counting_iterator<i64>(0);
+    // strictly smaller than T: all of them
+    std::size_t n_lt = 0;
+    if ((e = host_sum(thrust::make_transform_iterator(cnt, KeyLessU64{keys, T}), n, &n_lt, s)) != cudaSuccess) return e;
+    if ((e = select_flagged(cnt, thrust::make_transform_iterator(cnt, KeyLessFlag{keys, T}), out_idx, n, s)) != cudaSuccess) return e;
+    if (n_lt < k) {
+        // ties at T: take the first (k - n_lt) in index order
+        const std::size_t need = k - n_lt;
+        std::size_t n_eq = 0;
+        if ((e = host_sum(thrust::make_transform_iterator(cnt, KeyEqU64{keys, T}), n, &n_eq, s)) != cudaSuccess) return e;
+        DevBuf eb; if ((e = eb.alloc(n_eq * sizeof(i64))) != cudaSuccess) return e;
+        auto* d_eq = static_cast<i64*>(eb.p);
+        if ((e = select_flagged(cnt, thrust::make_transform_iterator(cnt, KeyEqFlag{keys, T}), d_eq, n, s)) != cudaSuccess) return e;
+        if ((e = cudaMemcpyAsync(out_idx + n_lt, d_eq, need * sizeof(i64),
+                                 cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
     }
-    return cudaGetLastError();
+    // order the k winners by key (ties by index, unspecified anyway)
+    DevBuf kb; if ((e = kb.alloc(k * sizeof(u64))) != cudaSuccess) return e;
+    auto* d_k = static_cast<u64*>(kb.p);
+    if ((e = gpudb_cuda_ops::gather(out_idx, k, keys, d_k, s)) != cudaSuccess) return e;
+    return gpudb_cuda_ops::sort_pairs_u64(d_k, out_idx, k, s);
 }
 
 template <typename A>
-std::size_t count_survivors(const A* agg, std::size_t n, int cmp, A t, cudaStream_t s) {
-    if (cmp == 0) return n;
-    return static_cast<std::size_t>(
-        thrust::count_if(thrust::cuda::par.on(s), agg, agg + n, Keep<A>{cmp, t}));
+cudaError_t count_survivors(const A* agg, std::size_t n, int cmp, A t, std::size_t* h_out, cudaStream_t s) {
+    if (cmp == 0) { *h_out = n; return cudaSuccess; }
+    auto cnt = thrust::make_counting_iterator<i64>(0);
+    return host_sum(thrust::make_transform_iterator(cnt, KeepU64<A>{agg, Keep<A>{cmp, t}}), n, h_out, s);
 }
 
 // Writes exactly n_out rows: the survivors of cmp (key order) when topk == 0,
@@ -314,80 +262,68 @@ template <typename A>
 cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::size_t n,
                          int cmp, A t, std::size_t topk, bool desc, std::size_t n_out,
                          i64* out_keys, A* out_agg, i64* out_cnt, cudaStream_t s) {
-    auto pol = thrust::cuda::par.on(s);
     const bool has_cnt = (cnt != nullptr);
-    DevBuf sk, sa, sc;                       // survivors (only when cmp active)
+    cudaError_t e;
+    DevBuf sk, sa, sc;                       // survivors (only when cmp active and top-k follows)
     const i64* k_in = keys; const A* a_in = agg; const i64* c_in = cnt;
     std::size_t n_surv = n;
-    try {
-        if (cmp != 0) {
-            n_surv = count_survivors(agg, n, cmp, t, s);
-            // When there is no top-k the survivors ARE the output: select
-            // straight into the caller's buffers.
-            i64* dk = (topk == 0) ? out_keys : nullptr;
-            A*   da = (topk == 0) ? out_agg  : nullptr;
-            i64* dc = (topk == 0) ? out_cnt  : nullptr;
-            if (topk != 0) {
-                cudaError_t e;
-                if ((e = sk.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
-                if ((e = sa.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
-                if (has_cnt && (e = sc.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
-                dk = static_cast<i64*>(sk.p); da = static_cast<A*>(sa.p);
-                dc = has_cnt ? static_cast<i64*>(sc.p) : nullptr;
-            }
-            if (has_cnt) {
-                auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg, cnt));
-                auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da, dc));
-                thrust::copy_if(pol, first, first + n, agg, out, Keep<A>{cmp, t});
-            } else {
-                auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg));
-                auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da));
-                thrust::copy_if(pol, first, first + n, agg, out, Keep<A>{cmp, t});
-            }
-            if (topk == 0) return cudaGetLastError();
-            k_in = dk; a_in = da; c_in = dc;
-        } else if (topk == 0) {
-            // No filter at all: plain copies (caller normally avoids this path).
-            cudaMemcpyAsync(out_keys, keys, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
-            cudaMemcpyAsync(out_agg,  agg,  n * sizeof(A),   cudaMemcpyDeviceToDevice, s);
-            if (has_cnt) cudaMemcpyAsync(out_cnt, cnt, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
-            return cudaGetLastError();
+    auto ci = thrust::make_counting_iterator<i64>(0);
+    if (cmp != 0) {
+        if ((e = count_survivors(agg, n, cmp, t, &n_surv, s)) != cudaSuccess) return e;
+        i64* dk = (topk == 0) ? out_keys : nullptr;
+        A*   da = (topk == 0) ? out_agg  : nullptr;
+        i64* dc = (topk == 0) ? out_cnt  : nullptr;
+        if (topk != 0) {
+            if ((e = sk.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+            if ((e = sa.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
+            if (has_cnt && (e = sc.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+            dk = static_cast<i64*>(sk.p); da = static_cast<A*>(sa.p);
+            dc = has_cnt ? static_cast<i64*>(sc.p) : nullptr;
         }
-        // top-k over n_surv survivors. Small k: radix-select on order keys
-        // (8 histogram passes + one compaction). Large k: full radix sort of
-        // (aggregate copy, index) pairs.
-        cudaError_t e;
-        if (n_out * 8 <= n_surv) {
-            DevBuf kb, ix;
-            if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
-            if ((e = ix.alloc(n_out * sizeof(i64)))  != cudaSuccess) return e;
-            auto* okeys = static_cast<u64*>(kb.p);
-            i64*  idx   = static_cast<i64*>(ix.p);
-            if (desc) thrust::transform(pol, a_in, a_in + n_surv, okeys, InvOrderKey<A>{});
-            else      thrust::transform(pol, a_in, a_in + n_surv, okeys, OrderKey<A>{});
-            if ((e = radix_select_k(okeys, n_surv, n_out, idx, s)) != cudaSuccess) return e;
-            thrust::gather(pol, idx, idx + n_out, k_in, out_keys);
-            thrust::gather(pol, idx, idx + n_out, a_in, out_agg);
-            if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
-            return cudaGetLastError();
+        auto flags = thrust::make_transform_iterator(ci, KeepFlag<A>{agg, Keep<A>{cmp, t}});
+        if (has_cnt) {
+            auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg, cnt));
+            auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da, dc));
+            if ((e = select_flagged(first, flags, out, n, s)) != cudaSuccess) return e;
+        } else {
+            auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg));
+            auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da));
+            if ((e = select_flagged(first, flags, out, n, s)) != cudaSuccess) return e;
         }
-        // Full sort on the same order keys as the select path, so NaN placement
-        // (greatest) and -0.0/0.0 handling are identical whichever path runs.
-        DevBuf kb, ix;
-        if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
-        if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
-        auto* okeys = static_cast<u64*>(kb.p);
-        i64*  idx   = static_cast<i64*>(ix.p);
-        if (desc) thrust::transform(pol, a_in, a_in + n_surv, okeys, InvOrderKey<A>{});
-        else      thrust::transform(pol, a_in, a_in + n_surv, okeys, OrderKey<A>{});
-        thrust::sequence(pol, idx, idx + n_surv);
-        thrust::sort_by_key(pol, okeys, okeys + n_surv, idx);
-        thrust::gather(pol, idx, idx + n_out, k_in, out_keys);
-        thrust::gather(pol, idx, idx + n_out, a_in, out_agg);
-        if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
+        if (topk == 0) return cudaGetLastError();
+        k_in = dk; a_in = da; c_in = dc;
+    } else if (topk == 0) {
+        // No filter at all: plain copies (caller normally avoids this path).
+        if ((e = cudaMemcpyAsync(out_keys, keys, n * sizeof(i64), cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+        if ((e = cudaMemcpyAsync(out_agg,  agg,  n * sizeof(A),   cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+        if (has_cnt && (e = cudaMemcpyAsync(out_cnt, cnt, n * sizeof(i64), cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+        return cudaGetLastError();
     }
+    // top-k over n_surv survivors, on order keys (one total order, NaN greatest).
+    DevBuf kb, ix;
+    if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
+    auto* okeys = static_cast<u64*>(kb.p);
+    if (desc) e = gpudb_cuda_ops::transform(a_in, okeys, n_surv, InvOrderKey<A>{}, s);
+    else      e = gpudb_cuda_ops::transform(a_in, okeys, n_surv, OrderKey<A>{}, s);
+    if (e != cudaSuccess) return e;
+    if (n_out * 8 <= n_surv) {
+        // Small k: radix-select (8 histogram passes + one compaction).
+        if ((e = ix.alloc(n_out * sizeof(i64))) != cudaSuccess) return e;
+        i64* idx = static_cast<i64*>(ix.p);
+        if ((e = radix_select_k(okeys, n_surv, n_out, idx, s)) != cudaSuccess) return e;
+        if ((e = gpudb_cuda_ops::gather(idx, n_out, k_in, out_keys, s)) != cudaSuccess) return e;
+        if ((e = gpudb_cuda_ops::gather(idx, n_out, a_in, out_agg, s)) != cudaSuccess) return e;
+        if (has_cnt && (e = gpudb_cuda_ops::gather(idx, n_out, c_in, out_cnt, s)) != cudaSuccess) return e;
+        return cudaGetLastError();
+    }
+    // Large k: full radix sort of (order key, index).
+    if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+    i64* idx = static_cast<i64*>(ix.p);
+    if ((e = gpudb_cuda_ops::sequence(idx, n_surv, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sort_pairs_u64(okeys, idx, n_surv, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::gather(idx, n_out, k_in, out_keys, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::gather(idx, n_out, a_in, out_agg, s)) != cudaSuccess) return e;
+    if (has_cnt && (e = gpudb_cuda_ops::gather(idx, n_out, c_in, out_cnt, s)) != cudaSuccess) return e;
     return cudaGetLastError();
 }
 
@@ -395,17 +331,77 @@ cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::siz
 
 extern "C" {
 
+// Number of distinct runs in an ascending-sorted i64 array (0 for n == 0).
+// Synchronizes the stream; the count lands on the host.
+cudaError_t gpudb_cuda_sorted_run_count(const i64* d_sorted, std::size_t n,
+                                        std::size_t* h_runs, cudaStream_t s) {
+    auto cnt = thrust::make_counting_iterator<i64>(0);
+    return host_sum(thrust::make_transform_iterator(cnt, RunStart{d_sorted}), n, h_runs, s);
+}
+
+// SUM(vals) + COUNT(*) per run of d_sorted; outputs sized n_groups exactly.
+cudaError_t gpudb_cuda_groupby_sum_i64(const i64* d_sorted, const i64* d_perm,
+                                       const i64* d_vals, std::size_t n,
+                                       i64* out_keys, i64* out_sums, i64* out_counts,
+                                       std::size_t* h_runs, cudaStream_t s) {
+    auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
+                                                 PermValI64{d_vals, d_perm});
+    return reduce_runs<u64>(d_sorted, n, first, AddU64Pair{}, out_keys,
+                            reinterpret_cast<u64*>(out_sums), out_counts, h_runs, s);
+}
+
+cudaError_t gpudb_cuda_groupby_sum_f64(const i64* d_sorted, const i64* d_perm,
+                                       const double* d_vals, std::size_t n,
+                                       i64* out_keys, double* out_sums, i64* out_counts,
+                                       std::size_t* h_runs, cudaStream_t s) {
+    auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
+                                                 PermValF64{d_vals, d_perm});
+    return reduce_runs<double>(d_sorted, n, first, AddF64Pair{}, out_keys, out_sums, out_counts, h_runs, s);
+}
+
+// COUNT(*) per run of d_sorted (keys only; no permutation needed).
+cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
+                                     i64* out_keys, i64* out_counts,
+                                     std::size_t* h_runs, cudaStream_t s) {
+    DevBuf nr; cudaError_t e = nr.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    e = with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceReduce::ReduceByKey(tmp, b, d_sorted, out_keys,
+                                              thrust::constant_iterator<u64>(1ULL),
+                                              reinterpret_cast<u64*>(out_counts),
+                                              static_cast<u64*>(nr.p), AddU64{}, n, s);
+    });
+    if (e != cudaSuccess) return e;
+    u64 runs = 0;
+    if ((e = cudaMemcpyAsync(&runs, nr.p, sizeof(u64), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
+    if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
+    *h_runs = static_cast<std::size_t>(runs);
+    return cudaSuccess;
+}
+
+// f64 sort cache: d_sorted <- vals sorted ascending (NaN last), d_perm <- the
+// original indices in that order. Radix sort on order-preserving u64 keys
+// built in d_sorted itself; the sorted doubles are then gathered over the
+// (no longer needed) keys in place, so no extra n-sized buffer is required —
+// peak extra memory is the sort's own scratch.
+cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
+                                     i64* d_perm, std::size_t n, cudaStream_t s) {
+    auto* k = reinterpret_cast<u64*>(d_sorted);
+    cudaError_t e;
+    if ((e = gpudb_cuda_ops::transform(d_vals, k, n, F64OrderKey{}, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sequence(d_perm, n, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sort_pairs_u64(k, d_perm, n, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::gather(d_perm, n, d_vals, d_sorted, s)) != cudaSuccess) return e;
+    return cudaStreamSynchronize(s);
+}
+
 cudaError_t gpudb_cuda_groupby_survivors_i64(const i64* agg, std::size_t n, int cmp, i64 t,
                                              std::size_t* h_out, cudaStream_t s) {
-    try { *h_out = count_survivors<i64>(agg, n, cmp, t, s); }
-    catch (...) { return gpudb_cuda_detail::map_exception(); }
-    return cudaGetLastError();
+    return count_survivors<i64>(agg, n, cmp, t, h_out, s);
 }
 cudaError_t gpudb_cuda_groupby_survivors_f64(const double* agg, std::size_t n, int cmp, double t,
                                              std::size_t* h_out, cudaStream_t s) {
-    try { *h_out = count_survivors<double>(agg, n, cmp, t, s); }
-    catch (...) { return gpudb_cuda_detail::map_exception(); }
-    return cudaGetLastError();
+    return count_survivors<double>(agg, n, cmp, t, h_out, s);
 }
 cudaError_t gpudb_cuda_groupby_filter_i64(const i64* keys, const i64* agg, const i64* cnt, std::size_t n,
                                           int cmp, i64 t, std::size_t topk, int desc, std::size_t n_out,

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -12,6 +12,7 @@
 // order-preserving uint64 keys (NaN greatest, matching DuckDB's total order)
 // so the radix path is used, then the sorted values are gathered back.
 
+#include <cmath>
 #include <cstdint>
 #include <cuda_runtime.h>
 
@@ -191,6 +192,26 @@ struct Keep {
             case 2:  return a >= t;
             case 3:  return a <  t;
             case 4:  return a <= t;
+            default: return true;
+        }
+    }
+};
+// f64: DuckDB's total order for HAVING — NaN is greater than everything (so
+// NaN groups pass '>' and '>=', fail '<' and '<='), -0.0 == 0.0. Mirrors
+// apply_group_filter_host exactly; NOT the order-key mapping (which would
+// separate -0.0 from 0.0).
+template <>
+struct Keep<double> {
+    int cmp; double t;
+    __host__ __device__ static bool lt(double x, double y) {
+        return !isnan(x) && (isnan(y) || x < y);
+    }
+    __host__ __device__ bool operator()(double a) const {
+        switch (cmp) {
+            case 1:  return lt(t, a);     // a >  t
+            case 2:  return !lt(a, t);    // a >= t
+            case 3:  return lt(a, t);     // a <  t
+            case 4:  return !lt(t, a);    // a <= t
             default: return true;
         }
     }

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -21,6 +21,9 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
+#include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/functional.h>
 #include <thrust/reduce.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
@@ -166,6 +169,137 @@ cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
         return gpudb_cuda_detail::map_exception();
     }
     return cudaStreamSynchronize(s);
+}
+
+} // extern "C"
+
+// ---- GroupByFilter on the device (v0.6): cmp on the aggregate, then top-k ----
+//
+// Survivors are selected with copy_if (order preserved, so the key-sorted
+// order survives); top-k radix-sorts (aggregate, index) pairs — primitive
+// keys and values, so Thrust takes the radix path — and gathers the first k.
+// cmp codes mirror GroupByFilter::Cmp: 0 None, 1 GT, 2 GE, 3 LT, 4 LE.
+
+namespace {
+
+template <typename A>
+struct Keep {
+    int cmp; A t;
+    __host__ __device__ bool operator()(A a) const {
+        switch (cmp) {
+            case 1:  return a >  t;
+            case 2:  return a >= t;
+            case 3:  return a <  t;
+            case 4:  return a <= t;
+            default: return true;
+        }
+    }
+};
+
+struct DevBuf {
+    void* p = nullptr;
+    cudaError_t alloc(std::size_t bytes) { return bytes ? cudaMalloc(&p, bytes) : cudaSuccess; }
+    ~DevBuf() { if (p) cudaFree(p); }
+};
+
+template <typename A>
+std::size_t count_survivors(const A* agg, std::size_t n, int cmp, A t, cudaStream_t s) {
+    if (cmp == 0) return n;
+    return static_cast<std::size_t>(
+        thrust::count_if(thrust::cuda::par.on(s), agg, agg + n, Keep<A>{cmp, t}));
+}
+
+// Writes exactly n_out rows: the survivors of cmp (key order) when topk == 0,
+// else the first n_out of the survivors sorted by aggregate. cnt may be
+// null (count op: the aggregate IS the count). Caller sized the outputs.
+template <typename A>
+cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::size_t n,
+                         int cmp, A t, std::size_t topk, bool desc, std::size_t n_out,
+                         i64* out_keys, A* out_agg, i64* out_cnt, cudaStream_t s) {
+    auto pol = thrust::cuda::par.on(s);
+    const bool has_cnt = (cnt != nullptr);
+    DevBuf sk, sa, sc;                       // survivors (only when cmp active)
+    const i64* k_in = keys; const A* a_in = agg; const i64* c_in = cnt;
+    std::size_t n_surv = n;
+    try {
+        if (cmp != 0) {
+            n_surv = count_survivors(agg, n, cmp, t, s);
+            // When there is no top-k the survivors ARE the output: select
+            // straight into the caller's buffers.
+            i64* dk = (topk == 0) ? out_keys : nullptr;
+            A*   da = (topk == 0) ? out_agg  : nullptr;
+            i64* dc = (topk == 0) ? out_cnt  : nullptr;
+            if (topk != 0) {
+                cudaError_t e;
+                if ((e = sk.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+                if ((e = sa.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
+                if (has_cnt && (e = sc.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+                dk = static_cast<i64*>(sk.p); da = static_cast<A*>(sa.p);
+                dc = has_cnt ? static_cast<i64*>(sc.p) : nullptr;
+            }
+            if (has_cnt) {
+                auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg, cnt));
+                auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da, dc));
+                thrust::copy_if(pol, first, first + n, agg, out, Keep<A>{cmp, t});
+            } else {
+                auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg));
+                auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da));
+                thrust::copy_if(pol, first, first + n, agg, out, Keep<A>{cmp, t});
+            }
+            if (topk == 0) return cudaGetLastError();
+            k_in = dk; a_in = da; c_in = dc;
+        } else if (topk == 0) {
+            // No filter at all: plain copies (caller normally avoids this path).
+            cudaMemcpyAsync(out_keys, keys, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
+            cudaMemcpyAsync(out_agg,  agg,  n * sizeof(A),   cudaMemcpyDeviceToDevice, s);
+            if (has_cnt) cudaMemcpyAsync(out_cnt, cnt, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
+            return cudaGetLastError();
+        }
+        // top-k over n_surv survivors: radix sort (aggregate copy, index).
+        DevBuf ak, ix;
+        cudaError_t e;
+        if ((e = ak.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
+        if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+        A*   a_sorted = static_cast<A*>(ak.p);
+        i64* idx      = static_cast<i64*>(ix.p);
+        cudaMemcpyAsync(a_sorted, a_in, n_surv * sizeof(A), cudaMemcpyDeviceToDevice, s);
+        thrust::sequence(pol, idx, idx + n_surv);
+        if (desc) thrust::sort_by_key(pol, a_sorted, a_sorted + n_surv, idx, thrust::greater<A>());
+        else      thrust::sort_by_key(pol, a_sorted, a_sorted + n_surv, idx, thrust::less<A>());
+        thrust::gather(pol, idx, idx + n_out, k_in, out_keys);
+        if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
+        cudaMemcpyAsync(out_agg, a_sorted, n_out * sizeof(A), cudaMemcpyDeviceToDevice, s);
+    } catch (...) {
+        return gpudb_cuda_detail::map_exception();
+    }
+    return cudaGetLastError();
+}
+
+} // namespace
+
+extern "C" {
+
+cudaError_t gpudb_cuda_groupby_survivors_i64(const i64* agg, std::size_t n, int cmp, i64 t,
+                                             std::size_t* h_out, cudaStream_t s) {
+    try { *h_out = count_survivors<i64>(agg, n, cmp, t, s); }
+    catch (...) { return gpudb_cuda_detail::map_exception(); }
+    return cudaGetLastError();
+}
+cudaError_t gpudb_cuda_groupby_survivors_f64(const double* agg, std::size_t n, int cmp, double t,
+                                             std::size_t* h_out, cudaStream_t s) {
+    try { *h_out = count_survivors<double>(agg, n, cmp, t, s); }
+    catch (...) { return gpudb_cuda_detail::map_exception(); }
+    return cudaGetLastError();
+}
+cudaError_t gpudb_cuda_groupby_filter_i64(const i64* keys, const i64* agg, const i64* cnt, std::size_t n,
+                                          int cmp, i64 t, std::size_t topk, int desc, std::size_t n_out,
+                                          i64* out_keys, i64* out_agg, i64* out_cnt, cudaStream_t s) {
+    return apply_filter<i64>(keys, agg, cnt, n, cmp, t, topk, desc != 0, n_out, out_keys, out_agg, out_cnt, s);
+}
+cudaError_t gpudb_cuda_groupby_filter_f64(const i64* keys, const double* agg, const i64* cnt, std::size_t n,
+                                          int cmp, double t, std::size_t topk, int desc, std::size_t n_out,
+                                          i64* out_keys, double* out_agg, i64* out_cnt, cudaStream_t s) {
+    return apply_filter<double>(keys, agg, cnt, n, cmp, t, topk, desc != 0, n_out, out_keys, out_agg, out_cnt, s);
 }
 
 } // extern "C"

--- a/src/backends/cuda/kernels/join_kernel.cu
+++ b/src/backends/cuda/kernels/join_kernel.cu
@@ -18,11 +18,17 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
+#include "cub_ops.cuh"
+
 #include "thrust_errors.cuh"
 
 namespace {
 
 constexpr int BLOCK = 256;
+
+// i64 <-> order-preserving u64 (sign bit flipped), for the radix sort.
+struct FlipSign     { __host__ __device__ unsigned long long operator()(std::int64_t v) const { return static_cast<unsigned long long>(v) ^ (1ULL << 63); } };
+struct FlipSignBack { __host__ __device__ unsigned long long operator()(unsigned long long k) const { return k ^ (1ULL << 63); } };
 
 using u64 = unsigned long long;
 
@@ -194,12 +200,16 @@ cudaError_t gpudb_cuda_join_build_sort(const std::int64_t* d_keys,
     cudaError_t e = cudaMemcpyAsync(d_sorted, d_keys, n * sizeof(std::int64_t),
                                     cudaMemcpyDeviceToDevice, s);
     if (e != cudaSuccess) return e;
-    try {
-        thrust::sequence(thrust::cuda::par.on(s), d_perm, d_perm + n);
-        thrust::sort_by_key(thrust::cuda::par.on(s), d_sorted, d_sorted + n, d_perm);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
+    // Sort as order-preserving u64 keys (sign bit flipped) so the radix pass
+    // handles negatives; flip back afterwards. Explicit temp storage: a
+    // device fault returns its cudaError_t here instead of aborting.
+    e = gpudb_cuda_ops::transform(d_sorted, reinterpret_cast<u64*>(d_sorted), n, FlipSign{}, s);
+    if (e != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sequence(d_perm, n, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sort_pairs_u64(reinterpret_cast<u64*>(d_sorted), d_perm, n, s)) != cudaSuccess) return e;
+    e = gpudb_cuda_ops::transform(reinterpret_cast<const u64*>(d_sorted),
+                                  reinterpret_cast<u64*>(d_sorted), n, FlipSignBack{}, s);
+    if (e != cudaSuccess) return e;
     return cudaStreamSynchronize(s);
 }
 
@@ -245,12 +255,15 @@ cudaError_t gpudb_cuda_join_rows_count(const std::int64_t* d_probe,
 // total <- sum(cnt); cnt <- exclusive_scan(cnt) in place. Synchronizes.
 cudaError_t gpudb_cuda_join_rows_scan(u64* d_cnt, std::size_t n,
                                       u64* h_total, cudaStream_t s) {
-    try {
-        *h_total = thrust::reduce(thrust::cuda::par.on(s), d_cnt, d_cnt + n, u64{0});
-        thrust::exclusive_scan(thrust::cuda::par.on(s), d_cnt, d_cnt + n, d_cnt);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
+    gpudb_cuda_ops::DevBuf tot;
+    cudaError_t e = tot.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sum_u64(d_cnt, n, static_cast<u64*>(tot.p), s)) != cudaSuccess) return e;
+    e = gpudb_cuda_ops::with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceScan::ExclusiveSum(tmp, b, d_cnt, d_cnt, n, s);
+    });
+    if (e != cudaSuccess) return e;
+    if ((e = cudaMemcpyAsync(h_total, tot.p, sizeof(u64), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
     return cudaStreamSynchronize(s);
 }
 

--- a/src/backends/cuda/kernels/join_kernel.cu
+++ b/src/backends/cuda/kernels/join_kernel.cu
@@ -18,6 +18,8 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
+#include "thrust_errors.cuh"
+
 namespace {
 
 constexpr int BLOCK = 256;
@@ -196,7 +198,7 @@ cudaError_t gpudb_cuda_join_build_sort(const std::int64_t* d_keys,
         thrust::sequence(thrust::cuda::par.on(s), d_perm, d_perm + n);
         thrust::sort_by_key(thrust::cuda::par.on(s), d_sorted, d_sorted + n, d_perm);
     } catch (...) {
-        return cudaErrorMemoryAllocation;
+        return gpudb_cuda_detail::map_exception();
     }
     return cudaStreamSynchronize(s);
 }
@@ -247,7 +249,7 @@ cudaError_t gpudb_cuda_join_rows_scan(u64* d_cnt, std::size_t n,
         *h_total = thrust::reduce(thrust::cuda::par.on(s), d_cnt, d_cnt + n, u64{0});
         thrust::exclusive_scan(thrust::cuda::par.on(s), d_cnt, d_cnt + n, d_cnt);
     } catch (...) {
-        return cudaErrorMemoryAllocation;
+        return gpudb_cuda_detail::map_exception();
     }
     return cudaStreamSynchronize(s);
 }

--- a/src/backends/cuda/kernels/thrust_errors.cuh
+++ b/src/backends/cuda/kernels/thrust_errors.cuh
@@ -1,0 +1,29 @@
+// thrust_errors.cuh — map exceptions thrown inside Thrust/CUB calls to the
+// cudaError_t the launchers return, so the host wrapper reports the real
+// cause (launch failure, illegal address, bad stream, ...) instead of
+// labelling every failure "out of memory".
+#pragma once
+
+#include <cuda_runtime.h>
+#include <new>
+#include <thrust/system_error.h>
+#include <thrust/system/cuda/error.h>
+
+namespace gpudb_cuda_detail {
+
+// Call as: `catch (...) { return gpudb_cuda_detail::map_exception(); }`
+inline cudaError_t map_exception() noexcept {
+    try {
+        throw;
+    } catch (const thrust::system_error& e) {
+        if (e.code().category() == thrust::cuda_category())
+            return static_cast<cudaError_t>(e.code().value());
+        return cudaErrorUnknown;
+    } catch (const std::bad_alloc&) {
+        return cudaErrorMemoryAllocation;
+    } catch (...) {
+        return cudaErrorUnknown;
+    }
+}
+
+} // namespace gpudb_cuda_detail

--- a/test/cpp/test_aggregator.cpp
+++ b/test/cpp/test_aggregator.cpp
@@ -261,11 +261,13 @@ void test_backend(gpudb::Backend b) {
             auto tk = agg->topk_resident(*vc, N + 10, false);   // k clamps to rows
             EXPECT_EQ(tk.idx.size(), N);
 
-            // gpudb::GroupByFilter (device-side HAVING + top-k of groups) vs the host
-            // reference on adversarial filters: threshold equal to a sum (all
-            // four comparisons), everything filtered, k > survivors, k == 1,
-            // negative thresholds, heavy ties, cmp + top-k, count and f64 ops.
+            // GroupByFilter, adversarial cases (CUDA-side additions to the
+            // "resident group by filter" block below): threshold equal to a
+            // sum for all four comparisons, everything filtered, k > survivors,
+            // k == 1, negative thresholds, heavy ties, cmp + top-k, f64 top-k,
+            // count op, and the filtered cap wording.
             {
+                std::printf("  resident group by filter, adversarial cases:\n");
                 using Cmp = gpudb::GroupByFilter::Cmp;
                 const std::size_t cap = std::size_t(100) * 1000000;
                 auto base_i = agg->groupby_sum_resident_i64(*kc, *vc, cap);

--- a/test/cpp/test_aggregator.cpp
+++ b/test/cpp/test_aggregator.cpp
@@ -261,6 +261,74 @@ void test_backend(gpudb::Backend b) {
             auto tk = agg->topk_resident(*vc, N + 10, false);   // k clamps to rows
             EXPECT_EQ(tk.idx.size(), N);
 
+            // gpudb::GroupByFilter (device-side HAVING + top-k of groups) vs the host
+            // reference on adversarial filters: threshold equal to a sum (all
+            // four comparisons), everything filtered, k > survivors, k == 1,
+            // negative thresholds, heavy ties, cmp + top-k, count and f64 ops.
+            {
+                using Cmp = gpudb::GroupByFilter::Cmp;
+                const std::size_t cap = std::size_t(100) * 1000000;
+                auto base_i = agg->groupby_sum_resident_i64(*kc, *vc, cap);
+                auto base_f = agg->groupby_sum_resident_f64(*kc, *fc, cap);
+                auto base_c = agg->groupby_count_resident(*kc, cap);
+                EXPECT_EQ(base_i.groups_total, ref.size());
+                const std::int64_t eq_sum = base_i.sums[base_i.sums.size() / 3];
+                const double       eq_f   = base_f.sums_f64[base_f.sums_f64.size() / 3];
+                const std::int64_t max_sum = *std::max_element(base_i.sums.begin(), base_i.sums.end());
+                const gpudb::GroupByFilter filters[] = {
+                    {Cmp::GT, eq_sum, eq_f, 0, true}, {Cmp::GE, eq_sum, eq_f, 0, true},
+                    {Cmp::LT, eq_sum, eq_f, 0, true}, {Cmp::LE, eq_sum, eq_f, 0, true},
+                    {Cmp::GT, max_sum + 1, 1e300, 0, true},              // everything filtered
+                    {Cmp::None, 0, 0.0, 10, true}, {Cmp::None, 0, 0.0, 10, false},
+                    {Cmp::None, 0, 0.0, 1, true},
+                    {Cmp::GT, max_sum - 2, eq_f, 1000000, true},         // k > survivors
+                    {Cmp::LT, 0, 0.0, 25, false}, {Cmp::LE, -900000, -2.0e5, 7, true},
+                    {Cmp::None, 0, 0.0, 3000, true},                     // ties among small counts
+                };
+                auto same = [](const gpudb::GroupByResidentResult& a, const gpudb::GroupByResidentResult& b, bool f64) {
+                    if (a.keys.size() != b.keys.size() || a.groups_total != b.groups_total) return false;
+                    std::vector<std::size_t> ia(a.keys.size()), ib(b.keys.size());
+                    for (std::size_t i = 0; i < ia.size(); ++i) { ia[i] = i; ib[i] = i; }
+                    std::sort(ia.begin(), ia.end(), [&](std::size_t x, std::size_t y) { return a.keys[x] < a.keys[y]; });
+                    std::sort(ib.begin(), ib.end(), [&](std::size_t x, std::size_t y) { return b.keys[x] < b.keys[y]; });
+                    for (std::size_t i = 0; i < ia.size(); ++i) {
+                        const std::size_t x = ia[i], y = ib[i];
+                        if (a.keys[x] != b.keys[y] || a.counts[x] != b.counts[y]) return false;
+                        if (f64) {
+                            const double tol = 1e-9 * std::max(1.0, std::abs(b.sums_f64[y]));
+                            if (std::abs(a.sums_f64[x] - b.sums_f64[y]) > tol) return false;
+                        } else if (!a.sums.empty() && a.sums[x] != b.sums[y]) return false;
+                    }
+                    return true;
+                };
+                for (const auto& fl : filters) {
+                    gpudb::GroupByResidentResult ri = base_i, rf = base_f, rc = base_c;
+                    gpudb::apply_group_filter_host(ri, fl, gpudb::FilterAgg::SumI64, cap, "ref");
+                    gpudb::apply_group_filter_host(rf, fl, gpudb::FilterAgg::SumF64, cap, "ref");
+                    gpudb::apply_group_filter_host(rc, fl, gpudb::FilterAgg::Count,  cap, "ref");
+                    auto gi = agg->groupby_sum_resident_i64(*kc, *vc, cap, fl);
+                    auto gf = agg->groupby_sum_resident_f64(*kc, *fc, cap, fl);
+                    auto gc = agg->groupby_count_resident(*kc, cap, fl);
+                    EXPECT(same(gi, ri, false));
+                    EXPECT(same(gf, rf, true));
+                    EXPECT(same(gc, rc, false));
+                    // order contract: key ascending without top-k, by aggregate with it
+                    bool ord = true;
+                    if (fl.topk == 0) ord = std::is_sorted(gi.keys.begin(), gi.keys.end());
+                    else for (std::size_t i = 1; i < gi.sums.size(); ++i)
+                        ord = ord && (fl.topk_desc ? gi.sums[i - 1] >= gi.sums[i] : gi.sums[i - 1] <= gi.sums[i]);
+                    EXPECT(ord);
+                }
+                // cap bounds the rows returned, with the filtered wording
+                bool threw_f = false;
+                try { (void)agg->groupby_sum_resident_i64(*kc, *vc, 3, gpudb::GroupByFilter{Cmp::GE, std::numeric_limits<std::int64_t>::min(), 0.0, 0, true}); }
+                catch (const std::runtime_error& e) { threw_f = std::string(e.what()).find("rows after the filter, above the cap of 3") != std::string::npos; }
+                EXPECT(threw_f);
+                auto small = agg->groupby_sum_resident_i64(*kc, *vc, 9, gpudb::GroupByFilter{Cmp::None, 0, 0.0, 9, true});
+                EXPECT_EQ(small.keys.size(), std::size_t(9));
+                EXPECT_EQ(small.groups_total, ref.size());
+            }
+
             // Regression: keys whose min and max share a low byte while a
             // key between them does not (0x4146, 0x4E46, 0x4E4F, 0x5246 —
             // TPC-H returnflag/linestatus packed). A radix sort that skips

--- a/test/cpp/test_aggregator.cpp
+++ b/test/cpp/test_aggregator.cpp
@@ -5,6 +5,10 @@
 #include "../../src/backends/groupby_filter.hpp"
 
 #include <algorithm>
+#if defined(__linux__)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -743,7 +747,58 @@ void test_hybrid_groupby() {
     }
 }
 
-int main() {
+#if GPUDB_HAVE_CUDA && defined(__linux__)
+extern "C" int gpudb_cuda_debug_fault_inject(void* stream);   // cudaError_t; 0 == success
+
+// A device fault (illegal address) is sticky: the context is dead for the
+// rest of the process. The contract is that it reaches SQL as an error, not
+// as an abort — Thrust temporaries used to throw from a destructor on the
+// failing cudaFree and terminate the process. The scenario runs in a fresh
+// child process (re-exec of this binary; a fork could not reuse the
+// parent's CUDA context): it poisons the context, calls a resident op, and
+// must see a std::runtime_error naming the fault and exit normally.
+int cuda_fault_child() {
+    try {
+        auto agg = gpudb::make_aggregator(gpudb::Backend::CUDA);
+        std::vector<std::int64_t> k = {1, 1, 2, 3};
+        auto kc = agg->upload_i64(k.data(), k.size());
+        (void)gpudb_cuda_debug_fault_inject(nullptr);
+        try {
+            (void)agg->groupby_count_resident(*kc, 100);
+            return 2;                                                 // no error at all
+        } catch (const std::runtime_error& e) {
+            return std::string(e.what()).find("illegal memory access") != std::string::npos ? 0 : 1;
+        }
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "fault child: unexpected: %s\n", e.what());
+        return 4;
+    }
+}
+
+void test_cuda_device_fault_is_an_error() {
+    std::printf("--- CUDA device fault surfaces as std::runtime_error (child process) ---\n");
+    std::fflush(stdout);
+    const pid_t pid = fork();
+    if (pid == 0) {
+        execl("/proc/self/exe", "test_gpudb", "--cuda-fault-child", static_cast<char*>(nullptr));
+        std::_Exit(5);                                                // exec failed
+    }
+    int status = 0;
+    (void)waitpid(pid, &status, 0);
+    const bool clean_exit = WIFEXITED(status);
+    const int  rc         = clean_exit ? WEXITSTATUS(status) : -1;
+    EXPECT(clean_exit);           // not SIGABRT / SIGSEGV
+    EXPECT_EQ(rc, 0);             // runtime_error naming the illegal access
+    std::printf("  child: %s, rc=%d\n", clean_exit ? "exited" : "killed by signal", rc);
+}
+#endif
+
+int main(int argc, char** argv) {
+#if GPUDB_HAVE_CUDA && defined(__linux__)
+    if (argc > 1 && std::string(argv[1]) == "--cuda-fault-child") return cuda_fault_child();
+#else
+    (void)argc; (void)argv;
+#endif
     std::printf("gpudb test suite\n");
     std::printf("available backends:");
     for (auto b : gpudb::available_backends()) std::printf(" %s", gpudb::to_string(b));
@@ -761,6 +816,10 @@ int main() {
     test_hybrid_aggregator();
     test_hybrid_groupby();
     test_hashjoin();
+
+#if GPUDB_HAVE_CUDA && defined(__linux__)
+    test_cuda_device_fault_is_an_error();
+#endif
 
 #if GPUDB_HAVE_METAL
     // Regression: the non-resident Metal GROUP BY's radix path (expected

--- a/test/cpp/test_aggregator.cpp
+++ b/test/cpp/test_aggregator.cpp
@@ -329,6 +329,42 @@ void test_backend(gpudb::Backend b) {
                 auto small = agg->groupby_sum_resident_i64(*kc, *vc, 9, gpudb::GroupByFilter{Cmp::None, 0, 0.0, 9, true});
                 EXPECT_EQ(small.keys.size(), std::size_t(9));
                 EXPECT_EQ(small.groups_total, ref.size());
+
+                // f64 NaN / inf rule on THIS backend vs the host reference:
+                // keys 1..8 -> +inf, -inf, NaN, -NaN, 10, -10, 0 (5 + -5),
+                // NaN from inf + -inf. cmp drops every NaN group; top-k treats
+                // every NaN as greatest (DESC first, ASC last).
+                {
+                    const double qn = std::numeric_limits<double>::quiet_NaN();
+                    const double in = std::numeric_limits<double>::infinity();
+                    std::vector<std::int64_t> nk = {1, 2, 3, 4, 5, 6, 7, 7, 8, 8};
+                    std::vector<double>       nv = {in, -in, qn, -qn, 10.0, -10.0, 5.0, -5.0, in, -in};
+                    auto nkc = agg->upload_i64(nk.data(), nk.size());
+                    auto nvc = agg->upload_f64(nv.data(), nv.size());
+                    const gpudb::GroupByFilter nf[] = {
+                        {Cmp::GT, 0, 0.0, 0, true}, {Cmp::LE, 0, 0.0, 0, true}, {Cmp::GE, 0, -in, 0, true},
+                        {Cmp::None, 0, 0.0, 3, true}, {Cmp::None, 0, 0.0, 3, false},
+                        {Cmp::None, 0, 0.0, 8, true}, {Cmp::GT, 0, -in, 2, true},
+                    };
+                    auto nbase = agg->groupby_sum_resident_f64(*nkc, *nvc, cap);
+                    for (const auto& fl : nf) {
+                        gpudb::GroupByResidentResult rr = nbase;
+                        gpudb::apply_group_filter_host(rr, fl, gpudb::FilterAgg::SumF64, cap, "ref");
+                        auto g = agg->groupby_sum_resident_f64(*nkc, *nvc, cap, fl);
+                        // exact row-by-row: NaN==NaN treated as equal, order must match
+                        bool ok = g.keys.size() == rr.keys.size();
+                        for (std::size_t i = 0; ok && i < g.keys.size(); ++i) {
+                            const double x = g.sums_f64[i], y = rr.sums_f64[i];
+                            const bool same_val = (std::isnan(x) && std::isnan(y)) || x == y;
+                            ok = same_val && (fl.topk == 0 ? g.keys[i] == rr.keys[i] : true);
+                        }
+                        EXPECT(ok);
+                    }
+                    auto t3 = agg->groupby_sum_resident_f64(*nkc, *nvc, cap, gpudb::GroupByFilter{Cmp::None, 0, 0.0, 3, true});
+                    EXPECT(t3.sums_f64.size() == 3 && std::isnan(t3.sums_f64[0]) && std::isnan(t3.sums_f64[1]) && std::isnan(t3.sums_f64[2]));
+                    auto a3 = agg->groupby_sum_resident_f64(*nkc, *nvc, cap, gpudb::GroupByFilter{Cmp::None, 0, 0.0, 3, false});
+                    EXPECT(a3.sums_f64.size() == 3 && a3.sums_f64[0] == -in && a3.sums_f64[1] == -10.0 && a3.sums_f64[2] == 0.0);
+                }
             }
 
             // Regression: keys whose min and max share a low byte while a

--- a/test/sql/gpu_groupby_resident.test
+++ b/test/sql/gpu_groupby_resident.test
@@ -219,3 +219,15 @@ SELECT count(*), min(key), max(key) FROM gpu_groupby_sum_resident_f64_having('na
 -- setup: SELECT gpu_upload_pair('nan', k, v) FROM (VALUES (1, 'inf'::DOUBLE), (2, '-inf'::DOUBLE), (3, 'nan'::DOUBLE), (4, 10.0), (5, -10.0), (6, 'inf'::DOUBLE), (6, '-inf'::DOUBLE)) t(k, v)
 SELECT string_agg(key, ',' ORDER BY key) FROM gpu_groupby_sum_resident_f64_having('nan', '>', 0.0);
 -- expect: 1,3,4,6
+
+-- 35. DOUBLE: negative-signed NaN is still greatest; -0.0 and 0.0 tie; k > groups returns all in aggregate order
+-- setup: SELECT gpu_upload_pair('nan2', k, v) FROM (VALUES (1, -('nan'::DOUBLE)), (2, -0.0), (3, 0.0), (4, 'inf'::DOUBLE), (5, -1.5)) t(k, v)
+SELECT count(*), sum(CASE WHEN isnan(sum) THEN 1 ELSE 0 END) AS nans FROM gpu_groupby_sum_resident_f64_topk('nan2', 99, 'desc');
+-- expect: 5  1
+-- setup: SELECT gpu_upload_pair('nan2', k, v) FROM (VALUES (1, -('nan'::DOUBLE)), (2, -0.0), (3, 0.0), (4, 'inf'::DOUBLE), (5, -1.5)) t(k, v)
+SELECT key FROM gpu_groupby_sum_resident_f64_topk('nan2', 2, 'desc') ORDER BY key;
+-- expect: 1
+-- expect: 4
+-- setup: SELECT gpu_upload_pair('nan2', k, v) FROM (VALUES (1, -('nan'::DOUBLE)), (2, -0.0), (3, 0.0), (4, 'inf'::DOUBLE), (5, -1.5)) t(k, v)
+SELECT count(*), min(key), max(key) FROM gpu_groupby_sum_resident_f64_having('nan2', '<=', 0.0);
+-- expect: 3  2  5


### PR DESCRIPTION
CUDA implementation of the v0.6 resident GROUP BY / top-k ABI from #75. Stacked on `feat/core-groupby-abi`; retarget to `main` after #75 merges.

## What

- `groupby_sum_resident_i64` / `_f64` / `groupby_count_resident`: the key column reuses the v0.5 sorted-build cache (sorted keys + original-index permutation). Values are read through the permutation and reduced per key run with `thrust::reduce_by_key` (CUB `DeviceReduce::ReduceByKey` underneath) carrying a `(sum, count)` pair, so sums and counts come out of one pass and rows are naturally sorted by key. i64 sums accumulate in `uint64` (bit-exact across backends); f64 under the tolerance contract; counts exact. The group count comes from a run-count pass first, so `max_groups` is checked before any output is allocated or copied, with the ABI's error text.
- `topk_resident`: a slice of the cached sort (descending = tail, reversed on the host); `k` clamped. F64 columns get their own cache: order-preserving `uint64` keys (NaN greatest, `-0.0 < 0.0`) on the radix path, built in the cache buffer itself so no extra 8n-byte buffer is needed at 300M rows.
- Host result vectors: for a 120 MB result the PCIe copy is ~12 ms but first-touch page faulting of the fresh `std::vector` is ~27 ms; reserving, advising `MADV_HUGEPAGE` on the untouched range, then resizing brings that to ~11 ms. Applied to the GROUP BY / top-k outputs and the row-returning join. No-op off Linux or with THP disabled. (A pinned double-buffered staging path was tried and dropped: the copy itself was not the bottleneck.)

Files: `src/backends/cuda/kernels/groupby_resident_kernel.cu` (new), `src/backends/cuda/cuda_aggregator.cpp`, one line in `src/CMakeLists.txt`.

## Verification (RTX 4090 Laptop, CUDA 13.0.88, CUB 3.0.1)

- `test_gpudb`: 146 / 146 (resident group-by / top-k block runs on CPU and CUDA).
- `scripts/groupby_parity_check.sh build-linux`: 10 / 10 scenarios.
- `scripts/run_sql_tests.sh gpu_groupby_resident`: 9 pass, 4 expected guardrails.
- Standalone driver vs host reference (n = 1 … 20M rows / 4.9M groups): i64 sums bit-exact including `INT64_MAX`/`MIN` wraps, f64 max relative error 1.5e-11, counts exact, output sorted, repeat call identical, cap / row-mismatch / dtype / backend-tag / empty-input behaviour as specified, NaN and `-0.0` ordering checked both directions.

## Numbers (BENCHMARK.md, `2026-08-28 (v0.6.0)` → CUDA subsection)

Native and gpudb timed by the same per-statement clock in the same `gpudb-sql --multi` process (embedded libduckdb v1.5.2), warm, min–max of 2 after a discard; end-to-end = native statement / gpudb statement, on-device = native statement / `kernel_ms`, always printed together.

| shape | SF | native stmt | gpudb stmt | `kernel_ms` | `transfer_ms` | end-to-end / on-device |
|---|---|---:|---:|---:|---:|---:|
| (A) `sum(l_quantity) GROUP BY l_orderkey`, 15M groups | 10 | 135–138 ms | 96–97 ms | 4.5–4.7 | 70.5–71.7 | 1.4× / 29× |
| (A) same, 75M groups | 50 | 684–693 ms | 458–464 ms | 21.4 | 340–347 | 1.5× / 32× |
| (B) `HAVING sum > 300` | 10 / 50 | 204–209 / 991–1013 | 105–106 / 491–505 | 4.5 / 21.4 | 72 / 343–349 | 2.0× / 45–47× |
| (C) f64 `sum(l_extendedprice)` | 10 / 50 | 206–213 / 982–994 | 104–106 / 498–503 | 4.6 / 21.4 | 72 / 347 | 2.0× / 45–46× |
| (D) `count(*)` | 10 / 50 | 135–140 / 672–687 | 64–66 / 309–314 | 2.6 / 11.7 | 47 / 235 | 2.1–2.2× / 52–58× |
| (E) top-10 DESC | 10 / 50 | 31 / 145 | cold 34.6 / 169 (the sort), then 0.14–0.28 | | | cold 0.85–0.9× (native wins) |
| (F) 4-group packed-ascii key | 10 / 50 | 106–110 / 433–439 | 4.7–7.5 / 28 | same | ~0 | 14–23× / 15.5× |
| (F′) 7-group `l_linenumber` | 10 / 50 | 34–36 / 185–186 | 6.3–9.2 / 34–38 | same | ~0 | 3.7–5.6× / 4.9–5.4× |

Results equal native in every row. For (A)–(D) the kernel is 3–5 % of the statement; ≈75 % is the 24 B/group result crossing PCIe and ≈20–25 % is DuckDB streaming those rows out of the table function — on a unified-memory machine the transfer column disappears. The subsection also records the earlier draft's mistake (native statement vs operator `wall_ms`) and why it was wrong.

Side effect of the huge-page change on the v0.5 row-returning join: `gpu_join_rows_resident` over 60M pairs at SF10 now measures 195–215 ms operator wall (transfer 182–189 ms, was 342), statement 255–275 ms, vs the v0.5 native 232–272 ms — roughly a tie instead of 0.5×. Noted under the v0.6 subsection; the v0.5 table is left as measured.

## Audit follow-ups (in this PR)

- Thrust/CUB failures inside the launchers now surface as the real `cudaError_t` (launch failure, illegal address, …) via a shared `thrust_errors.cuh` helper instead of "out of memory". Known limit: a sticky device fault inside a Thrust call makes Thrust's own temporary-buffer destructor throw on `cudaFree` → `std::terminate` before the mapping runs (the context is dead at that point regardless).
- Huge-page advice uses `sysconf(_SC_PAGESIZE)` for alignment (64 KiB-page kernels).
- Edge runs on the 4090: f64 top-k special values (NaN/−NaN/±inf/±0.0/subnormals) order identically to native; 1- and 2-row pairs; the cap error text with 20 repetitions leaking 0 KiB; NULL keys/payloads dropped exactly like the native `IS NOT NULL` query; 20 × upload/GROUP BY/drop of a 50M-row pair returns device memory to baseline (delta 0 KiB).
