### PR TITLE
build(ext): static libstdc++/libgcc for the Linux loadable extension

### DIFF
--- a/src/extension/CMakeLists.txt
+++ b/src/extension/CMakeLists.txt
@@ -58,6 +58,13 @@ set_target_properties(gpudb_duckdb PROPERTIES
 # symbol table wholesale.
 if(UNIX AND NOT APPLE)
     target_link_options(gpudb_duckdb PRIVATE "LINKER:--exclude-libs,ALL")
+    # Link libstdc++ and libgcc statically so the loadable extension carries no
+    # GLIBCXX_/CXXABI_ symbol-version floor from the build machine (a v0.6.0
+    # asset built on a 24.04 box needed GLIBCXX_3.4.32 and failed to LOAD on
+    # 22.04 userlands). glibc itself stays dynamic — its floor is set by the
+    # build environment's headers, so release assets are built on the oldest
+    # supported userland (Ubuntu 22.04, glibc 2.35).
+    target_link_options(gpudb_duckdb PRIVATE -static-libstdc++ -static-libgcc)
 endif()
 
 # Output naming / location.


### PR DESCRIPTION
The v0.6.0 `linux_amd64` asset failed to `LOAD` on Ubuntu 22.04 (Colab): `libstdc++.so.6: version GLIBCXX_3.4.32 not found`. It was built on a 24.04 box, and the loadable extension inherited that box's libstdc++ symbol-version floor.

This links libstdc++ and libgcc statically into `gpudb_duckdb` on Linux (`-static-libstdc++ -static-libgcc`, next to the existing `--exclude-libs,ALL`). Measured on the tagged commit, host build (24.04, CUDA 13.0.88, static CUDA runtime):

| | before | after |
|---|---|---|
| `GLIBCXX_` floor | 3.4.32 | none |
| `CXXABI_` floor | 1.3.9 | none |
| NEEDED | libgomp, libpthread, libstdc++, libm, libgcc_s, libc | libgomp, libc, ld-linux |
| `GLIBC_` floor | 2.38 | 2.38 (`__isoc23_strtoul*`, `arc4random`) |

The glibc floor is set by the build environment's headers and static archives, not by link flags, so release assets must be built on the oldest supported userland: Ubuntu 22.04 (glibc 2.35), e.g. in `nvidia/cuda:13.0.x-devel-ubuntu22.04`. The comment in the CMake block says so. No code change; the registry (Makefile) path builds on the community CI images and is unaffected.