### PR TITLE
chore(release): version 0.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(gpudb
-    VERSION 0.5.0
+    VERSION 0.6.0
     DESCRIPTION "GPU-accelerated operators for DuckDB (CUDA + Metal)"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ SELECT gpu_join_sum_resident('l.k', 'l.v', 'o');   -- = sum(...) FROM lineitem J
 -- or within 1e-9 of native, verified by scripts/join_parity_check.sh
 ```
 
-Apache-2.0 · v0.5.0 · Linux + macOS · DuckDB ≥ 1.2
+Apache-2.0 · v0.6.0 · Linux + macOS · DuckDB ≥ 1.2
 
 ---
 
@@ -315,8 +315,8 @@ Two SQL paths, by design (v0.4.0):
 
 The SQL test suite lives in `test/sql/*.test`. Each file is plain SQL with
 `-- expect:` lines after each query; the runner reports per-query
-PASS / FAIL / GUARDRAIL / SKIP. As of v0.5.0: 91 queries, 0 failures — 87
-result checks plus 4 GUARDRAIL cases (deliberate misuse such as a `DOUBLE` join
+PASS / FAIL / GUARDRAIL / SKIP. As of v0.6.0: 126 queries, 0 failures — 113
+result checks plus 13 GUARDRAIL cases (deliberate misuse such as a `DOUBLE` join
 key or a `NULL` upload name, which the extension must reject with a clear
 error; the suite fails if one of them unexpectedly succeeds) — plus full
 resident-surface coverage in the community-CI sqllogic suite.


### PR DESCRIPTION
Bump project version to 0.6.0 (extension_version derives from it); README badge-row text. Registry note on line 170 stays until the registry serves v0.6.0.