### PR TITLE
feat(cuda): radix-select top-k of groups; CUB explicit temp storage so device faults surface as SQL errors

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -243,6 +243,28 @@ single); the first call on a key column pays its sort (≈35 ms at SF10,
 it. Break-even for (A) is ≈95 repeated statements at SF10 (≈40 ms saved
 each), ≈80 at SF50 (≈230 ms each).
 
+**Follow-up on this branch — radix-select for (G), CUB on explicit temp
+storage.** Top-k of groups now finds the k-th aggregate with eight 256-bin
+histogram passes over order keys and compacts the winners (the full sort is
+kept for k ≥ groups/8); every resident step also moved from Thrust's
+self-allocating algorithms to CUB primitives on buffers we own, so a device
+fault returns its `cudaError_t` (→ SQL error) instead of aborting the
+process (unit-tested in a child process). Same harness as above, same day:
+
+| measurement | SF | native stmt (ms) | gpudb stmt (ms) | `kernel_ms` | before (sort-based) | end-to-end / on-device |
+|---|---|---:|---:|---:|---:|---:|
+| (G) top-10 groups by sum | 10 | 211–215 | 16.1–16.3 | 11.6–11.8 | 26.6–26.8 (kernel 21) | **13× / 18×** |
+| (G) top-10 groups by sum | 50 | 1009–1023 | 60–64 | 52–56 | 86–123 (kernel 78–115) | **16–17× / 18–19×** |
+| (B′) HAVING sum > 300 (unchanged path, CUB build) | 10 | 204–206 | 12.0–12.3 | 9.6–9.8 | 11.7–12.9 | 17× / 21× |
+| (B′) HAVING sum > 300 (unchanged path, CUB build) | 50 | 1019–1023 | 50–57 | 45–52 | 42–78 | 18–20× / 20–23× |
+
+(G) is now the reduce-by-key itself (the (B′) floor, 45–52 ms at SF50) plus
+≈8 ms of select — the 75M-key aggregate sort it replaced was 40–70 ms. Raw
+(G) lines: SF10 native 215.0 / 211.3 / 215.3, gpudb 16.06 / 16.33 / 16.17
+(`kernel_ms` 11.57 / 11.84 / 11.71); SF50 native 1009.2 / 1013.5 / 1009.6,
+gpudb 64.2 / 60.2 / 61.2 (`kernel_ms` 56.3 / 52.5 / 53.2); sums == native
+in every run.
+
 **Where the statement time goes (A–D).** The kernel is 3–5 % of the
 statement; ≈75 % is the result crossing device→host (15M × 24 B = 360 MB at
 SF10, 1.8 GB at SF50) and ≈20–25 % is DuckDB streaming those rows out of

--- a/src/backends/cuda/kernels/cub_ops.cuh
+++ b/src/backends/cuda/kernels/cub_ops.cuh
@@ -1,0 +1,121 @@
+// cub_ops.cuh — CUB device primitives on EXPLICIT temp storage, plus the tiny
+// element-wise kernels the resident paths need. Nothing here allocates
+// behind our back: every buffer is a cudaMalloc we own and free ourselves,
+// and a free that fails (sticky device fault) is ignored rather than thrown
+// from a destructor — so a fault surfaces to the host wrapper as the real
+// cudaError_t instead of std::terminate.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <cub/cub.cuh>
+
+namespace gpudb_cuda_ops {
+
+using u64 = unsigned long long;
+using i64 = std::int64_t;
+
+struct DevBuf {
+    void* p = nullptr;
+    std::size_t bytes = 0;
+    cudaError_t alloc(std::size_t b) {
+        release();
+        bytes = b;
+        return b ? cudaMalloc(&p, b) : cudaSuccess;
+    }
+    void release() { if (p) { (void)cudaFree(p); p = nullptr; } bytes = 0; }
+    ~DevBuf() { release(); }
+    DevBuf() = default;
+    DevBuf(const DevBuf&) = delete;
+    DevBuf& operator=(const DevBuf&) = delete;
+};
+
+// Run a CUB call twice: size query, then for real on temp storage we own.
+template <typename F>
+cudaError_t with_temp(F&& call) {
+    std::size_t bytes = 0;
+    cudaError_t e = call(static_cast<void*>(nullptr), bytes);
+    if (e != cudaSuccess) return e;
+    DevBuf tmp;
+    if ((e = tmp.alloc(bytes ? bytes : 1)) != cudaSuccess) return e;
+    return call(tmp.p, bytes);
+}
+
+constexpr int kBlock = 256;
+inline unsigned grid_for(std::size_t n) {
+    const std::size_t g = (n + kBlock - 1) / kBlock;
+    return static_cast<unsigned>(g > 65535u * 16u ? 65535u * 16u : (g ? g : 1));
+}
+
+template <typename T, typename F>
+__global__ void transform_kernel(const T* __restrict__ in, u64* __restrict__ out,
+                                 std::size_t n, F f) {
+    const std::size_t stride = static_cast<std::size_t>(gridDim.x) * blockDim.x;
+    for (std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         i < n; i += stride) out[i] = f(in[i]);
+}
+template <typename T, typename F>
+cudaError_t transform(const T* in, u64* out, std::size_t n, F f, cudaStream_t s) {
+    if (n) transform_kernel<T, F><<<grid_for(n), kBlock, 0, s>>>(in, out, n, f);
+    return cudaGetLastError();
+}
+
+__global__ inline void sequence_kernel(i64* __restrict__ out, std::size_t n) {
+    const std::size_t stride = static_cast<std::size_t>(gridDim.x) * blockDim.x;
+    for (std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         i < n; i += stride) out[i] = static_cast<i64>(i);
+}
+inline cudaError_t sequence(i64* out, std::size_t n, cudaStream_t s) {
+    if (n) sequence_kernel<<<grid_for(n), kBlock, 0, s>>>(out, n);
+    return cudaGetLastError();
+}
+
+template <typename T>
+__global__ void gather_kernel(const i64* __restrict__ idx, std::size_t n,
+                              const T* __restrict__ src, T* __restrict__ dst) {
+    const std::size_t stride = static_cast<std::size_t>(gridDim.x) * blockDim.x;
+    for (std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         i < n; i += stride) dst[i] = src[idx[i]];
+}
+template <typename T>
+cudaError_t gather(const i64* idx, std::size_t n, const T* src, T* dst, cudaStream_t s) {
+    if (n) gather_kernel<T><<<grid_for(n), kBlock, 0, s>>>(idx, n, src, dst);
+    return cudaGetLastError();
+}
+
+// Sum of a transform over [0, n) (used for run counts and survivor counts).
+template <typename It>
+cudaError_t sum_u64(It first, std::size_t n, u64* d_out, cudaStream_t s) {
+    return with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceReduce::Sum(tmp, b, first, d_out, n, s);
+    });
+}
+
+// Ascending radix sort of (u64 key, i64 value) pairs, in place on the
+// caller's buffers (an alternate buffer pair is allocated here).
+inline cudaError_t sort_pairs_u64(u64* keys, i64* vals, std::size_t n, cudaStream_t s) {
+    if (n < 2) return cudaSuccess;
+    DevBuf ka, va;
+    cudaError_t e;
+    if ((e = ka.alloc(n * sizeof(u64))) != cudaSuccess) return e;
+    if ((e = va.alloc(n * sizeof(i64))) != cudaSuccess) return e;
+    cub::DoubleBuffer<u64> dk(keys, static_cast<u64*>(ka.p));
+    cub::DoubleBuffer<i64> dv(vals, static_cast<i64*>(va.p));
+    e = with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceRadixSort::SortPairs(tmp, b, dk, dv, n, 0, 64, s);
+    });
+    if (e != cudaSuccess) return e;
+    // Results may be in the alternate buffers: copy back if so.
+    if (dk.Current() != keys) {
+        if ((e = cudaMemcpyAsync(keys, dk.Current(), n * sizeof(u64),
+                                 cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+    }
+    if (dv.Current() != vals) {
+        if ((e = cudaMemcpyAsync(vals, dv.Current(), n * sizeof(i64),
+                                 cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+    }
+    return cudaStreamSynchronize(s);   // the alternates are freed on return
+}
+
+} // namespace gpudb_cuda_ops

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -12,7 +12,7 @@
 // order-preserving uint64 keys (NaN greatest, matching DuckDB's total order)
 // so the radix path is used, then the sorted values are gathered back.
 
-#include <cmath>
+#include <algorithm>
 #include <cstdint>
 #include <cuda_runtime.h>
 
@@ -196,26 +196,6 @@ struct Keep {
         }
     }
 };
-// f64: DuckDB's total order for HAVING — NaN is greater than everything (so
-// NaN groups pass '>' and '>=', fail '<' and '<='), -0.0 == 0.0. Mirrors
-// apply_group_filter_host exactly; NOT the order-key mapping (which would
-// separate -0.0 from 0.0).
-template <>
-struct Keep<double> {
-    int cmp; double t;
-    __host__ __device__ static bool lt(double x, double y) {
-        return !isnan(x) && (isnan(y) || x < y);
-    }
-    __host__ __device__ bool operator()(double a) const {
-        switch (cmp) {
-            case 1:  return lt(t, a);     // a >  t
-            case 2:  return !lt(a, t);    // a >= t
-            case 3:  return lt(a, t);     // a <  t
-            case 4:  return !lt(t, a);    // a <= t
-            default: return true;
-        }
-    }
-};
 
 struct DevBuf {
     void* p = nullptr;
@@ -227,6 +207,16 @@ struct DevBuf {
 // folds sign-magnitude with EVERY NaN greatest (DuckDB ORDER BY order) and
 // -0.0 == 0.0 handled by the tie rule. Inverted keys turn "largest k" into
 // "smallest k" so one ascending radix sort serves both directions.
+// ---- radix-select for top-k of groups ----
+//
+// Aggregates are mapped to order-preserving u64 keys (i64: flip the sign
+// bit; f64: sign-magnitude fold with NaN greatest, as in F64OrderKey). For
+// "largest k" the keys are inverted so the problem is always "smallest k".
+// Eight MSB->LSB passes of a 256-bin histogram over the elements matching
+// the prefix so far locate the k-th key T; the output is every element
+// with key < T plus enough key == T elements to reach k (tie choice
+// unspecified, per the contract), finally sorted by key.
+
 template <typename A> struct OrderKey;
 template <> struct OrderKey<i64> {
     __host__ __device__ u64 operator()(i64 v) const { return static_cast<u64>(v) ^ (1ULL << 63); }
@@ -237,6 +227,76 @@ template <> struct OrderKey<double> {
 template <typename A> struct InvOrderKey {
     __host__ __device__ u64 operator()(A v) const { return ~OrderKey<A>{}(v); }
 };
+
+__global__ void radix_hist_kernel(const u64* __restrict__ keys, std::size_t n,
+                                  u64 prefix, int shift, u64* __restrict__ hist) {
+    __shared__ unsigned int sh[256];
+    for (int i = threadIdx.x; i < 256; i += blockDim.x) sh[i] = 0u;
+    __syncthreads();
+    const std::size_t stride = static_cast<std::size_t>(gridDim.x) * blockDim.x;
+    for (std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+         i < n; i += stride) {
+        const u64 k = keys[i];
+        if (shift == 56 || (k >> (shift + 8)) == prefix)
+            atomicAdd(&sh[(k >> shift) & 0xFFu], 1u);
+    }
+    __syncthreads();
+    for (int i = threadIdx.x; i < 256; i += blockDim.x)
+        if (sh[i]) atomicAdd(&hist[i], static_cast<u64>(sh[i]));
+}
+
+struct KeyLess  { u64 t; __host__ __device__ bool operator()(u64 k) const { return k <  t; } };
+struct KeyEqual { u64 t; __host__ __device__ bool operator()(u64 k) const { return k == t; } };
+
+// Selects the k smallest of `keys` (u64 order keys, n of them) into idx[0..k)
+// sorted ascending by key. Requires 0 < k <= n. Uses only its own scratch.
+inline cudaError_t radix_select_k(const u64* keys, std::size_t n, std::size_t k,
+                                  i64* out_idx, cudaStream_t s) {
+    auto pol = thrust::cuda::par.on(s);
+    DevBuf hb; cudaError_t e = hb.alloc(256 * sizeof(u64));
+    if (e != cudaSuccess) return e;
+    auto* d_hist = static_cast<u64*>(hb.p);
+    u64 h[256];
+    u64 prefix = 0; std::size_t want = k;              // want-th smallest among prefix matches
+    const int grid = static_cast<int>(std::min<std::size_t>((n + 255) / 256, 4096));
+    for (int pass = 0; pass < 8; ++pass) {
+        const int shift = 56 - 8 * pass;
+        if ((e = cudaMemsetAsync(d_hist, 0, 256 * sizeof(u64), s)) != cudaSuccess) return e;
+        radix_hist_kernel<<<grid, 256, 0, s>>>(keys, n, prefix, shift, d_hist);
+        if ((e = cudaMemcpyAsync(h, d_hist, sizeof(h), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
+        if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
+        std::size_t acc = 0; int bin = 255;
+        for (int b = 0; b < 256; ++b) { if (acc + h[b] >= want) { bin = b; break; } acc += h[b]; }
+        want -= acc;
+        prefix = (prefix << 8) | static_cast<u64>(bin);
+    }
+    const u64 T = prefix;
+    try {
+        auto cnt = thrust::make_counting_iterator<i64>(0);
+        // strictly smaller than T: all of them
+        auto end_lt = thrust::copy_if(pol, cnt, cnt + static_cast<i64>(n), keys, out_idx, KeyLess{T});
+        const std::size_t n_lt = static_cast<std::size_t>(end_lt - out_idx);
+        if (n_lt < k) {
+            // ties at T: take the first (k - n_lt) in index order
+            const std::size_t need = k - n_lt;
+            const std::size_t n_eq = static_cast<std::size_t>(
+                thrust::count_if(pol, keys, keys + n, KeyEqual{T}));
+            DevBuf eb; if ((e = eb.alloc(n_eq * sizeof(i64))) != cudaSuccess) return e;
+            auto* d_eq = static_cast<i64*>(eb.p);
+            thrust::copy_if(pol, cnt, cnt + static_cast<i64>(n), keys, d_eq, KeyEqual{T});
+            if ((e = cudaMemcpyAsync(out_idx + n_lt, d_eq, need * sizeof(i64),
+                                     cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+        }
+        // order the k winners by key (ties by index, unspecified anyway)
+        DevBuf kb; if ((e = kb.alloc(k * sizeof(u64))) != cudaSuccess) return e;
+        auto* d_k = static_cast<u64*>(kb.p);
+        thrust::gather(pol, out_idx, out_idx + k, keys, d_k);
+        thrust::sort_by_key(pol, d_k, d_k + k, out_idx);
+    } catch (...) {
+        return gpudb_cuda_detail::map_exception();
+    }
+    return cudaGetLastError();
+}
 
 template <typename A>
 std::size_t count_survivors(const A* agg, std::size_t n, int cmp, A t, cudaStream_t s) {
@@ -291,11 +351,26 @@ cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::siz
             if (has_cnt) cudaMemcpyAsync(out_cnt, cnt, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
             return cudaGetLastError();
         }
-        // top-k over n_surv survivors: radix sort of (order key, index) — the
-        // order keys give one total order (NaN greatest) for both directions.
-        DevBuf kb, ix;
+        // top-k over n_surv survivors. Small k: radix-select on order keys
+        // (8 histogram passes + one compaction). Large k: full radix sort of
+        // (aggregate copy, index) pairs.
         cudaError_t e;
-        if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
+        if (n_out * 8 <= n_surv) {
+            DevBuf kb, ix;
+            if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
+            if ((e = ix.alloc(n_out * sizeof(i64)))  != cudaSuccess) return e;
+            auto* okeys = static_cast<u64*>(kb.p);
+            i64*  idx   = static_cast<i64*>(ix.p);
+            if (desc) thrust::transform(pol, a_in, a_in + n_surv, okeys, InvOrderKey<A>{});
+            else      thrust::transform(pol, a_in, a_in + n_surv, okeys, OrderKey<A>{});
+            if ((e = radix_select_k(okeys, n_surv, n_out, idx, s)) != cudaSuccess) return e;
+            thrust::gather(pol, idx, idx + n_out, k_in, out_keys);
+            thrust::gather(pol, idx, idx + n_out, a_in, out_agg);
+            if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
+            return cudaGetLastError();
+        }
+        DevBuf ak, ix;
+        if ((e = ak.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
         if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
         auto* okeys = static_cast<u64*>(kb.p);
         i64*  idx   = static_cast<i64*>(ix.p);

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -210,7 +210,9 @@ struct DevBuf {
 // ---- radix-select for top-k of groups ----
 //
 // Aggregates are mapped to order-preserving u64 keys (i64: flip the sign
-// bit; f64: sign-magnitude fold with NaN greatest, as in F64OrderKey). For
+// bit; f64: sign-magnitude fold with every NaN greatest — DuckDB's ORDER BY
+// places NaN above +inf — and -0.0 < 0.0, as in F64OrderKey). Both top-k
+// paths (select and full sort) use these keys, so the order is one. For
 // "largest k" the keys are inverted so the problem is always "smallest k".
 // Eight MSB->LSB passes of a 256-bin histogram over the elements matching
 // the prefix so far locate the k-th key T; the output is every element
@@ -369,8 +371,10 @@ cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::siz
             if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
             return cudaGetLastError();
         }
-        DevBuf ak, ix;
-        if ((e = ak.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
+        // Full sort on the same order keys as the select path, so NaN placement
+        // (greatest) and -0.0/0.0 handling are identical whichever path runs.
+        DevBuf kb, ix;
+        if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
         if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
         auto* okeys = static_cast<u64*>(kb.p);
         i64*  idx   = static_cast<i64*>(ix.p);

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -414,4 +414,17 @@ cudaError_t gpudb_cuda_groupby_filter_f64(const i64* keys, const double* agg, co
     return apply_filter<double>(keys, agg, cnt, n, cmp, t, topk, desc != 0, n_out, out_keys, out_agg, out_cnt, s);
 }
 
+
+// Test hook: poison the context with an out-of-bounds device read so the
+// next resident op sees a sticky cudaErrorIllegalAddress. Only for the
+// fault-injection unit test (run in a forked child — the context is dead
+// afterwards). Returns the error the poisoning itself produced.
+cudaError_t gpudb_cuda_debug_fault_inject(cudaStream_t s) {
+    DevBuf b; cudaError_t e = b.alloc(64);
+    if (e != cudaSuccess) return e;
+    if ((e = cudaMemsetAsync(b.p, 0, 64, s)) != cudaSuccess) return e;
+    std::size_t runs = 0;
+    return gpudb_cuda_sorted_run_count(static_cast<const i64*>(b.p), std::size_t(1) << 28, &runs, s);
+}
+
 } // extern "C"

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -19,6 +19,7 @@
 // so the radix path is used, then the sorted values are gathered back.
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cuda_runtime.h>
 
@@ -110,6 +111,7 @@ cudaError_t reduce_runs(const i64* d_sorted, std::size_t n, Val vals_first, Add 
                         std::size_t* h_runs, cudaStream_t s) {
     DevBuf nr; cudaError_t e = nr.alloc(sizeof(u64));
     if (e != cudaSuccess) return e;
+    if ((e = cudaMemsetAsync(nr.p, 0, sizeof(u64), s)) != cudaSuccess) return e;   // CUB 2.x writes 32 bits
     auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(out_agg, reinterpret_cast<u64*>(out_counts)));
     e = with_temp([&](void* tmp, std::size_t& b) {
         return cub::DeviceReduce::ReduceByKey(tmp, b, d_sorted, out_keys, vals_first, out_vals,
@@ -142,6 +144,7 @@ template <typename In, typename Flags, typename Out>
 cudaError_t select_flagged(In in, Flags flags, Out out, std::size_t n, cudaStream_t s) {
     DevBuf ns; cudaError_t e = ns.alloc(sizeof(u64));
     if (e != cudaSuccess) return e;
+    if ((e = cudaMemsetAsync(ns.p, 0, sizeof(u64), s)) != cudaSuccess) return e;   // CUB 2.x writes 32 bits
     return with_temp([&](void* tmp, std::size_t& b) {
         return cub::DeviceSelect::Flagged(tmp, b, in, flags, out, static_cast<u64*>(ns.p), n, s);
     });
@@ -159,6 +162,26 @@ struct Keep {
             case 2:  return a >= t;
             case 3:  return a <  t;
             case 4:  return a <= t;
+            default: return true;
+        }
+    }
+};
+// f64: DuckDB's total order for HAVING — NaN is greater than everything (so
+// NaN groups pass '>' and '>=', fail '<' and '<='), -0.0 == 0.0. Mirrors
+// apply_group_filter_host exactly; NOT the order-key mapping (which would
+// separate -0.0 from 0.0).
+template <>
+struct Keep<double> {
+    int cmp; double t;
+    __host__ __device__ static bool lt(double x, double y) {
+        return !isnan(x) && (isnan(y) || x < y);
+    }
+    __host__ __device__ bool operator()(double a) const {
+        switch (cmp) {
+            case 1:  return lt(t, a);     // a >  t
+            case 2:  return !lt(a, t);    // a >= t
+            case 3:  return lt(a, t);     // a <  t
+            case 4:  return !lt(t, a);    // a <= t
             default: return true;
         }
     }
@@ -365,6 +388,7 @@ cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
                                      std::size_t* h_runs, cudaStream_t s) {
     DevBuf nr; cudaError_t e = nr.alloc(sizeof(u64));
     if (e != cudaSuccess) return e;
+    if ((e = cudaMemsetAsync(nr.p, 0, sizeof(u64), s)) != cudaSuccess) return e;   // CUB 2.x writes 32 bits
     e = with_temp([&](void* tmp, std::size_t& b) {
         return cub::DeviceReduce::ReduceByKey(tmp, b, d_sorted, out_keys,
                                               thrust::constant_iterator<u64>(1ULL),

--- a/src/backends/cuda/kernels/groupby_resident_kernel.cu
+++ b/src/backends/cuda/kernels/groupby_resident_kernel.cu
@@ -2,11 +2,17 @@
 //
 // GROUP BY reuses the v0.5 build-side sort cache on the key column (keys
 // sorted ascending + original-index permutation). Values are read through
-// the permutation and reduced per key run with reduce_by_key (Thrust over
-// CUB DeviceReduce::ReduceByKey), so output rows come out sorted by key —
-// the cross-backend contract in gpu_backend.hpp. i64 sums accumulate in
-// uint64 (wrap-add commutes -> bit-exact regardless of reduction order);
-// f64 sums are backend-ordered under the tolerance contract.
+// the permutation and reduced per key run with CUB DeviceReduce::ReduceByKey,
+// so output rows come out sorted by key — the cross-backend contract in
+// gpu_backend.hpp. i64 sums accumulate in uint64 (wrap-add commutes ->
+// bit-exact regardless of reduction order); f64 sums are backend-ordered
+// under the tolerance contract.
+//
+// Every CUB call here runs on EXPLICIT temp storage we allocate and free
+// (cub_ops.cuh); Thrust is used only for its allocation-free iterators. So a
+// device fault inside any step comes back to the host wrapper as its real
+// cudaError_t (-> std::runtime_error -> SQL error) instead of a Thrust
+// temporary's destructor throwing on cudaFree and aborting the process.
 //
 // top-k on an f64 column needs its own sort: doubles are mapped to
 // order-preserving uint64 keys (NaN greatest, matching DuckDB's total order)
@@ -16,27 +22,20 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-#include <thrust/execution_policy.h>
-#include <thrust/gather.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/copy.h>
-#include <thrust/count.h>
-#include <thrust/functional.h>
-#include <thrust/reduce.h>
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
 #include <thrust/tuple.h>
-#include <thrust/unique.h>
 
-#include "thrust_errors.cuh"
+#include "cub_ops.cuh"
 
 namespace {
 
 using u64 = unsigned long long;
 using i64 = std::int64_t;
+using gpudb_cuda_ops::DevBuf;
+using gpudb_cuda_ops::with_temp;
 
 // (value, 1) through the permutation: sorted position i -> original row perm[i].
 struct PermValI64 {
@@ -65,6 +64,17 @@ struct AddF64Pair {
                                   thrust::get<1>(a) + thrust::get<1>(b));
     }
 };
+struct AddU64 {
+    __host__ __device__ u64 operator()(u64 a, u64 b) const { return a + b; }
+};
+
+// 1 at every run start of an ascending-sorted key array.
+struct RunStart {
+    const i64* keys;
+    __host__ __device__ u64 operator()(i64 i) const {
+        return (i == 0 || keys[i] != keys[i - 1]) ? 1ULL : 0ULL;
+    }
+};
 
 // Order-preserving map double -> uint64: negatives reversed, positives get the
 // top bit, NaN (any sign) maps to the maximum so it sorts last.
@@ -77,111 +87,68 @@ struct F64OrderKey {
     }
 };
 
-} // namespace
+// Order-preserving u64 keys for the aggregate: i64 flips the sign bit; f64
+// folds sign-magnitude with EVERY NaN greatest (DuckDB ORDER BY order) and
+// -0.0 == 0.0 handled by the tie rule. Inverted keys turn "largest k" into
+// "smallest k" so one ascending radix sort serves both directions.
+template <typename A> struct OrderKey;
+template <> struct OrderKey<i64> {
+    __host__ __device__ u64 operator()(i64 v) const { return static_cast<u64>(v) ^ (1ULL << 63); }
+};
+template <> struct OrderKey<double> {
+    __host__ __device__ u64 operator()(double d) const { return F64OrderKey{}(d); }
+};
+template <typename A> struct InvOrderKey {
+    __host__ __device__ u64 operator()(A v) const { return ~OrderKey<A>{}(v); }
+};
 
-extern "C" {
-
-// Number of distinct runs in an ascending-sorted i64 array (0 for n == 0).
-// Synchronizes the stream; the count lands on the host.
-cudaError_t gpudb_cuda_sorted_run_count(const i64* d_sorted, std::size_t n,
-                                        std::size_t* h_runs, cudaStream_t s) {
-    if (n == 0) { *h_runs = 0; return cudaSuccess; }
-    try {
-        *h_runs = static_cast<std::size_t>(
-            thrust::unique_count(thrust::cuda::par.on(s), d_sorted, d_sorted + n));
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaGetLastError();
+// Reduce the permuted values per key run. Outputs sized to the run count;
+// the run count actually produced lands in *h_runs.
+template <typename A, typename Val, typename Add>
+cudaError_t reduce_runs(const i64* d_sorted, std::size_t n, Val vals_first, Add add,
+                        i64* out_keys, A* out_agg, i64* out_counts,
+                        std::size_t* h_runs, cudaStream_t s) {
+    DevBuf nr; cudaError_t e = nr.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(out_agg, reinterpret_cast<u64*>(out_counts)));
+    e = with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceReduce::ReduceByKey(tmp, b, d_sorted, out_keys, vals_first, out_vals,
+                                              static_cast<u64*>(nr.p), add, n, s);
+    });
+    if (e != cudaSuccess) return e;
+    u64 runs = 0;
+    if ((e = cudaMemcpyAsync(&runs, nr.p, sizeof(u64), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
+    if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
+    *h_runs = static_cast<std::size_t>(runs);
+    return cudaSuccess;
 }
 
-// SUM(vals) + COUNT(*) per run of d_sorted; outputs sized n_groups exactly.
-// Writes the run count actually produced to *h_runs (sanity-checked by host).
-cudaError_t gpudb_cuda_groupby_sum_i64(const i64* d_sorted, const i64* d_perm,
-                                       const i64* d_vals, std::size_t n,
-                                       i64* out_keys, i64* out_sums, i64* out_counts,
-                                       std::size_t* h_runs, cudaStream_t s) {
-    try {
-        auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
-                                                     PermValI64{d_vals, d_perm});
-        auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(
-            reinterpret_cast<u64*>(out_sums), reinterpret_cast<u64*>(out_counts)));
-        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
-                                          d_sorted, d_sorted + n, first,
-                                          out_keys, out_vals,
-                                          thrust::equal_to<i64>(), AddU64Pair());
-        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaGetLastError();
+// Sum of a device-side transform, returned to the host.
+template <typename It>
+cudaError_t host_sum(It first, std::size_t n, std::size_t* h_out, cudaStream_t s) {
+    if (n == 0) { *h_out = 0; return cudaSuccess; }
+    DevBuf o; cudaError_t e = o.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sum_u64(first, n, static_cast<u64*>(o.p), s)) != cudaSuccess) return e;
+    u64 v = 0;
+    if ((e = cudaMemcpyAsync(&v, o.p, sizeof(u64), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
+    if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
+    *h_out = static_cast<std::size_t>(v);
+    return cudaSuccess;
 }
 
-cudaError_t gpudb_cuda_groupby_sum_f64(const i64* d_sorted, const i64* d_perm,
-                                       const double* d_vals, std::size_t n,
-                                       i64* out_keys, double* out_sums, i64* out_counts,
-                                       std::size_t* h_runs, cudaStream_t s) {
-    try {
-        auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
-                                                     PermValF64{d_vals, d_perm});
-        auto out_vals = thrust::make_zip_iterator(thrust::make_tuple(
-            out_sums, reinterpret_cast<u64*>(out_counts)));
-        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
-                                          d_sorted, d_sorted + n, first,
-                                          out_keys, out_vals,
-                                          thrust::equal_to<i64>(), AddF64Pair());
-        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaGetLastError();
+// Compact `in` (any random-access iterator) where flag(i) into `out`.
+template <typename In, typename Flags, typename Out>
+cudaError_t select_flagged(In in, Flags flags, Out out, std::size_t n, cudaStream_t s) {
+    DevBuf ns; cudaError_t e = ns.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    return with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceSelect::Flagged(tmp, b, in, flags, out, static_cast<u64*>(ns.p), n, s);
+    });
 }
-
-// COUNT(*) per run of d_sorted (keys only; no permutation needed).
-cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
-                                     i64* out_keys, i64* out_counts,
-                                     std::size_t* h_runs, cudaStream_t s) {
-    try {
-        auto ends = thrust::reduce_by_key(thrust::cuda::par.on(s),
-                                          d_sorted, d_sorted + n,
-                                          thrust::constant_iterator<u64>(1ULL),
-                                          out_keys, reinterpret_cast<u64*>(out_counts));
-        *h_runs = static_cast<std::size_t>(ends.first - out_keys);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaGetLastError();
-}
-
-// f64 sort cache: d_sorted <- vals sorted ascending (NaN last), d_perm <- the
-// original indices in that order. Radix sort on order-preserving u64 keys
-// built in d_sorted itself; the sorted doubles are then gathered over the
-// (no longer needed) keys in place, so no extra n-sized buffer is required —
-// peak extra memory is the sort's own scratch.
-cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
-                                     i64* d_perm, std::size_t n, cudaStream_t s) {
-    try {
-        auto* k = reinterpret_cast<u64*>(d_sorted);
-        thrust::transform(thrust::cuda::par.on(s), d_vals, d_vals + n, k, F64OrderKey());
-        thrust::sequence(thrust::cuda::par.on(s), d_perm, d_perm + n);
-        thrust::sort_by_key(thrust::cuda::par.on(s), k, k + n, d_perm);
-        thrust::gather(thrust::cuda::par.on(s), d_perm, d_perm + n, d_vals, d_sorted);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
-    return cudaStreamSynchronize(s);
-}
-
-} // extern "C"
 
 // ---- GroupByFilter on the device (v0.6): cmp on the aggregate, then top-k ----
-//
-// Survivors are selected with copy_if (order preserved, so the key-sorted
-// order survives); top-k radix-sorts (aggregate, index) pairs — primitive
-// keys and values, so Thrust takes the radix path — and gathers the first k.
 // cmp codes mirror GroupByFilter::Cmp: 0 None, 1 GT, 2 GE, 3 LT, 4 LE.
-
-namespace {
 
 template <typename A>
 struct Keep {
@@ -196,40 +163,28 @@ struct Keep {
         }
     }
 };
-
-struct DevBuf {
-    void* p = nullptr;
-    cudaError_t alloc(std::size_t bytes) { return bytes ? cudaMalloc(&p, bytes) : cudaSuccess; }
-    ~DevBuf() { if (p) cudaFree(p); }
+template <typename A>
+struct KeepU64 {          // Keep as a 0/1 count over element indices
+    const A* agg; Keep<A> k;
+    __host__ __device__ u64 operator()(i64 i) const { return k(agg[i]) ? 1ULL : 0ULL; }
+};
+template <typename A>
+struct KeepFlag {         // Keep as a bool flag over element indices
+    const A* agg; Keep<A> k;
+    __host__ __device__ bool operator()(i64 i) const { return k(agg[i]); }
 };
 
-// Order-preserving u64 keys for the aggregate: i64 flips the sign bit; f64
-// folds sign-magnitude with EVERY NaN greatest (DuckDB ORDER BY order) and
-// -0.0 == 0.0 handled by the tie rule. Inverted keys turn "largest k" into
-// "smallest k" so one ascending radix sort serves both directions.
+struct KeyLessU64  { const u64* keys; u64 t; __host__ __device__ u64  operator()(i64 i) const { return keys[i] <  t ? 1ULL : 0ULL; } };
+struct KeyLessFlag { const u64* keys; u64 t; __host__ __device__ bool operator()(i64 i) const { return keys[i] <  t; } };
+struct KeyEqU64    { const u64* keys; u64 t; __host__ __device__ u64  operator()(i64 i) const { return keys[i] == t ? 1ULL : 0ULL; } };
+struct KeyEqFlag   { const u64* keys; u64 t; __host__ __device__ bool operator()(i64 i) const { return keys[i] == t; } };
+
 // ---- radix-select for top-k of groups ----
 //
-// Aggregates are mapped to order-preserving u64 keys (i64: flip the sign
-// bit; f64: sign-magnitude fold with every NaN greatest — DuckDB's ORDER BY
-// places NaN above +inf — and -0.0 < 0.0, as in F64OrderKey). Both top-k
-// paths (select and full sort) use these keys, so the order is one. For
-// "largest k" the keys are inverted so the problem is always "smallest k".
 // Eight MSB->LSB passes of a 256-bin histogram over the elements matching
-// the prefix so far locate the k-th key T; the output is every element
-// with key < T plus enough key == T elements to reach k (tie choice
+// the prefix so far locate the k-th smallest key T; the output is every
+// element with key < T plus enough key == T elements to reach k (tie choice
 // unspecified, per the contract), finally sorted by key.
-
-template <typename A> struct OrderKey;
-template <> struct OrderKey<i64> {
-    __host__ __device__ u64 operator()(i64 v) const { return static_cast<u64>(v) ^ (1ULL << 63); }
-};
-template <> struct OrderKey<double> {
-    __host__ __device__ u64 operator()(double d) const { return F64OrderKey{}(d); }
-};
-template <typename A> struct InvOrderKey {
-    __host__ __device__ u64 operator()(A v) const { return ~OrderKey<A>{}(v); }
-};
-
 __global__ void radix_hist_kernel(const u64* __restrict__ keys, std::size_t n,
                                   u64 prefix, int shift, u64* __restrict__ hist) {
     __shared__ unsigned int sh[256];
@@ -247,14 +202,10 @@ __global__ void radix_hist_kernel(const u64* __restrict__ keys, std::size_t n,
         if (sh[i]) atomicAdd(&hist[i], static_cast<u64>(sh[i]));
 }
 
-struct KeyLess  { u64 t; __host__ __device__ bool operator()(u64 k) const { return k <  t; } };
-struct KeyEqual { u64 t; __host__ __device__ bool operator()(u64 k) const { return k == t; } };
-
 // Selects the k smallest of `keys` (u64 order keys, n of them) into idx[0..k)
 // sorted ascending by key. Requires 0 < k <= n. Uses only its own scratch.
 inline cudaError_t radix_select_k(const u64* keys, std::size_t n, std::size_t k,
                                   i64* out_idx, cudaStream_t s) {
-    auto pol = thrust::cuda::par.on(s);
     DevBuf hb; cudaError_t e = hb.alloc(256 * sizeof(u64));
     if (e != cudaSuccess) return e;
     auto* d_hist = static_cast<u64*>(hb.p);
@@ -265,6 +216,7 @@ inline cudaError_t radix_select_k(const u64* keys, std::size_t n, std::size_t k,
         const int shift = 56 - 8 * pass;
         if ((e = cudaMemsetAsync(d_hist, 0, 256 * sizeof(u64), s)) != cudaSuccess) return e;
         radix_hist_kernel<<<grid, 256, 0, s>>>(keys, n, prefix, shift, d_hist);
+        if ((e = cudaGetLastError()) != cudaSuccess) return e;
         if ((e = cudaMemcpyAsync(h, d_hist, sizeof(h), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
         if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
         std::size_t acc = 0; int bin = 255;
@@ -273,38 +225,34 @@ inline cudaError_t radix_select_k(const u64* keys, std::size_t n, std::size_t k,
         prefix = (prefix << 8) | static_cast<u64>(bin);
     }
     const u64 T = prefix;
-    try {
-        auto cnt = thrust::make_counting_iterator<i64>(0);
-        // strictly smaller than T: all of them
-        auto end_lt = thrust::copy_if(pol, cnt, cnt + static_cast<i64>(n), keys, out_idx, KeyLess{T});
-        const std::size_t n_lt = static_cast<std::size_t>(end_lt - out_idx);
-        if (n_lt < k) {
-            // ties at T: take the first (k - n_lt) in index order
-            const std::size_t need = k - n_lt;
-            const std::size_t n_eq = static_cast<std::size_t>(
-                thrust::count_if(pol, keys, keys + n, KeyEqual{T}));
-            DevBuf eb; if ((e = eb.alloc(n_eq * sizeof(i64))) != cudaSuccess) return e;
-            auto* d_eq = static_cast<i64*>(eb.p);
-            thrust::copy_if(pol, cnt, cnt + static_cast<i64>(n), keys, d_eq, KeyEqual{T});
-            if ((e = cudaMemcpyAsync(out_idx + n_lt, d_eq, need * sizeof(i64),
-                                     cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
-        }
-        // order the k winners by key (ties by index, unspecified anyway)
-        DevBuf kb; if ((e = kb.alloc(k * sizeof(u64))) != cudaSuccess) return e;
-        auto* d_k = static_cast<u64*>(kb.p);
-        thrust::gather(pol, out_idx, out_idx + k, keys, d_k);
-        thrust::sort_by_key(pol, d_k, d_k + k, out_idx);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
+    auto cnt = thrust::make_counting_iterator<i64>(0);
+    // strictly smaller than T: all of them
+    std::size_t n_lt = 0;
+    if ((e = host_sum(thrust::make_transform_iterator(cnt, KeyLessU64{keys, T}), n, &n_lt, s)) != cudaSuccess) return e;
+    if ((e = select_flagged(cnt, thrust::make_transform_iterator(cnt, KeyLessFlag{keys, T}), out_idx, n, s)) != cudaSuccess) return e;
+    if (n_lt < k) {
+        // ties at T: take the first (k - n_lt) in index order
+        const std::size_t need = k - n_lt;
+        std::size_t n_eq = 0;
+        if ((e = host_sum(thrust::make_transform_iterator(cnt, KeyEqU64{keys, T}), n, &n_eq, s)) != cudaSuccess) return e;
+        DevBuf eb; if ((e = eb.alloc(n_eq * sizeof(i64))) != cudaSuccess) return e;
+        auto* d_eq = static_cast<i64*>(eb.p);
+        if ((e = select_flagged(cnt, thrust::make_transform_iterator(cnt, KeyEqFlag{keys, T}), d_eq, n, s)) != cudaSuccess) return e;
+        if ((e = cudaMemcpyAsync(out_idx + n_lt, d_eq, need * sizeof(i64),
+                                 cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
     }
-    return cudaGetLastError();
+    // order the k winners by key (ties by index, unspecified anyway)
+    DevBuf kb; if ((e = kb.alloc(k * sizeof(u64))) != cudaSuccess) return e;
+    auto* d_k = static_cast<u64*>(kb.p);
+    if ((e = gpudb_cuda_ops::gather(out_idx, k, keys, d_k, s)) != cudaSuccess) return e;
+    return gpudb_cuda_ops::sort_pairs_u64(d_k, out_idx, k, s);
 }
 
 template <typename A>
-std::size_t count_survivors(const A* agg, std::size_t n, int cmp, A t, cudaStream_t s) {
-    if (cmp == 0) return n;
-    return static_cast<std::size_t>(
-        thrust::count_if(thrust::cuda::par.on(s), agg, agg + n, Keep<A>{cmp, t}));
+cudaError_t count_survivors(const A* agg, std::size_t n, int cmp, A t, std::size_t* h_out, cudaStream_t s) {
+    if (cmp == 0) { *h_out = n; return cudaSuccess; }
+    auto cnt = thrust::make_counting_iterator<i64>(0);
+    return host_sum(thrust::make_transform_iterator(cnt, KeepU64<A>{agg, Keep<A>{cmp, t}}), n, h_out, s);
 }
 
 // Writes exactly n_out rows: the survivors of cmp (key order) when topk == 0,
@@ -314,80 +262,68 @@ template <typename A>
 cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::size_t n,
                          int cmp, A t, std::size_t topk, bool desc, std::size_t n_out,
                          i64* out_keys, A* out_agg, i64* out_cnt, cudaStream_t s) {
-    auto pol = thrust::cuda::par.on(s);
     const bool has_cnt = (cnt != nullptr);
-    DevBuf sk, sa, sc;                       // survivors (only when cmp active)
+    cudaError_t e;
+    DevBuf sk, sa, sc;                       // survivors (only when cmp active and top-k follows)
     const i64* k_in = keys; const A* a_in = agg; const i64* c_in = cnt;
     std::size_t n_surv = n;
-    try {
-        if (cmp != 0) {
-            n_surv = count_survivors(agg, n, cmp, t, s);
-            // When there is no top-k the survivors ARE the output: select
-            // straight into the caller's buffers.
-            i64* dk = (topk == 0) ? out_keys : nullptr;
-            A*   da = (topk == 0) ? out_agg  : nullptr;
-            i64* dc = (topk == 0) ? out_cnt  : nullptr;
-            if (topk != 0) {
-                cudaError_t e;
-                if ((e = sk.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
-                if ((e = sa.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
-                if (has_cnt && (e = sc.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
-                dk = static_cast<i64*>(sk.p); da = static_cast<A*>(sa.p);
-                dc = has_cnt ? static_cast<i64*>(sc.p) : nullptr;
-            }
-            if (has_cnt) {
-                auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg, cnt));
-                auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da, dc));
-                thrust::copy_if(pol, first, first + n, agg, out, Keep<A>{cmp, t});
-            } else {
-                auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg));
-                auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da));
-                thrust::copy_if(pol, first, first + n, agg, out, Keep<A>{cmp, t});
-            }
-            if (topk == 0) return cudaGetLastError();
-            k_in = dk; a_in = da; c_in = dc;
-        } else if (topk == 0) {
-            // No filter at all: plain copies (caller normally avoids this path).
-            cudaMemcpyAsync(out_keys, keys, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
-            cudaMemcpyAsync(out_agg,  agg,  n * sizeof(A),   cudaMemcpyDeviceToDevice, s);
-            if (has_cnt) cudaMemcpyAsync(out_cnt, cnt, n * sizeof(i64), cudaMemcpyDeviceToDevice, s);
-            return cudaGetLastError();
+    auto ci = thrust::make_counting_iterator<i64>(0);
+    if (cmp != 0) {
+        if ((e = count_survivors(agg, n, cmp, t, &n_surv, s)) != cudaSuccess) return e;
+        i64* dk = (topk == 0) ? out_keys : nullptr;
+        A*   da = (topk == 0) ? out_agg  : nullptr;
+        i64* dc = (topk == 0) ? out_cnt  : nullptr;
+        if (topk != 0) {
+            if ((e = sk.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+            if ((e = sa.alloc(n_surv * sizeof(A)))   != cudaSuccess) return e;
+            if (has_cnt && (e = sc.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+            dk = static_cast<i64*>(sk.p); da = static_cast<A*>(sa.p);
+            dc = has_cnt ? static_cast<i64*>(sc.p) : nullptr;
         }
-        // top-k over n_surv survivors. Small k: radix-select on order keys
-        // (8 histogram passes + one compaction). Large k: full radix sort of
-        // (aggregate copy, index) pairs.
-        cudaError_t e;
-        if (n_out * 8 <= n_surv) {
-            DevBuf kb, ix;
-            if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
-            if ((e = ix.alloc(n_out * sizeof(i64)))  != cudaSuccess) return e;
-            auto* okeys = static_cast<u64*>(kb.p);
-            i64*  idx   = static_cast<i64*>(ix.p);
-            if (desc) thrust::transform(pol, a_in, a_in + n_surv, okeys, InvOrderKey<A>{});
-            else      thrust::transform(pol, a_in, a_in + n_surv, okeys, OrderKey<A>{});
-            if ((e = radix_select_k(okeys, n_surv, n_out, idx, s)) != cudaSuccess) return e;
-            thrust::gather(pol, idx, idx + n_out, k_in, out_keys);
-            thrust::gather(pol, idx, idx + n_out, a_in, out_agg);
-            if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
-            return cudaGetLastError();
+        auto flags = thrust::make_transform_iterator(ci, KeepFlag<A>{agg, Keep<A>{cmp, t}});
+        if (has_cnt) {
+            auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg, cnt));
+            auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da, dc));
+            if ((e = select_flagged(first, flags, out, n, s)) != cudaSuccess) return e;
+        } else {
+            auto first = thrust::make_zip_iterator(thrust::make_tuple(keys, agg));
+            auto out   = thrust::make_zip_iterator(thrust::make_tuple(dk, da));
+            if ((e = select_flagged(first, flags, out, n, s)) != cudaSuccess) return e;
         }
-        // Full sort on the same order keys as the select path, so NaN placement
-        // (greatest) and -0.0/0.0 handling are identical whichever path runs.
-        DevBuf kb, ix;
-        if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
-        if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
-        auto* okeys = static_cast<u64*>(kb.p);
-        i64*  idx   = static_cast<i64*>(ix.p);
-        if (desc) thrust::transform(pol, a_in, a_in + n_surv, okeys, InvOrderKey<A>{});
-        else      thrust::transform(pol, a_in, a_in + n_surv, okeys, OrderKey<A>{});
-        thrust::sequence(pol, idx, idx + n_surv);
-        thrust::sort_by_key(pol, okeys, okeys + n_surv, idx);
-        thrust::gather(pol, idx, idx + n_out, k_in, out_keys);
-        thrust::gather(pol, idx, idx + n_out, a_in, out_agg);
-        if (has_cnt) thrust::gather(pol, idx, idx + n_out, c_in, out_cnt);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
+        if (topk == 0) return cudaGetLastError();
+        k_in = dk; a_in = da; c_in = dc;
+    } else if (topk == 0) {
+        // No filter at all: plain copies (caller normally avoids this path).
+        if ((e = cudaMemcpyAsync(out_keys, keys, n * sizeof(i64), cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+        if ((e = cudaMemcpyAsync(out_agg,  agg,  n * sizeof(A),   cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+        if (has_cnt && (e = cudaMemcpyAsync(out_cnt, cnt, n * sizeof(i64), cudaMemcpyDeviceToDevice, s)) != cudaSuccess) return e;
+        return cudaGetLastError();
     }
+    // top-k over n_surv survivors, on order keys (one total order, NaN greatest).
+    DevBuf kb, ix;
+    if ((e = kb.alloc(n_surv * sizeof(u64))) != cudaSuccess) return e;
+    auto* okeys = static_cast<u64*>(kb.p);
+    if (desc) e = gpudb_cuda_ops::transform(a_in, okeys, n_surv, InvOrderKey<A>{}, s);
+    else      e = gpudb_cuda_ops::transform(a_in, okeys, n_surv, OrderKey<A>{}, s);
+    if (e != cudaSuccess) return e;
+    if (n_out * 8 <= n_surv) {
+        // Small k: radix-select (8 histogram passes + one compaction).
+        if ((e = ix.alloc(n_out * sizeof(i64))) != cudaSuccess) return e;
+        i64* idx = static_cast<i64*>(ix.p);
+        if ((e = radix_select_k(okeys, n_surv, n_out, idx, s)) != cudaSuccess) return e;
+        if ((e = gpudb_cuda_ops::gather(idx, n_out, k_in, out_keys, s)) != cudaSuccess) return e;
+        if ((e = gpudb_cuda_ops::gather(idx, n_out, a_in, out_agg, s)) != cudaSuccess) return e;
+        if (has_cnt && (e = gpudb_cuda_ops::gather(idx, n_out, c_in, out_cnt, s)) != cudaSuccess) return e;
+        return cudaGetLastError();
+    }
+    // Large k: full radix sort of (order key, index).
+    if ((e = ix.alloc(n_surv * sizeof(i64))) != cudaSuccess) return e;
+    i64* idx = static_cast<i64*>(ix.p);
+    if ((e = gpudb_cuda_ops::sequence(idx, n_surv, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sort_pairs_u64(okeys, idx, n_surv, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::gather(idx, n_out, k_in, out_keys, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::gather(idx, n_out, a_in, out_agg, s)) != cudaSuccess) return e;
+    if (has_cnt && (e = gpudb_cuda_ops::gather(idx, n_out, c_in, out_cnt, s)) != cudaSuccess) return e;
     return cudaGetLastError();
 }
 
@@ -395,17 +331,77 @@ cudaError_t apply_filter(const i64* keys, const A* agg, const i64* cnt, std::siz
 
 extern "C" {
 
+// Number of distinct runs in an ascending-sorted i64 array (0 for n == 0).
+// Synchronizes the stream; the count lands on the host.
+cudaError_t gpudb_cuda_sorted_run_count(const i64* d_sorted, std::size_t n,
+                                        std::size_t* h_runs, cudaStream_t s) {
+    auto cnt = thrust::make_counting_iterator<i64>(0);
+    return host_sum(thrust::make_transform_iterator(cnt, RunStart{d_sorted}), n, h_runs, s);
+}
+
+// SUM(vals) + COUNT(*) per run of d_sorted; outputs sized n_groups exactly.
+cudaError_t gpudb_cuda_groupby_sum_i64(const i64* d_sorted, const i64* d_perm,
+                                       const i64* d_vals, std::size_t n,
+                                       i64* out_keys, i64* out_sums, i64* out_counts,
+                                       std::size_t* h_runs, cudaStream_t s) {
+    auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
+                                                 PermValI64{d_vals, d_perm});
+    return reduce_runs<u64>(d_sorted, n, first, AddU64Pair{}, out_keys,
+                            reinterpret_cast<u64*>(out_sums), out_counts, h_runs, s);
+}
+
+cudaError_t gpudb_cuda_groupby_sum_f64(const i64* d_sorted, const i64* d_perm,
+                                       const double* d_vals, std::size_t n,
+                                       i64* out_keys, double* out_sums, i64* out_counts,
+                                       std::size_t* h_runs, cudaStream_t s) {
+    auto first = thrust::make_transform_iterator(thrust::counting_iterator<i64>(0),
+                                                 PermValF64{d_vals, d_perm});
+    return reduce_runs<double>(d_sorted, n, first, AddF64Pair{}, out_keys, out_sums, out_counts, h_runs, s);
+}
+
+// COUNT(*) per run of d_sorted (keys only; no permutation needed).
+cudaError_t gpudb_cuda_groupby_count(const i64* d_sorted, std::size_t n,
+                                     i64* out_keys, i64* out_counts,
+                                     std::size_t* h_runs, cudaStream_t s) {
+    DevBuf nr; cudaError_t e = nr.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    e = with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceReduce::ReduceByKey(tmp, b, d_sorted, out_keys,
+                                              thrust::constant_iterator<u64>(1ULL),
+                                              reinterpret_cast<u64*>(out_counts),
+                                              static_cast<u64*>(nr.p), AddU64{}, n, s);
+    });
+    if (e != cudaSuccess) return e;
+    u64 runs = 0;
+    if ((e = cudaMemcpyAsync(&runs, nr.p, sizeof(u64), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
+    if ((e = cudaStreamSynchronize(s)) != cudaSuccess) return e;
+    *h_runs = static_cast<std::size_t>(runs);
+    return cudaSuccess;
+}
+
+// f64 sort cache: d_sorted <- vals sorted ascending (NaN last), d_perm <- the
+// original indices in that order. Radix sort on order-preserving u64 keys
+// built in d_sorted itself; the sorted doubles are then gathered over the
+// (no longer needed) keys in place, so no extra n-sized buffer is required —
+// peak extra memory is the sort's own scratch.
+cudaError_t gpudb_cuda_sort_f64_perm(const double* d_vals, double* d_sorted,
+                                     i64* d_perm, std::size_t n, cudaStream_t s) {
+    auto* k = reinterpret_cast<u64*>(d_sorted);
+    cudaError_t e;
+    if ((e = gpudb_cuda_ops::transform(d_vals, k, n, F64OrderKey{}, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sequence(d_perm, n, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sort_pairs_u64(k, d_perm, n, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::gather(d_perm, n, d_vals, d_sorted, s)) != cudaSuccess) return e;
+    return cudaStreamSynchronize(s);
+}
+
 cudaError_t gpudb_cuda_groupby_survivors_i64(const i64* agg, std::size_t n, int cmp, i64 t,
                                              std::size_t* h_out, cudaStream_t s) {
-    try { *h_out = count_survivors<i64>(agg, n, cmp, t, s); }
-    catch (...) { return gpudb_cuda_detail::map_exception(); }
-    return cudaGetLastError();
+    return count_survivors<i64>(agg, n, cmp, t, h_out, s);
 }
 cudaError_t gpudb_cuda_groupby_survivors_f64(const double* agg, std::size_t n, int cmp, double t,
                                              std::size_t* h_out, cudaStream_t s) {
-    try { *h_out = count_survivors<double>(agg, n, cmp, t, s); }
-    catch (...) { return gpudb_cuda_detail::map_exception(); }
-    return cudaGetLastError();
+    return count_survivors<double>(agg, n, cmp, t, h_out, s);
 }
 cudaError_t gpudb_cuda_groupby_filter_i64(const i64* keys, const i64* agg, const i64* cnt, std::size_t n,
                                           int cmp, i64 t, std::size_t topk, int desc, std::size_t n_out,

--- a/src/backends/cuda/kernels/join_kernel.cu
+++ b/src/backends/cuda/kernels/join_kernel.cu
@@ -18,11 +18,17 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 
+#include "cub_ops.cuh"
+
 #include "thrust_errors.cuh"
 
 namespace {
 
 constexpr int BLOCK = 256;
+
+// i64 <-> order-preserving u64 (sign bit flipped), for the radix sort.
+struct FlipSign     { __host__ __device__ unsigned long long operator()(std::int64_t v) const { return static_cast<unsigned long long>(v) ^ (1ULL << 63); } };
+struct FlipSignBack { __host__ __device__ unsigned long long operator()(unsigned long long k) const { return k ^ (1ULL << 63); } };
 
 using u64 = unsigned long long;
 
@@ -194,12 +200,16 @@ cudaError_t gpudb_cuda_join_build_sort(const std::int64_t* d_keys,
     cudaError_t e = cudaMemcpyAsync(d_sorted, d_keys, n * sizeof(std::int64_t),
                                     cudaMemcpyDeviceToDevice, s);
     if (e != cudaSuccess) return e;
-    try {
-        thrust::sequence(thrust::cuda::par.on(s), d_perm, d_perm + n);
-        thrust::sort_by_key(thrust::cuda::par.on(s), d_sorted, d_sorted + n, d_perm);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
+    // Sort as order-preserving u64 keys (sign bit flipped) so the radix pass
+    // handles negatives; flip back afterwards. Explicit temp storage: a
+    // device fault returns its cudaError_t here instead of aborting.
+    e = gpudb_cuda_ops::transform(d_sorted, reinterpret_cast<u64*>(d_sorted), n, FlipSign{}, s);
+    if (e != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sequence(d_perm, n, s)) != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sort_pairs_u64(reinterpret_cast<u64*>(d_sorted), d_perm, n, s)) != cudaSuccess) return e;
+    e = gpudb_cuda_ops::transform(reinterpret_cast<const u64*>(d_sorted),
+                                  reinterpret_cast<u64*>(d_sorted), n, FlipSignBack{}, s);
+    if (e != cudaSuccess) return e;
     return cudaStreamSynchronize(s);
 }
 
@@ -245,12 +255,15 @@ cudaError_t gpudb_cuda_join_rows_count(const std::int64_t* d_probe,
 // total <- sum(cnt); cnt <- exclusive_scan(cnt) in place. Synchronizes.
 cudaError_t gpudb_cuda_join_rows_scan(u64* d_cnt, std::size_t n,
                                       u64* h_total, cudaStream_t s) {
-    try {
-        *h_total = thrust::reduce(thrust::cuda::par.on(s), d_cnt, d_cnt + n, u64{0});
-        thrust::exclusive_scan(thrust::cuda::par.on(s), d_cnt, d_cnt + n, d_cnt);
-    } catch (...) {
-        return gpudb_cuda_detail::map_exception();
-    }
+    gpudb_cuda_ops::DevBuf tot;
+    cudaError_t e = tot.alloc(sizeof(u64));
+    if (e != cudaSuccess) return e;
+    if ((e = gpudb_cuda_ops::sum_u64(d_cnt, n, static_cast<u64*>(tot.p), s)) != cudaSuccess) return e;
+    e = gpudb_cuda_ops::with_temp([&](void* tmp, std::size_t& b) {
+        return cub::DeviceScan::ExclusiveSum(tmp, b, d_cnt, d_cnt, n, s);
+    });
+    if (e != cudaSuccess) return e;
+    if ((e = cudaMemcpyAsync(h_total, tot.p, sizeof(u64), cudaMemcpyDeviceToHost, s)) != cudaSuccess) return e;
     return cudaStreamSynchronize(s);
 }
 

--- a/test/cpp/test_aggregator.cpp
+++ b/test/cpp/test_aggregator.cpp
@@ -5,6 +5,10 @@
 #include "../../src/backends/groupby_filter.hpp"
 
 #include <algorithm>
+#if defined(__linux__)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -743,7 +747,58 @@ void test_hybrid_groupby() {
     }
 }
 
-int main() {
+#if GPUDB_HAVE_CUDA && defined(__linux__)
+extern "C" int gpudb_cuda_debug_fault_inject(void* stream);   // cudaError_t; 0 == success
+
+// A device fault (illegal address) is sticky: the context is dead for the
+// rest of the process. The contract is that it reaches SQL as an error, not
+// as an abort — Thrust temporaries used to throw from a destructor on the
+// failing cudaFree and terminate the process. The scenario runs in a fresh
+// child process (re-exec of this binary; a fork could not reuse the
+// parent's CUDA context): it poisons the context, calls a resident op, and
+// must see a std::runtime_error naming the fault and exit normally.
+int cuda_fault_child() {
+    try {
+        auto agg = gpudb::make_aggregator(gpudb::Backend::CUDA);
+        std::vector<std::int64_t> k = {1, 1, 2, 3};
+        auto kc = agg->upload_i64(k.data(), k.size());
+        (void)gpudb_cuda_debug_fault_inject(nullptr);
+        try {
+            (void)agg->groupby_count_resident(*kc, 100);
+            return 2;                                                 // no error at all
+        } catch (const std::runtime_error& e) {
+            return std::string(e.what()).find("illegal memory access") != std::string::npos ? 0 : 1;
+        }
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "fault child: unexpected: %s\n", e.what());
+        return 4;
+    }
+}
+
+void test_cuda_device_fault_is_an_error() {
+    std::printf("--- CUDA device fault surfaces as std::runtime_error (child process) ---\n");
+    std::fflush(stdout);
+    const pid_t pid = fork();
+    if (pid == 0) {
+        execl("/proc/self/exe", "test_gpudb", "--cuda-fault-child", static_cast<char*>(nullptr));
+        std::_Exit(5);                                                // exec failed
+    }
+    int status = 0;
+    (void)waitpid(pid, &status, 0);
+    const bool clean_exit = WIFEXITED(status);
+    const int  rc         = clean_exit ? WEXITSTATUS(status) : -1;
+    EXPECT(clean_exit);           // not SIGABRT / SIGSEGV
+    EXPECT_EQ(rc, 0);             // runtime_error naming the illegal access
+    std::printf("  child: %s, rc=%d\n", clean_exit ? "exited" : "killed by signal", rc);
+}
+#endif
+
+int main(int argc, char** argv) {
+#if GPUDB_HAVE_CUDA && defined(__linux__)
+    if (argc > 1 && std::string(argv[1]) == "--cuda-fault-child") return cuda_fault_child();
+#else
+    (void)argc; (void)argv;
+#endif
     std::printf("gpudb test suite\n");
     std::printf("available backends:");
     for (auto b : gpudb::available_backends()) std::printf(" %s", gpudb::to_string(b));
@@ -761,6 +816,10 @@ int main() {
     test_hybrid_aggregator();
     test_hybrid_groupby();
     test_hashjoin();
+
+#if GPUDB_HAVE_CUDA && defined(__linux__)
+    test_cuda_device_fault_is_an_error();
+#endif
 
 #if GPUDB_HAVE_METAL
     // Regression: the non-resident Metal GROUP BY's radix path (expected


### PR DESCRIPTION
Follow-ups to #76 on the CUDA side, stacked on `feat/cuda-groupby-resident` (retarget after #76 merges). Three items, kept in one branch because the second rewrites the file the first lives in:

1. **Radix-select for top-k of groups.** The k-th aggregate is located with eight MSB→LSB passes of a 256-bin histogram over order-preserving `u64` keys (i64 sign-flip; f64 sign-magnitude fold with every NaN greatest), then the winners are compacted — strictly-better plus enough ties to reach k (tie choice unspecified, per the contract) — and sorted by key. The full radix sort is kept for k ≥ groups/8. Same total order on both paths.
2. **CUB on explicit temp storage instead of Thrust temporaries in the resident paths** (`cub_ops.cuh`). Thrust's algorithms allocate scratch whose destructor throws on `cudaFree` after a sticky device fault (`std::terminate`). The join sort/scan and every group-by / filter / top-k step now run CUB primitives on buffers we allocate and free ourselves; Thrust is used only for its allocation-free iterators. A device fault now reaches the host wrapper as its real `cudaError_t` → `std::runtime_error` → SQL error, and the process stays alive (the context is dead, as before). Unit-tested: the test binary re-execs itself as a child that poisons the context through a debug hook (`gpudb_cuda_debug_fault_inject`) and must see a `runtime_error` naming the illegal access, not a signal.
3. **f64 NaN/inf top-k order** — contract fix landed in #76 itself; here both top-k paths share the order keys.

## Numbers (RTX 4090 Laptop, same harness as the v0.6.0 section: native and gpudb inside one `gpudb-sql --multi` process, first run discarded)

| shape | SF | native stmt | gpudb stmt | `kernel_ms` | before (#76, sort-based) |
|---|---|---:|---:|---:|---:|
| (G) top-10 groups by sum | 10 | 211–215 ms | 16.1–16.3 ms | 11.6–11.8 | 26.6–26.8 (kernel 21) |
| (G) top-10 groups by sum | 50 | 1009–1023 ms | 60–64 ms | 52–56 | 86–123 (kernel 78–115) |
| (B′) HAVING sum > 300 | 10 / 50 | 204–206 / 1019–1023 | 12.0–12.3 / 50–57 | 9.6–9.8 / 45–52 | unchanged path |

(G) is now the reduce-by-key floor plus ≈8 ms of select. Sums equal native in every run. Added to the CUDA subsection of BENCHMARK.md as a follow-up block.

## Verification

- `test_gpudb` 358 / 358 (adds the device-fault child-process test); `groupby_parity_check.sh` 11 / 11; `join_parity_check.sh` 12 / 12; `run_sql_tests.sh` full suite passing; `gpu_groupby_resident` 28 / 0.
- Standalone drivers vs the host reference: 15 filter cases × 3 ops on 2M rows / 250k groups; the NaN/inf probe (cmp drops NaN groups; DESC lists NaN first, ASC last).
- Fault probe: an out-of-bounds device read inside the run-count step returns `cudaErrorIllegalAddress` (700) and the process exits 0 — previously `terminate called … device free failed: cudaErrorIllegalAddress`.
