### PR TITLE
fix(build): stamp the loadable extension with the project version

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -71,7 +71,10 @@ if [ -n "$RAW_EXT" ] && [ -f "$(dirname "$0")/build_helpers/append_extension_met
         *)       PLATFORM="" ;;
     esac
     DUCKDB_C_API_VERSION="${DUCKDB_C_API_VERSION:-v1.2.0}"
-    EXT_VERSION="${EXT_VERSION:-v0.1.1}"
+    # Stamp the version from CMakeLists.txt (project VERSION) unless overridden;
+    # a stale default here used to overwrite CMake's own stamp with v0.1.1.
+    CMAKE_VERSION_STR="$(sed -n 's/^[[:space:]]*VERSION[[:space:]][[:space:]]*\([0-9][0-9.]*\).*/\1/p' "$(dirname "$0")/../CMakeLists.txt" | head -1)"
+    EXT_VERSION="${EXT_VERSION:-v${CMAKE_VERSION_STR:-0.0.0}}"
     OUT_FILE="$BUILD_DIR/src/extension/gpudb.${PLATFORM}.duckdb_extension"
     if [ -n "$PLATFORM" ]; then
         echo "==> packaging loadable extension ($PLATFORM, ABI=$DUCKDB_C_API_VERSION, ext=$EXT_VERSION)"


### PR DESCRIPTION
scripts/build.sh re-packaged the extension after CMake with a hard-coded default EXT_VERSION=v0.1.1, overwriting the v${PROJECT_VERSION} stamp — every build.sh-produced asset (including the v0.5.0 release binaries) reports extension_version v0.1.1 in its footer. Now derived from CMakeLists.txt (env EXT_VERSION still overrides). The community-extensions Makefile path is unaffected.